### PR TITLE
Disable common's std feature on guest crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,31 +17,74 @@ jobs:
     - run: rustup update stable && rustup default stable
     - run: find . -type f -name '*.rs' -print0 | xargs -I {} -0 rustfmt --check "{}"
 
-  build:
+  build-common:
     strategy:
       matrix:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             profile: dev
-            features: std
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            profile: dev
-            features:
           - os: ubuntu-latest
             target: wasm32-unknown-unknown
             profile: release
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update stable && rustup default stable
+    - run: rustup target add ${{ matrix.target }}
+    - run: cargo build --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} -p stellar-contract-env-common
+
+  build-guest:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            profile: dev
+          - os: ubuntu-latest
+            target: wasm32-unknown-unknown
+            profile: release
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update stable && rustup default stable
+    - run: rustup target add ${{ matrix.target }}
+    - run: cargo build --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} -p stellar-contract-env-guest
+
+  build-host:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            profile: dev
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update stable && rustup default stable
+    - run: rustup target add ${{ matrix.target }}
+    - run: cargo build --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} -p stellar-contract-env-host
+
+  test-common:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            profile: test
+            features: std
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            profile: test
             features:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
     - run: rustup target add ${{ matrix.target }}
-    - run: cargo build --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-guest
-    - run: cargo build --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-host
+    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-common
 
-  test:
+  test-guest:
     strategy:
       matrix:
         include:
@@ -54,6 +97,18 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
     - run: rustup target add ${{ matrix.target }}
-    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-common
-    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-guest
-    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-host
+    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} -p stellar-contract-env-guest
+
+  test-host:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            profile: test
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update stable && rustup default stable
+    - run: rustup target add ${{ matrix.target }}
+    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} -p stellar-contract-env-host

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,6 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
     - run: rustup target add ${{ matrix.target }}
-    - run: cargo build --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-common
     - run: cargo build --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-guest
     - run: cargo build --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-host
 
@@ -55,6 +54,5 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
     - run: rustup target add ${{ matrix.target }}
-    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-common
     - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-guest
     - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-host

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,11 +48,12 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             profile: test
-            features: std
+            features:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
     - run: rustup target add ${{ matrix.target }}
+    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-common
     - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-guest
     - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-host

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
     - run: rustup target add ${{ matrix.target }}
-    - run: cargo build --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --no-default-features --features '${{ matrix.features }}'
+    - run: cargo build --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}'
 
   test:
     strategy:
@@ -53,4 +53,4 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
     - run: rustup target add ${{ matrix.target }}
-    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --no-default-features --features '${{ matrix.features }}'
+    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,9 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
     - run: rustup target add ${{ matrix.target }}
-    - run: cargo build --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}'
+    - run: cargo build --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-common
+    - run: cargo build --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-guest
+    - run: cargo build --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-host
 
   test:
     strategy:
@@ -53,4 +55,6 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
     - run: rustup target add ${{ matrix.target }}
-    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}'
+    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-common
+    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-guest
+    - run: cargo test --verbose --profile ${{ matrix.profile }} --target ${{ matrix.target }} --features '${{ matrix.features }}' -p stellar-contract-env-host

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+test:
+	cargo check -p stellar-contract-env-guest --target wasm32-unknown-unknown
+	cargo check -p stellar-contract-env-host
+	cargo test -p stellar-contract-env-guest
+	cargo test -p stellar-contract-env-host
+
+watch:
+	cargo watch \
+		-x 'check -p stellar-contract-env-guest --target wasm32-unknown-unknown' \
+		-x 'check -p stellar-contract-env-host' \
+		-x 'test -p stellar-contract-env-guest' \
+		-x 'test -p stellar-contract-env-host'

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,9 @@ test:
 	cargo test -p stellar-contract-env-host
 
 watch:
-	cargo watch \
+	cargo watch --clear \
 		-x 'check -p stellar-contract-env-guest --target wasm32-unknown-unknown' \
 		-x 'check -p stellar-contract-env-host' \
+		-x 'test -p stellar-contract-env-common' \
 		-x 'test -p stellar-contract-env-guest' \
 		-x 'test -p stellar-contract-env-host'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 test:
 	cargo check -p stellar-contract-env-guest --target wasm32-unknown-unknown
 	cargo check -p stellar-contract-env-host
+	cargo test -p stellar-contract-env-common
+	cargo test -p stellar-contract-env-common --features std
 	cargo test -p stellar-contract-env-guest
 	cargo test -p stellar-contract-env-host
 

--- a/stellar-contract-env-common/Cargo.toml
+++ b/stellar-contract-env-common/Cargo.toml
@@ -9,3 +9,4 @@ stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "1fa7c3
 
 [features]
 std = ["stellar-xdr/std"]
+panic_handler = []

--- a/stellar-contract-env-common/Cargo.toml
+++ b/stellar-contract-env-common/Cargo.toml
@@ -8,5 +8,4 @@ static_assertions = "1.1.0"
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "1fa7c3ebdefd6c78719ede6b294aa64e13077d2a", default-features = false }
 
 [features]
-default = ["std"]
 std = ["stellar-xdr/std"]

--- a/stellar-contract-env-common/src/rt.rs
+++ b/stellar-contract-env-common/src/rt.rs
@@ -11,17 +11,7 @@ pub fn trap() -> ! {
     panic!()
 }
 
