### PR TITLE
Rename Val -> RawVal, reorganize host to make WeakHost crate-private.

### DIFF
--- a/stellar-contract-env-common/src/bitset.rs
+++ b/stellar-contract-env-common/src/bitset.rs
@@ -1,39 +1,39 @@
-use super::val::{Tag, ValType};
-use super::Val;
+use super::raw_val::{RawValType, Tag};
+use super::RawVal;
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 
 #[repr(transparent)]
 #[derive(Copy, Clone)]
-pub struct BitSet(Val);
+pub struct BitSet(RawVal);
 
-impl ValType for BitSet {
-    fn is_val_type(v: Val) -> bool {
+impl RawValType for BitSet {
+    fn is_val_type(v: RawVal) -> bool {
         v.has_tag(Tag::BitSet)
     }
 
-    unsafe fn unchecked_from_val(v: Val) -> Self {
+    unsafe fn unchecked_from_val(v: RawVal) -> Self {
         BitSet(v)
     }
 }
 
-impl From<BitSet> for Val {
+impl From<BitSet> for RawVal {
     #[inline(always)]
     fn from(b: BitSet) -> Self {
         b.0
     }
 }
 
-impl AsRef<Val> for BitSet {
+impl AsRef<RawVal> for BitSet {
     #[inline(always)]
-    fn as_ref(&self) -> &Val {
+    fn as_ref(&self) -> &RawVal {
         &self.0
     }
 }
 
-impl AsMut<Val> for BitSet {
+impl AsMut<RawVal> for BitSet {
     #[inline(always)]
-    fn as_mut(&mut self) -> &mut Val {
+    fn as_mut(&mut self) -> &mut RawVal {
         &mut self.0
     }
 }
@@ -72,7 +72,7 @@ impl BitSet {
     #[inline(always)]
     pub const fn try_from_u64(u: u64) -> Result<BitSet, ()> {
         if u & 0x0fff_ffff_ffff_ffff == u {
-            Ok(BitSet(unsafe { Val::from_body_and_tag(u, Tag::BitSet) }))
+            Ok(BitSet(unsafe { RawVal::from_body_and_tag(u, Tag::BitSet) }))
         } else {
             Err(())
         }

--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -1,4 +1,4 @@
-use super::Val;
+use super::RawVal;
 use core::any;
 
 // This trait needs to be implemented by any type that plays the role of the
@@ -15,43 +15,43 @@ pub trait Env: Sized + Clone {
 
     // Used to deep-compare objects, result is an -1, 0, 1
     // value for lt, eq, gt, respectively.
-    fn obj_cmp(&self, a: Val, b: Val) -> i64;
+    fn obj_cmp(&self, a: RawVal, b: RawVal) -> i64;
 
-    fn log_value(&mut self, v: Val) -> Val;
-    fn get_last_operation_result(&mut self) -> Val;
+    fn log_value(&mut self, v: RawVal) -> RawVal;
+    fn get_last_operation_result(&mut self) -> RawVal;
 
-    fn obj_from_u64(&mut self, u: u64) -> Val;
-    fn obj_to_u64(&mut self, u: Val) -> u64;
-    fn obj_from_i64(&mut self, i: i64) -> Val;
-    fn obj_to_i64(&mut self, i: Val) -> i64;
+    fn obj_from_u64(&mut self, u: u64) -> RawVal;
+    fn obj_to_u64(&mut self, u: RawVal) -> u64;
+    fn obj_from_i64(&mut self, i: i64) -> RawVal;
+    fn obj_to_i64(&mut self, i: RawVal) -> i64;
 
-    fn map_new(&mut self) -> Val;
-    fn map_put(&mut self, m: Val, k: Val, v: Val) -> Val;
-    fn map_get(&mut self, m: Val, k: Val) -> Val;
-    fn map_del(&mut self, m: Val, k: Val) -> Val;
-    fn map_len(&mut self, m: Val) -> Val;
-    fn map_keys(&mut self, m: Val) -> Val;
-    fn map_has(&mut self, m: Val, k: Val) -> Val;
+    fn map_new(&mut self) -> RawVal;
+    fn map_put(&mut self, m: RawVal, k: RawVal, v: RawVal) -> RawVal;
+    fn map_get(&mut self, m: RawVal, k: RawVal) -> RawVal;
+    fn map_del(&mut self, m: RawVal, k: RawVal) -> RawVal;
+    fn map_len(&mut self, m: RawVal) -> RawVal;
+    fn map_keys(&mut self, m: RawVal) -> RawVal;
+    fn map_has(&mut self, m: RawVal, k: RawVal) -> RawVal;
 
-    fn vec_new(&mut self) -> Val;
-    fn vec_put(&mut self, v: Val, i: Val, x: Val) -> Val;
-    fn vec_get(&mut self, v: Val, i: Val) -> Val;
-    fn vec_del(&mut self, v: Val, i: Val) -> Val;
-    fn vec_len(&mut self, v: Val) -> Val;
-    fn vec_push(&mut self, v: Val, x: Val) -> Val;
-    fn vec_pop(&mut self, v: Val) -> Val;
-    fn vec_take(&mut self, v: Val, n: Val) -> Val;
-    fn vec_drop(&mut self, v: Val, n: Val) -> Val;
-    fn vec_front(&mut self, v: Val) -> Val;
-    fn vec_back(&mut self, v: Val) -> Val;
-    fn vec_insert(&mut self, v: Val, i: Val, n: Val) -> Val;
-    fn vec_append(&mut self, v1: Val, v2: Val) -> Val;
+    fn vec_new(&mut self) -> RawVal;
+    fn vec_put(&mut self, v: RawVal, i: RawVal, x: RawVal) -> RawVal;
+    fn vec_get(&mut self, v: RawVal, i: RawVal) -> RawVal;
+    fn vec_del(&mut self, v: RawVal, i: RawVal) -> RawVal;
+    fn vec_len(&mut self, v: RawVal) -> RawVal;
+    fn vec_push(&mut self, v: RawVal, x: RawVal) -> RawVal;
+    fn vec_pop(&mut self, v: RawVal) -> RawVal;
+    fn vec_take(&mut self, v: RawVal, n: RawVal) -> RawVal;
+    fn vec_drop(&mut self, v: RawVal, n: RawVal) -> RawVal;
+    fn vec_front(&mut self, v: RawVal) -> RawVal;
+    fn vec_back(&mut self, v: RawVal) -> RawVal;
+    fn vec_insert(&mut self, v: RawVal, i: RawVal, n: RawVal) -> RawVal;
+    fn vec_append(&mut self, v1: RawVal, v2: RawVal) -> RawVal;
 
-    fn pay(&mut self, src: Val, dst: Val, asset: Val, amount: Val) -> Val;
-    fn account_balance(&mut self, acc: Val) -> Val;
-    fn account_trust_line(&mut self, acc: Val, asset: Val) -> Val;
-    fn trust_line_balance(&mut self, tl: Val) -> Val;
-    fn get_contract_data(&mut self, k: Val) -> Val;
-    fn put_contract_data(&mut self, k: Val, v: Val) -> Val;
-    fn has_contract_data(&mut self, k: Val) -> Val;
+    fn pay(&mut self, src: RawVal, dst: RawVal, asset: RawVal, amount: RawVal) -> RawVal;
+    fn account_balance(&mut self, acc: RawVal) -> RawVal;
+    fn account_trust_line(&mut self, acc: RawVal, asset: RawVal) -> RawVal;
+    fn trust_line_balance(&mut self, tl: RawVal) -> RawVal;
+    fn get_contract_data(&mut self, k: RawVal) -> RawVal;
+    fn put_contract_data(&mut self, k: RawVal, v: RawVal) -> RawVal;
+    fn has_contract_data(&mut self, k: RawVal) -> RawVal;
 }

--- a/stellar-contract-env-common/src/env_obj.rs
+++ b/stellar-contract-env-common/src/env_obj.rs
@@ -1,5 +1,7 @@
-use super::{xdr::ScObjectType, Env, EnvVal, HasEnv, RawObj, Tag, Val, ValType};
+use super::{xdr::ScObjectType, Env, EnvVal, HasEnv, RawObj, RawVal, RawValType, Tag};
 
+// EnvObj is just an EnvVal that is statically guaranteed (by construction) to refer
+// to Tag::Object, so it's safe to call methods on it that are meaningful to objects.
 #[derive(Clone)]
 pub struct EnvObj<E: Env>(EnvVal<E>);
 
@@ -30,20 +32,17 @@ impl<E: Env> Into<EnvVal<E>> for EnvObj<E> {
     }
 }
 
-impl<E: Env> Into<Val> for EnvObj<E> {
-    fn into(self) -> Val {
+impl<E: Env> Into<RawVal> for EnvObj<E> {
+    fn into(self) -> RawVal {
         self.0.into()
     }
 }
 
 impl<E: Env> Into<RawObj> for EnvObj<E> {
     fn into(self) -> RawObj {
-        unsafe { <RawObj as ValType>::unchecked_from_val(self.0.val) }
+        unsafe { <RawObj as RawValType>::unchecked_from_val(self.0.val) }
     }
 }
-
-// EnvObj is just an EnvVal that is statically guaranteed (by construction) to refer
-// to Tag::Object, so it's safe to call methods on it that are meaningful to objects.
 
 impl<E: Env> EnvObj<E> {
     #[inline(always)]
@@ -52,17 +51,17 @@ impl<E: Env> EnvObj<E> {
     }
 
     // NB: we don't provide a "get_type" to avoid casting a bad bit-pattern
-    // into an ScObjectType. Instead we provide an "is_type" below to check
+    // into an ScObjectType. Instead we provide an "is_obj_type" below to check
     // any specific bit-pattern.
 
     #[inline(always)]
     pub fn from_type_and_handle(ty: ScObjectType, handle: u32, env: E) -> EnvObj<E> {
-        let val = unsafe { Val::from_major_minor_and_tag(handle, ty as u32, Tag::Object) };
+        let val = unsafe { RawVal::from_major_minor_and_tag(handle, ty as u32, Tag::Object) };
         EnvObj(EnvVal { env, val })
     }
 
     #[inline(always)]
-    pub fn is_type(&self, ty: ScObjectType) -> bool {
+    pub fn is_obj_type(&self, ty: ScObjectType) -> bool {
         self.0.val.has_minor(ty as u32)
     }
 }

--- a/stellar-contract-env-common/src/lib.rs
+++ b/stellar-contract-env-common/src/lib.rs
@@ -7,23 +7,33 @@ mod env_val;
 mod has_env;
 mod or_abort;
 mod raw_obj;
+mod raw_val;
 mod rt;
 mod status;
 mod symbol;
-mod val;
 
-pub use bitset::BitSet;
+// Re-export the XDR definitions
+pub use stellar_xdr as xdr;
+
+// Export some runtime interfaces
+pub use or_abort::OrAbort;
+pub use rt::trap;
+
+// RawVal and RawObj are the 64-bit transparent type.
+pub use raw_obj::RawObj;
+pub use raw_val::{RawVal, RawValType, Tag};
+
+// RawVal and EnvObj couple raw types to environments.
 pub use env::Env;
 pub use env_obj::EnvObj;
 pub use env_val::{EnvVal, EnvValType};
 pub use has_env::HasEnv;
-pub use or_abort::OrAbort;
-pub use raw_obj::RawObj;
-pub use rt::trap;
+
+// BitSet, Status and Symbol wrap RawVals.
+// TODO: maybe these should wrap EnvVals?
+pub use bitset::BitSet;
 pub use status::{Status, OK, UNKNOWN_ERROR};
-pub use stellar_xdr as xdr;
 pub use symbol::{Symbol, SymbolIter};
-pub use val::{Tag, Val, ValType};
 
 #[inline(always)]
 // Awkward: this is a free function rather than a trait call because

--- a/stellar-contract-env-common/src/raw_obj.rs
+++ b/stellar-contract-env-common/src/raw_obj.rs
@@ -1,38 +1,40 @@
-use super::{xdr::ScObjectType, Tag, Val, ValType};
+use super::{xdr::ScObjectType, RawVal, RawValType, Tag};
 
+// RawObj is just an RawVal that is statically guaranteed (by construction) to refer
+// to Tag::Object, so it's safe to call methods on it that are meaningful to objects.
 #[repr(transparent)]
 #[derive(Copy, Clone)]
-pub struct RawObj(Val);
+pub struct RawObj(RawVal);
 
-impl ValType for RawObj {
+impl RawValType for RawObj {
     #[inline(always)]
-    fn is_val_type(v: Val) -> bool {
+    fn is_val_type(v: RawVal) -> bool {
         v.has_tag(Tag::Object)
     }
 
     #[inline(always)]
-    unsafe fn unchecked_from_val(v: Val) -> Self {
+    unsafe fn unchecked_from_val(v: RawVal) -> Self {
         RawObj(v)
     }
 }
 
-impl From<RawObj> for Val {
+impl From<RawObj> for RawVal {
     #[inline(always)]
     fn from(s: RawObj) -> Self {
         s.0
     }
 }
 
-impl AsRef<Val> for RawObj {
+impl AsRef<RawVal> for RawObj {
     #[inline(always)]
-    fn as_ref(&self) -> &Val {
+    fn as_ref(&self) -> &RawVal {
         &self.0
     }
 }
 
-impl AsMut<Val> for RawObj {
+impl AsMut<RawVal> for RawObj {
     #[inline(always)]
-    fn as_mut(&mut self) -> &mut Val {
+    fn as_mut(&mut self) -> &mut RawVal {
         &mut self.0
     }
 }
@@ -42,7 +44,7 @@ impl RawObj {
     // an ScStatusType. Instead we provide an "is_type" to check any specific
     // bit-pattern.
     #[inline(always)]
-    pub const fn is_type(&self, ty: ScObjectType) -> bool {
+    pub const fn is_obj_type(&self, ty: ScObjectType) -> bool {
         self.0.has_minor(ty as u32)
     }
 
@@ -52,12 +54,12 @@ impl RawObj {
     }
 
     #[inline(always)]
-    pub fn val_is_obj_type(v: Val, ty: ScObjectType) -> bool {
+    pub fn val_is_obj_type(v: RawVal, ty: ScObjectType) -> bool {
         v.has_tag(Tag::Object) && v.has_minor(ty as u32)
     }
 
     #[inline(always)]
     pub const fn from_type_and_code(ty: ScObjectType, code: u32) -> RawObj {
-        RawObj(unsafe { Val::from_major_minor_and_tag(code, ty as u32, Tag::Object) })
+        RawObj(unsafe { RawVal::from_major_minor_and_tag(code, ty as u32, Tag::Object) })
     }
 }

--- a/stellar-contract-env-common/src/status.rs
+++ b/stellar-contract-env-common/src/status.rs
@@ -1,4 +1,4 @@
-use super::val::{Tag, Val, ValType};
+use super::raw_val::{RawVal, RawValType, Tag};
 use core::{
     cmp::Ordering,
     hash::{Hash, Hasher},
@@ -7,43 +7,43 @@ use stellar_xdr::ScStatusType;
 
 #[repr(transparent)]
 #[derive(Copy, Clone)]
-pub struct Status(Val);
+pub struct Status(RawVal);
 
 pub const UNKNOWN_ERROR: Status = Status(unsafe {
-    Val::from_major_minor_and_tag(0, ScStatusType::SstUnknownError as u32, Tag::Status)
+    RawVal::from_major_minor_and_tag(0, ScStatusType::SstUnknownError as u32, Tag::Status)
 });
 pub const OK: Status =
-    Status(unsafe { Val::from_major_minor_and_tag(0, ScStatusType::SstOk as u32, Tag::Status) });
+    Status(unsafe { RawVal::from_major_minor_and_tag(0, ScStatusType::SstOk as u32, Tag::Status) });
 
-impl ValType for Status {
+impl RawValType for Status {
     #[inline(always)]
-    fn is_val_type(v: Val) -> bool {
+    fn is_val_type(v: RawVal) -> bool {
         v.has_tag(Tag::Status)
     }
 
     #[inline(always)]
-    unsafe fn unchecked_from_val(v: Val) -> Self {
+    unsafe fn unchecked_from_val(v: RawVal) -> Self {
         Status(v)
     }
 }
 
-impl From<Status> for Val {
+impl From<Status> for RawVal {
     #[inline(always)]
     fn from(s: Status) -> Self {
         s.0
     }
 }
 
-impl AsRef<Val> for Status {
+impl AsRef<RawVal> for Status {
     #[inline(always)]
-    fn as_ref(&self) -> &Val {
+    fn as_ref(&self) -> &RawVal {
         &self.0
     }
 }
 
-impl AsMut<Val> for Status {
+impl AsMut<RawVal> for Status {
     #[inline(always)]
-    fn as_mut(&mut self) -> &mut Val {
+    fn as_mut(&mut self) -> &mut RawVal {
         &mut self.0
     }
 }
@@ -101,6 +101,6 @@ impl Status {
 
     #[inline(always)]
     pub const fn from_type_and_code(ty: ScStatusType, code: u32) -> Status {
-        Status(unsafe { Val::from_major_minor_and_tag(code, ty as u32, Tag::Status) })
+        Status(unsafe { RawVal::from_major_minor_and_tag(code, ty as u32, Tag::Status) })
     }
 }

--- a/stellar-contract-env-common/src/symbol.rs
+++ b/stellar-contract-env-common/src/symbol.rs
@@ -7,7 +7,7 @@ use core::{
 
 extern crate static_assertions as sa;
 
-use super::val::{Tag, Val, ValType, BODY_BITS};
+use super::raw_val::{RawVal, RawValType, Tag, BODY_BITS};
 
 const MAX_CHARS: usize = 10;
 const CODE_BITS: usize = 6;
@@ -17,22 +17,22 @@ sa::const_assert!(CODE_BITS * MAX_CHARS == BODY_BITS);
 
 #[repr(transparent)]
 #[derive(Copy, Clone)]
-pub struct Symbol(pub(crate) Val);
+pub struct Symbol(pub(crate) RawVal);
 
-impl From<Symbol> for Val {
+impl From<Symbol> for RawVal {
     #[inline(always)]
     fn from(s: Symbol) -> Self {
         s.0
     }
 }
 
-impl ValType for Symbol {
+impl RawValType for Symbol {
     #[inline(always)]
-    unsafe fn unchecked_from_val(v: Val) -> Self {
+    unsafe fn unchecked_from_val(v: RawVal) -> Self {
         Symbol(v)
     }
 
-    fn is_val_type(v: Val) -> bool {
+    fn is_val_type(v: RawVal) -> bool {
         v.has_tag(Tag::Symbol)
     }
 }
@@ -92,7 +92,7 @@ impl Symbol {
             };
             accum |= v;
         }
-        let v = unsafe { Val::from_body_and_tag(accum, Tag::Symbol) };
+        let v = unsafe { RawVal::from_body_and_tag(accum, Tag::Symbol) };
         Ok(Symbol(v))
     }
 
@@ -153,7 +153,7 @@ impl FromIterator<char> for Symbol {
             };
             accum |= v;
         }
-        let v = unsafe { Val::from_body_and_tag(accum, Tag::Symbol) };
+        let v = unsafe { RawVal::from_body_and_tag(accum, Tag::Symbol) };
         Symbol(v)
     }
 }

--- a/stellar-contract-env-guest/src/guest.rs
+++ b/stellar-contract-env-guest/src/guest.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
-use super::{Env, Val};
+use super::{Env, RawVal};
 
 // In guest code the environment is global/implicit, so is represented as a unit struct.
 #[derive(Copy, Clone, Default)]
@@ -16,139 +16,139 @@ impl Env for Guest {
         ()
     }
 
-    fn obj_cmp(&self, a: Val, b: Val) -> i64 {
+    fn obj_cmp(&self, a: RawVal, b: RawVal) -> i64 {
         todo!()
     }
 
-    fn log_value(&mut self, v: Val) -> Val {
+    fn log_value(&mut self, v: RawVal) -> RawVal {
         unsafe { context::log_value(v) }
     }
 
-    fn get_last_operation_result(&mut self) -> Val {
+    fn get_last_operation_result(&mut self) -> RawVal {
         unsafe { context::get_last_operation_result() }
     }
 
-    fn obj_from_u64(&mut self, u: u64) -> Val {
+    fn obj_from_u64(&mut self, u: u64) -> RawVal {
         unsafe { u64::from_u64(u) }
     }
 
-    fn obj_to_u64(&mut self, u: Val) -> u64 {
+    fn obj_to_u64(&mut self, u: RawVal) -> u64 {
         unsafe { u64::to_u64(u) }
     }
 
-    fn obj_from_i64(&mut self, i: i64) -> Val {
+    fn obj_from_i64(&mut self, i: i64) -> RawVal {
         unsafe { i64::from_i64(i) }
     }
 
-    fn obj_to_i64(&mut self, i: Val) -> i64 {
+    fn obj_to_i64(&mut self, i: RawVal) -> i64 {
         unsafe { i64::to_i64(i) }
     }
 
-    fn map_new(&mut self) -> Val {
+    fn map_new(&mut self) -> RawVal {
         unsafe { map::new() }
     }
 
-    fn map_put(&mut self, m: Val, k: Val, v: Val) -> Val {
+    fn map_put(&mut self, m: RawVal, k: RawVal, v: RawVal) -> RawVal {
         unsafe { map::put(m, k, v) }
     }
 
-    fn map_get(&mut self, m: Val, k: Val) -> Val {
+    fn map_get(&mut self, m: RawVal, k: RawVal) -> RawVal {
         unsafe { map::get(m, k) }
     }
 
-    fn map_del(&mut self, m: Val, k: Val) -> Val {
+    fn map_del(&mut self, m: RawVal, k: RawVal) -> RawVal {
         unsafe { map::del(m, k) }
     }
 
-    fn map_len(&mut self, m: Val) -> Val {
+    fn map_len(&mut self, m: RawVal) -> RawVal {
         unsafe { map::len(m) }
     }
 
-    fn map_keys(&mut self, m: Val) -> Val {
+    fn map_keys(&mut self, m: RawVal) -> RawVal {
         unsafe { map::keys(m) }
     }
 
-    fn map_has(&mut self, m: Val, k: Val) -> Val {
+    fn map_has(&mut self, m: RawVal, k: RawVal) -> RawVal {
         unsafe { map::has(m, k) }
     }
 
-    fn vec_new(&mut self) -> Val {
+    fn vec_new(&mut self) -> RawVal {
         unsafe { vec::new() }
     }
 
-    fn vec_put(&mut self, v: Val, i: Val, x: Val) -> Val {
+    fn vec_put(&mut self, v: RawVal, i: RawVal, x: RawVal) -> RawVal {
         unsafe { vec::put(v, i, x) }
     }
 
-    fn vec_get(&mut self, v: Val, i: Val) -> Val {
+    fn vec_get(&mut self, v: RawVal, i: RawVal) -> RawVal {
         unsafe { vec::get(v, i) }
     }
 
-    fn vec_del(&mut self, v: Val, i: Val) -> Val {
+    fn vec_del(&mut self, v: RawVal, i: RawVal) -> RawVal {
         unsafe { vec::del(v, i) }
     }
 
-    fn vec_len(&mut self, v: Val) -> Val {
+    fn vec_len(&mut self, v: RawVal) -> RawVal {
         unsafe { vec::len(v) }
     }
 
-    fn vec_push(&mut self, v: Val, x: Val) -> Val {
+    fn vec_push(&mut self, v: RawVal, x: RawVal) -> RawVal {
         unsafe { vec::push(v, x) }
     }
 
-    fn vec_pop(&mut self, v: Val) -> Val {
+    fn vec_pop(&mut self, v: RawVal) -> RawVal {
         unsafe { vec::pop(v) }
     }
 
-    fn vec_take(&mut self, v: Val, n: Val) -> Val {
+    fn vec_take(&mut self, v: RawVal, n: RawVal) -> RawVal {
         unsafe { vec::take(v, n) }
     }
 
-    fn vec_drop(&mut self, v: Val, n: Val) -> Val {
+    fn vec_drop(&mut self, v: RawVal, n: RawVal) -> RawVal {
         unsafe { vec::drop(v, n) }
     }
 
-    fn vec_front(&mut self, v: Val) -> Val {
+    fn vec_front(&mut self, v: RawVal) -> RawVal {
         unsafe { vec::front(v) }
     }
 
-    fn vec_back(&mut self, v: Val) -> Val {
+    fn vec_back(&mut self, v: RawVal) -> RawVal {
         unsafe { vec::back(v) }
     }
 
-    fn vec_insert(&mut self, v: Val, i: Val, n: Val) -> Val {
+    fn vec_insert(&mut self, v: RawVal, i: RawVal, n: RawVal) -> RawVal {
         unsafe { vec::insert(v, i, n) }
     }
 
-    fn vec_append(&mut self, v1: Val, v2: Val) -> Val {
+    fn vec_append(&mut self, v1: RawVal, v2: RawVal) -> RawVal {
         unsafe { vec::append(v1, v2) }
     }
 
-    fn pay(&mut self, src: Val, dst: Val, asset: Val, amount: Val) -> Val {
+    fn pay(&mut self, src: RawVal, dst: RawVal, asset: RawVal, amount: RawVal) -> RawVal {
         unsafe { ledger::pay(src, dst, asset, amount) }
     }
 
-    fn account_balance(&mut self, acc: Val) -> Val {
+    fn account_balance(&mut self, acc: RawVal) -> RawVal {
         unsafe { ledger::account_balance(acc) }
     }
 
-    fn account_trust_line(&mut self, acc: Val, asset: Val) -> Val {
+    fn account_trust_line(&mut self, acc: RawVal, asset: RawVal) -> RawVal {
         unsafe { ledger::account_trust_line(acc, asset) }
     }
 
-    fn trust_line_balance(&mut self, tl: Val) -> Val {
+    fn trust_line_balance(&mut self, tl: RawVal) -> RawVal {
         unsafe { ledger::trust_line_balance(tl) }
     }
 
-    fn get_contract_data(&mut self, k: Val) -> Val {
+    fn get_contract_data(&mut self, k: RawVal) -> RawVal {
         unsafe { ledger::get_contract_data(k) }
     }
 
-    fn put_contract_data(&mut self, k: Val, v: Val) -> Val {
+    fn put_contract_data(&mut self, k: RawVal, v: RawVal) -> RawVal {
         unsafe { ledger::put_contract_data(k, v) }
     }
 
-    fn has_contract_data(&mut self, k: Val) -> Val {
+    fn has_contract_data(&mut self, k: RawVal) -> RawVal {
         unsafe { ledger::has_contract_data(k) }
     }
 }
@@ -177,7 +177,7 @@ impl Env for Guest {
 
 // General context-access functions live in the wasm 'x' module.
 mod context {
-    use crate::Val;
+    use crate::RawVal;
     #[link(wasm_import_module = "x")]
     extern "C" {
 
@@ -193,136 +193,136 @@ mod context {
         // these possibilities seem unlikely at present, but either way they're
         // fairly straightforward.
         #[cfg_attr(target_family = "wasm", link_name = "$_")]
-        pub fn log_value(v: Val) -> Val;
+        pub(crate) fn log_value(v: RawVal) -> RawVal;
 
         // Fetches an OpResult object for inspection, in the rare case the user
         // wants more detail than is conveyed in a simple Status.
         #[cfg_attr(target_family = "wasm", link_name = "$0")]
-        pub fn get_last_operation_result() -> Val;
+        pub(crate) fn get_last_operation_result() -> RawVal;
     }
 }
 
 // U64 functions live in the wasm 'u' module
 mod u64 {
-    use crate::Val;
+    use crate::RawVal;
     #[link(wasm_import_module = "u")]
     extern "C" {
         #[cfg_attr(target_family = "wasm", link_name = "$_")]
-        pub fn from_u64(x: u64) -> Val;
+        pub(crate) fn from_u64(x: u64) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$0")]
-        pub fn to_u64(x: Val) -> u64;
+        pub(crate) fn to_u64(x: RawVal) -> u64;
     }
 }
 
 // I64 functions live in the wasm 'i' module
 mod i64 {
-    use crate::Val;
+    use crate::RawVal;
     #[link(wasm_import_module = "i")]
     extern "C" {
         #[cfg_attr(target_family = "wasm", link_name = "$_")]
-        pub fn from_i64(x: i64) -> Val;
+        pub(crate) fn from_i64(x: i64) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$0")]
-        pub fn to_i64(x: Val) -> i64;
+        pub(crate) fn to_i64(x: RawVal) -> i64;
     }
 }
 
 // Map functions live in the wasm 'm' module
 mod map {
-    use crate::Val;
+    use crate::RawVal;
     #[link(wasm_import_module = "m")]
     extern "C" {
         #[cfg_attr(target_family = "wasm", link_name = "$_")]
-        pub fn new() -> Val;
+        pub(crate) fn new() -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$0")]
-        pub fn put(m: Val, k: Val, v: Val) -> Val;
+        pub(crate) fn put(m: RawVal, k: RawVal, v: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$1")]
-        pub fn get(m: Val, k: Val) -> Val;
+        pub(crate) fn get(m: RawVal, k: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$2")]
-        pub fn del(m: Val, k: Val) -> Val;
+        pub(crate) fn del(m: RawVal, k: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$3")]
-        pub fn len(m: Val) -> Val;
+        pub(crate) fn len(m: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$4")]
-        pub fn keys(m: Val) -> Val;
+        pub(crate) fn keys(m: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$5")]
-        pub fn has(m: Val, k: Val) -> Val;
+        pub(crate) fn has(m: RawVal, k: RawVal) -> RawVal;
     }
 }
 
 // Vec functions live in the wasm 'v' module
 mod vec {
-    use crate::Val;
+    use crate::RawVal;
     #[link(wasm_import_module = "v")]
     extern "C" {
         #[cfg_attr(target_family = "wasm", link_name = "$_")]
-        pub fn new() -> Val;
+        pub(crate) fn new() -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$0")]
-        pub fn put(v: Val, i: Val, x: Val) -> Val;
+        pub(crate) fn put(v: RawVal, i: RawVal, x: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$1")]
-        pub fn get(v: Val, i: Val) -> Val;
+        pub(crate) fn get(v: RawVal, i: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$2")]
-        pub fn del(v: Val, i: Val) -> Val;
+        pub(crate) fn del(v: RawVal, i: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$3")]
-        pub fn len(v: Val) -> Val;
+        pub(crate) fn len(v: RawVal) -> RawVal;
 
         #[cfg_attr(target_family = "wasm", link_name = "$4")]
-        pub fn push(v: Val, x: Val) -> Val;
+        pub(crate) fn push(v: RawVal, x: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$5")]
-        pub fn pop(v: Val) -> Val;
+        pub(crate) fn pop(v: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$6")]
-        pub fn take(v: Val, n: Val) -> Val;
+        pub(crate) fn take(v: RawVal, n: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$7")]
-        pub fn drop(v: Val, n: Val) -> Val;
+        pub(crate) fn drop(v: RawVal, n: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$8")]
-        pub fn front(v: Val) -> Val;
+        pub(crate) fn front(v: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$9")]
-        pub fn back(v: Val) -> Val;
+        pub(crate) fn back(v: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$A")]
-        pub fn insert(v: Val, i: Val, x: Val) -> Val;
+        pub(crate) fn insert(v: RawVal, i: RawVal, x: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$B")]
-        pub fn append(v1: Val, v2: Val) -> Val;
+        pub(crate) fn append(v1: RawVal, v2: RawVal) -> RawVal;
     }
 }
 
 // Ledger functions live in the wasm 'l' module
 mod ledger {
-    use crate::Val;
+    use crate::RawVal;
     #[link(wasm_import_module = "l")]
     extern "C" {
         #[cfg_attr(target_family = "wasm", link_name = "$_")]
-        pub fn get_current_ledger_num() -> Val;
+        pub(crate) fn get_current_ledger_num() -> RawVal;
 
         // NB: this returns a raw/unboxed u64, not a Val union.
         #[cfg_attr(target_family = "wasm", link_name = "$0")]
-        pub fn get_current_ledger_close_time() -> u64;
+        pub(crate) fn get_current_ledger_close_time() -> u64;
 
         // NB: returns a Status; details can be fetched with
         // get_last_operation_result.
         #[cfg_attr(target_family = "wasm", link_name = "$1")]
-        pub fn pay(src: Val, dst: Val, asset: Val, amount: Val) -> Val;
+        pub(crate) fn pay(src: RawVal, dst: RawVal, asset: RawVal, amount: RawVal) -> RawVal;
 
         #[cfg_attr(target_family = "wasm", link_name = "$2")]
-        pub fn put_contract_data(key: Val, val: Val) -> Val;
+        pub(crate) fn put_contract_data(key: RawVal, val: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$3")]
-        pub fn has_contract_data(key: Val) -> Val;
+        pub(crate) fn has_contract_data(key: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$4")]
-        pub fn get_contract_data(key: Val) -> Val;
+        pub(crate) fn get_contract_data(key: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$5")]
-        pub fn del_contract_data(key: Val) -> Val;
+        pub(crate) fn del_contract_data(key: RawVal) -> RawVal;
 
         #[cfg_attr(target_family = "wasm", link_name = "$6")]
-        pub fn account_balance(acc: Val) -> Val;
+        pub(crate) fn account_balance(acc: RawVal) -> RawVal;
 
         #[cfg_attr(target_family = "wasm", link_name = "$7")]
-        pub fn account_trust_line(acc: Val, asset: Val) -> Val;
+        pub(crate) fn account_trust_line(acc: RawVal, asset: RawVal) -> RawVal;
 
         #[cfg_attr(target_family = "wasm", link_name = "$8")]
-        pub fn trust_line_balance(tl: Val) -> Val;
+        pub(crate) fn trust_line_balance(tl: RawVal) -> RawVal;
     }
 }
 
 // Cross-contract functions live in the wasm 'c' module
 mod call {
-    use crate::Val;
+    use crate::RawVal;
     #[link(wasm_import_module = "c")]
     extern "C" {
         // NB: returns callee-return-value-or-Status; details can be fetched with
@@ -332,70 +332,83 @@ mod call {
         // successfully returned a status, or call failed and failure _generated_ a
         // status. Possibly this distinction is too fussy to disambiguate.
         #[cfg_attr(target_family = "wasm", link_name = "$_")]
-        pub fn call0(contract: Val, func: Val) -> Val;
+        pub(crate) fn call0(contract: RawVal, func: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$0")]
-        pub fn call1(contract: Val, func: Val, a: Val) -> Val;
+        pub(crate) fn call1(contract: RawVal, func: RawVal, a: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$1")]
-        pub fn call2(contract: Val, func: Val, a: Val, b: Val) -> Val;
+        pub(crate) fn call2(contract: RawVal, func: RawVal, a: RawVal, b: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$2")]
-        pub fn call3(contract: Val, func: Val, a: Val, b: Val, c: Val) -> Val;
+        pub(crate) fn call3(
+            contract: RawVal,
+            func: RawVal,
+            a: RawVal,
+            b: RawVal,
+            c: RawVal,
+        ) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$3")]
-        pub fn call4(contract: Val, func: Val, a: Val, b: Val, c: Val, d: Val) -> Val;
+        pub(crate) fn call4(
+            contract: RawVal,
+            func: RawVal,
+            a: RawVal,
+            b: RawVal,
+            c: RawVal,
+            d: RawVal,
+        ) -> RawVal;
     }
 }
 
 // BigNum functions live in the wasm 'b' module
 mod bignum {
-    use crate::Val;
+    use crate::RawVal;
     #[link(wasm_import_module = "b")]
     extern "C" {
         #[cfg_attr(target_family = "wasm", link_name = "$_")]
-        pub fn from_u64(x: u64) -> Val;
+        pub(crate) fn from_u64(x: u64) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$0")]
-        pub fn add(lhs: Val, rhs: Val) -> Val;
+        pub(crate) fn add(lhs: RawVal, rhs: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$1")]
-        pub fn sub(lhs: Val, rhs: Val) -> Val;
+        pub(crate) fn sub(lhs: RawVal, rhs: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$2")]
-        pub fn mul(lhs: Val, rhs: Val) -> Val;
+        pub(crate) fn mul(lhs: RawVal, rhs: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$3")]
-        pub fn div(lhs: Val, rhs: Val) -> Val;
+        pub(crate) fn div(lhs: RawVal, rhs: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$4")]
-        pub fn rem(lhs: Val, rhs: Val) -> Val;
+        pub(crate) fn rem(lhs: RawVal, rhs: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$5")]
-        pub fn and(lhs: Val, rhs: Val) -> Val;
+        pub(crate) fn and(lhs: RawVal, rhs: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$6")]
-        pub fn or(lhs: Val, rhs: Val) -> Val;
+        pub(crate) fn or(lhs: RawVal, rhs: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$7")]
-        pub fn xor(lhs: Val, rhs: Val) -> Val;
+        pub(crate) fn xor(lhs: RawVal, rhs: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$8")]
-        pub fn shl(lhs: Val, rhs: u64) -> Val;
+        pub(crate) fn shl(lhs: RawVal, rhs: u64) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$9")]
-        pub fn shr(lhs: Val, rhs: u64) -> Val;
+        pub(crate) fn shr(lhs: RawVal, rhs: u64) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$A")]
-        pub fn cmp(lhs: Val, rhs: Val) -> Val;
+        pub(crate) fn cmp(lhs: RawVal, rhs: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$B")]
-        pub fn is_zero(x: Val) -> Val;
+        pub(crate) fn is_zero(x: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$C")]
-        pub fn neg(x: Val) -> Val;
+        pub(crate) fn neg(x: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$D")]
-        pub fn not(x: Val) -> Val;
+        pub(crate) fn not(x: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$E")]
-        pub fn gcd(lhs: Val, rhs: Val) -> Val;
+        pub(crate) fn gcd(lhs: RawVal, rhs: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$F")]
-        pub fn lcm(lhs: Val, rhs: Val) -> Val;
+        pub(crate) fn lcm(lhs: RawVal, rhs: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$G")]
-        pub fn pow(lhs: Val, rhs: u64) -> Val;
+        pub(crate) fn pow(lhs: RawVal, rhs: u64) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$H")]
-        pub fn pow_mod(p: Val, q: Val, m: Val) -> Val;
+        pub(crate) fn pow_mod(p: RawVal, q: RawVal, m: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$I")]
-        pub fn sqrt(x: Val) -> Val;
+        pub(crate) fn sqrt(x: RawVal) -> RawVal;
         #[cfg_attr(target_family = "wasm", link_name = "$J")]
-        pub fn bits(x: Val) -> u64;
+        pub(crate) fn bits(x: RawVal) -> u64;
         #[cfg_attr(target_family = "wasm", link_name = "$K")]
-        pub fn to_u64(x: Val) -> u64;
+        pub(crate) fn to_u64(x: RawVal) -> u64;
         #[cfg_attr(target_family = "wasm", link_name = "$L")]
-        pub fn to_i64(x: Val) -> i64;
+        pub(crate) fn to_i64(x: RawVal) -> i64;
         #[cfg_attr(target_family = "wasm", link_name = "$M")]
-        pub fn from_i64(x: i64) -> Val;
+        pub(crate) fn from_i64(x: i64) -> RawVal;
     }
 }

--- a/stellar-contract-env-host/src/host_object.rs
+++ b/stellar-contract-env-host/src/host_object.rs
@@ -1,18 +1,22 @@
-use super::xdr::{
-    AccountId, Asset, LedgerKey, Operation, OperationResult, Price, ScObjectType, Transaction,
+use super::{
+    weak_host::WeakHost,
+    xdr::{
+        AccountId, Asset, LedgerKey, Operation, OperationResult, Price, ScObjectType, Transaction,
+    },
+    EnvObj, EnvVal,
 };
-use super::{EnvVal, WeakHost};
-use im_rc::{OrdMap, Vector};
 
+use im_rc::{OrdMap, Vector};
 use num_bigint::BigInt;
 use num_rational::BigRational;
 
-pub type HostVal = EnvVal<WeakHost>;
-pub type HostMap = OrdMap<HostVal, HostVal>;
-pub type HostVec = Vector<HostVal>;
+pub(crate) type HostObj = EnvObj<WeakHost>;
+pub(crate) type HostVal = EnvVal<WeakHost>;
+pub(crate) type HostMap = OrdMap<HostVal, HostVal>;
+pub(crate) type HostVec = Vector<HostVal>;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum HostObject {
+pub(crate) enum HostObject {
     Box(HostVal),
     Vec(HostVec),
     Map(HostMap),
@@ -31,7 +35,7 @@ pub enum HostObject {
     AccountID(AccountId),
 }
 
-pub trait HostObjectType: Sized {
+pub(crate) trait HostObjectType: Sized {
     fn get_type() -> ScObjectType;
     fn inject(self) -> HostObject;
 }

--- a/stellar-contract-env-host/src/lib.rs
+++ b/stellar-contract-env-host/src/lib.rs
@@ -1,6 +1,9 @@
 mod host;
-mod host_object;
+pub(crate) mod host_object;
+pub(crate) mod weak_host;
 
-pub use host::{Host, WeakHost};
-pub use host_object::{HostMap, HostObject, HostObjectType, HostVal, HostVec};
+#[cfg(test)]
+mod test;
+
+pub use host::Host;
 pub use stellar_contract_env_common::*;

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -1,0 +1,39 @@
+use crate::{
+    xdr::{ScObject, ScObjectType, ScVal, ScVec},
+    EnvValType, Host, OrAbort, RawObj,
+};
+
+#[test]
+fn i64_roundtrip() {
+    let host = Host::default();
+    let i = 12345_i64;
+    let v = host.associate_env_val_type(i);
+    let j = <i64 as EnvValType>::try_from_env_val(v).unwrap();
+    assert_eq!(i, j);
+}
+
+#[test]
+fn vec_as_seen_by_host() -> Result<(), ()> {
+    let mut host = Host::default();
+    let scvec0: ScVec = ScVec(vec![ScVal::ScvU32(1)].try_into()?);
+    let scvec1: ScVec = ScVec(vec![ScVal::ScvU32(1)].try_into()?);
+    let scobj0: ScObject = ScObject::ScoVec(scvec0);
+    let scobj1: ScObject = ScObject::ScoVec(scvec1);
+    let scval0 = ScVal::ScvObject(Some(Box::new(scobj0)));
+    let scval1 = ScVal::ScvObject(Some(Box::new(scobj1)));
+    let val0 = host.to_host_val(&scval0).or_abort();
+    let val1 = host.to_host_val(&scval1).or_abort();
+    assert!(val0.val.is::<RawObj>());
+    assert!(val1.val.is::<RawObj>());
+    let obj0: RawObj = val0.val.try_into().or_abort();
+    let obj1: RawObj = val1.val.try_into().or_abort();
+    assert_eq!(obj0.get_handle(), 0);
+    assert_eq!(obj1.get_handle(), 1);
+    assert!(obj0.is_obj_type(ScObjectType::ScoVec));
+    assert!(obj1.is_obj_type(ScObjectType::ScoVec));
+    // Check that we got 2 distinct Vec objects
+    assert_ne!(val0.val.get_payload(), val1.val.get_payload());
+    // But also that they compare deep-equal.
+    assert_eq!(val0, val1);
+    Ok(())
+}

--- a/stellar-contract-env-host/src/weak_host.rs
+++ b/stellar-contract-env-host/src/weak_host.rs
@@ -1,0 +1,182 @@
+use crate::{host::HostImpl, Env, Host, RawVal};
+use core::fmt::Debug;
+use std::rc::Weak;
+
+// WeakHost is a newtype on Weak<HostImpl> so we can impl Env for it below. All
+// it does is upgrade its weak reference and call through to the underlying
+// method on Host, which holds a strong reference.
+//
+// It is not exported from the crate: we don't want users of Host to have to
+// worry about weak references becoming invalid.
+//
+// It exists because Host _uses_ EnvVal<WeakHost> for its own internal
+// representation of Vals -- HostVal -- when nesting them inside its own
+// objects, and they call back through the WeakHost implementation of Env in
+// order to do deep-equality and such.
+//
+// This is all a little convoluted and possibly too fixated on reusing code, but
+// it means we can mostly use Val in 3 separate contexts (host-internal, wasm
+// guest, and host-external-as-used-from-contract-unit-tests) only varying the
+// type of the environment stored inside each (Guest, WeakHost, and Host
+// respectively)
+
+#[derive(Clone)]
+pub(crate) struct WeakHost(pub(crate) Weak<HostImpl>);
+
+impl Debug for WeakHost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "WeakHost({:x})", self.0.as_ptr() as usize)
+    }
+}
+
+impl WeakHost {
+    fn get_host(&self) -> Host {
+        Host(self.0.upgrade().expect("WeakHost upgrade"))
+    }
+}
+
+impl Env for WeakHost {
+    fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
+        self as &mut dyn std::any::Any
+    }
+
+    fn check_same_env(&self, other: &Self) {
+        self.get_host().check_same_env(&other.get_host())
+    }
+
+    fn obj_cmp(&self, a: RawVal, b: RawVal) -> i64 {
+        self.get_host().obj_cmp(a, b)
+    }
+
+    fn log_value(&mut self, v: RawVal) -> RawVal {
+        self.get_host().log_value(v)
+    }
+
+    fn get_last_operation_result(&mut self) -> RawVal {
+        self.get_host().get_last_operation_result()
+    }
+
+    fn obj_from_u64(&mut self, u: u64) -> RawVal {
+        self.get_host().obj_from_u64(u)
+    }
+
+    fn obj_to_u64(&mut self, u: RawVal) -> u64 {
+        self.get_host().obj_to_u64(u)
+    }
+
+    fn obj_from_i64(&mut self, i: i64) -> RawVal {
+        self.get_host().obj_from_i64(i)
+    }
+
+    fn obj_to_i64(&mut self, i: RawVal) -> i64 {
+        self.get_host().obj_to_i64(i)
+    }
+
+    fn map_new(&mut self) -> RawVal {
+        self.get_host().map_new()
+    }
+
+    fn map_put(&mut self, m: RawVal, k: RawVal, v: RawVal) -> RawVal {
+        self.get_host().map_put(m, k, v)
+    }
+
+    fn map_get(&mut self, m: RawVal, k: RawVal) -> RawVal {
+        self.get_host().map_get(m, k)
+    }
+
+    fn map_del(&mut self, m: RawVal, k: RawVal) -> RawVal {
+        self.get_host().map_del(m, k)
+    }
+
+    fn map_len(&mut self, m: RawVal) -> RawVal {
+        self.get_host().map_len(m)
+    }
+
+    fn map_keys(&mut self, m: RawVal) -> RawVal {
+        self.get_host().map_keys(m)
+    }
+
+    fn map_has(&mut self, m: RawVal, k: RawVal) -> RawVal {
+        self.get_host().map_has(m, k)
+    }
+
+    fn vec_new(&mut self) -> RawVal {
+        self.get_host().vec_new()
+    }
+
+    fn vec_put(&mut self, v: RawVal, i: RawVal, x: RawVal) -> RawVal {
+        self.get_host().vec_put(v, i, x)
+    }
+
+    fn vec_get(&mut self, v: RawVal, i: RawVal) -> RawVal {
+        self.get_host().vec_get(v, i)
+    }
+
+    fn vec_del(&mut self, v: RawVal, i: RawVal) -> RawVal {
+        self.get_host().vec_del(v, i)
+    }
+
+    fn vec_len(&mut self, v: RawVal) -> RawVal {
+        self.get_host().vec_len(v)
+    }
+
+    fn vec_push(&mut self, v: RawVal, x: RawVal) -> RawVal {
+        self.get_host().vec_push(v, x)
+    }
+
+    fn vec_pop(&mut self, v: RawVal) -> RawVal {
+        self.get_host().vec_pop(v)
+    }
+
+    fn vec_take(&mut self, v: RawVal, n: RawVal) -> RawVal {
+        self.get_host().vec_take(v, n)
+    }
+
+    fn vec_drop(&mut self, v: RawVal, n: RawVal) -> RawVal {
+        self.get_host().vec_drop(v, n)
+    }
+
+    fn vec_front(&mut self, v: RawVal) -> RawVal {
+        self.get_host().vec_front(v)
+    }
+
+    fn vec_back(&mut self, v: RawVal) -> RawVal {
+        self.get_host().vec_back(v)
+    }
+
+    fn vec_insert(&mut self, v: RawVal, i: RawVal, n: RawVal) -> RawVal {
+        self.get_host().vec_insert(v, i, n)
+    }
+
+    fn vec_append(&mut self, v1: RawVal, v2: RawVal) -> RawVal {
+        self.get_host().vec_append(v1, v2)
+    }
+
+    fn pay(&mut self, src: RawVal, dst: RawVal, asset: RawVal, amount: RawVal) -> RawVal {
+        self.get_host().pay(src, dst, asset, amount)
+    }
+
+    fn account_balance(&mut self, acc: RawVal) -> RawVal {
+        self.get_host().account_balance(acc)
+    }
+
+    fn account_trust_line(&mut self, acc: RawVal, asset: RawVal) -> RawVal {
+        self.get_host().account_trust_line(acc, asset)
+    }
+
+    fn trust_line_balance(&mut self, tl: RawVal) -> RawVal {
+        self.get_host().trust_line_balance(tl)
+    }
+
+    fn get_contract_data(&mut self, k: RawVal) -> RawVal {
+        self.get_host().get_contract_data(k)
+    }
+
+    fn put_contract_data(&mut self, k: RawVal, v: RawVal) -> RawVal {
+        self.get_host().put_contract_data(k, v)
+    }
+
+    fn has_contract_data(&mut self, k: RawVal) -> RawVal {
+        self.get_host().has_contract_data(k)
+    }
+}

--- a/stellar-contract-env-host/tests/integration.rs
+++ b/stellar-contract-env-host/tests/integration.rs
@@ -1,0 +1,28 @@
+use stellar_contract_env_host::{xdr::ScObjectType, Env, Host, RawObj};
+
+#[test]
+fn vec_as_seen_by_user() -> Result<(), ()> {
+    let mut host = Host::default();
+    let int1 = host.obj_from_i64(5).in_env(&host);
+
+    let vec1a = host.vec_new().in_env(&host);
+    let vec1b = host.vec_push(vec1a.val, int1.val).in_env(&host);
+
+    assert_ne!(vec1a.val.get_payload(), vec1b.val.get_payload());
+
+    let vec2a = host.vec_new().in_env(&host);
+    let vec2b = host.vec_push(vec2a.val, int1.val).in_env(&host);
+
+    assert_ne!(vec2a.val.get_payload(), vec2b.val.get_payload());
+    assert_ne!(vec1b.val.get_payload(), vec2b.val.get_payload());
+    assert_eq!(vec1a, vec2a);
+    assert_eq!(vec1b, vec2b);
+    Ok(())
+}
+
+#[test]
+fn vec_host_fn() {
+    let mut host = Host::default();
+    let m = host.map_new();
+    assert!(RawObj::val_is_obj_type(m, ScObjectType::ScoMap));
+}


### PR DESCRIPTION
Based on conversation today, this buries the `WeakHost` type as a private detail in the host crate and only exposes `Host`, moving all substantial logic to the `impl Env for Host` and making `impl Env for WeakHost` just upgrade the weakref and call through to the `Host` impl. Then it renames `Val` to `RawVal` and reorganizes things a little so `EnvVal<Host>` ought to be relatively convenient to use from contract unit-test code. Adds an integration test to show how that works. I _think_ this is a good path, though we might want to bake-in a duplicate set of `EnvVal`-taking and returning default methods that do the `host.foo(ev.val).in_env(&host)` pattern?