-// Handle panic provides a panic handler that traps using the wasm unreachable
-// opcode, which is less expensive than the builtin panic handling.
-//
-// Not used when std feature is enabled and when targeting wasm because std
-// provides a panic handler. Note that std may be loaded even if the std feature
-// is off, such as when tests are built. The guard on the wasm target prevents
-// the handler from being loaded in those other cases. Note that adding a
-// not(test) here would not be sufficient since not(test) is only true for the
-// crate that the test resides in, and not for crates running tests dependent on
-// this crate.
-#[cfg(all(target_family = "wasm", not(feature = "std")))]
+#[cfg(feature = "panic_handler")]
 #[panic_handler]
 fn handle_panic(_: &core::panic::PanicInfo) -> ! {
     trap();

--- a/stellar-contract-env-common/src/rt.rs
+++ b/stellar-contract-env-common/src/rt.rs
@@ -11,8 +11,8 @@ pub fn trap() -> ! {
     panic!()
 }
 
-#[cfg(not(feature = "std"))]
-#[panic_handler]
-fn handle_panic(_: &core::panic::PanicInfo) -> ! {
-    trap();
-}
+//#[cfg(not(feature = "std"))]
+//#[panic_handler]
+//fn handle_panic(_: &core::panic::PanicInfo) -> ! {
+//    trap();
+//}

--- a/stellar-contract-env-common/src/rt.rs
+++ b/stellar-contract-env-common/src/rt.rs
@@ -11,8 +11,18 @@ pub fn trap() -> ! {
     panic!()
 }
 
-//#[cfg(not(feature = "std"))]
-//#[panic_handler]
-//fn handle_panic(_: &core::panic::PanicInfo) -> ! {
-//    trap();
-//}
+// Handle panic provides a panic handler that traps using the wasm unreachable
+// opcode, which is less expensive than the builtin panic handling.
+//
+// Not used when std feature is enabled and when targeting wasm because std
+// provides a panic handler. Note that std may be loaded even if the std feature
+// is off, such as when tests are built. The guard on the wasm target prevents
+// the handler from being loaded in those other cases. Note that adding a
+// not(test) here would not be sufficient since not(test) is only true for the
+// crate that the test resides in, and not for crates running tests dependent on
+// this crate.
+#[cfg(all(target_family = "wasm", not(feature = "std")))]
+#[panic_handler]
+fn handle_panic(_: &core::panic::PanicInfo) -> ! {
+    trap();
+}

--- a/stellar-contract-env-common/src/symbol.rs
+++ b/stellar-contract-env-common/src/symbol.rs
@@ -112,7 +112,7 @@ impl SymbolStr {
         let s: &[u8] = &self.0;
         for (i, x) in s.iter().enumerate() {
             if *x == 0 {
-                return i
+                return i;
             }
         }
         s.len()

--- a/stellar-contract-env-common/src/symbol.rs
+++ b/stellar-contract-env-common/src/symbol.rs
@@ -121,7 +121,8 @@ impl SymbolStr {
 
 impl Debug for SymbolStr {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("Symbol").field(&self.0).finish()
+        let s: &str = self.as_ref();
+        f.debug_tuple("Symbol").field(&s).finish()
     }
 }
 

--- a/stellar-contract-env-common/src/symbol.rs
+++ b/stellar-contract-env-common/src/symbol.rs
@@ -122,7 +122,7 @@ impl SymbolStr {
 impl Debug for SymbolStr {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let s: &str = self.as_ref();
-        f.debug_tuple("Symbol").field(&s).finish()
+        f.debug_tuple("SymbolStr").field(&s).finish()
     }
 }
 

--- a/stellar-contract-env-guest/Cargo.toml
+++ b/stellar-contract-env-guest/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-stellar-contract-env-common = { path = "../stellar-contract-env-common" }
+stellar-contract-env-common = { path = "../stellar-contract-env-common", default-features = false }

--- a/stellar-contract-env-guest/Cargo.toml
+++ b/stellar-contract-env-guest/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-stellar-contract-env-common = { path = "../stellar-contract-env-common", default-features = false }
+stellar-contract-env-common = { path = "../stellar-contract-env-common" }

--- a/stellar-contract-env-guest/Cargo.toml
+++ b/stellar-contract-env-guest/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 
 [dependencies]
 stellar-contract-env-common = { path = "../stellar-contract-env-common" }
+
+[features]
+panic_handler = ["stellar-contract-env-common/panic_handler"]

--- a/stellar-contract-env-guest/src/guest.rs
+++ b/stellar-contract-env-guest/src/guest.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
+
+use core::any::Any;
+
 use super::{Env, Val};
 
 // In guest code the environment is global/implicit, so is represented as a unit struct.
@@ -7,7 +10,7 @@ use super::{Env, Val};
 pub struct Guest;
 
 impl Env for Guest {
-    fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
+    fn as_mut_any(&mut self) -> &mut dyn Any {
         self
     }
 

--- a/stellar-contract-env-guest/src/lib.rs
+++ b/stellar-contract-env-guest/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 mod guest;
 

--- a/stellar-contract-env-guest/src/lib.rs
+++ b/stellar-contract-env-guest/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 mod guest;
 
 pub use guest::Guest;

--- a/stellar-contract-env-host/Cargo.toml
+++ b/stellar-contract-env-host/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-stellar-contract-env-common = { path = "../stellar-contract-env-common" }
+stellar-contract-env-common = { path = "../stellar-contract-env-common", features = ["std"] }
 static_assertions = "1.1.0"
 im-rc = "15.0.0"
 num-bigint = "0.4"


### PR DESCRIPTION
### What

Disable the std feature on guest crate.

### Why

The common crate defaults to having std enabled and passes that down to the xdr lib. We don't want anything to pull in std in the wasm when guest is in use.

### Known limitations

N/A