### PR TITLE
Allow EnvObj to be created by sdk

### DIFF
--- a/stellar-contract-env-common/src/env_obj.rs
+++ b/stellar-contract-env-common/src/env_obj.rs
@@ -1,7 +1,8 @@
 use super::{xdr::ScObjectType, Env, EnvVal, HasEnv, RawObj, RawVal, RawValType, Tag};
 
-// EnvObj is just an EnvVal that is statically guaranteed (by construction) to refer
-// to Tag::Object, so it's safe to call methods on it that are meaningful to objects.
+// EnvObj is just an EnvVal that is statically guaranteed (by construction) to
+// refer to a Tag::Object (RawObj), so it's safe to call methods on it that are
+// meaningful to objects.
 #[derive(Clone)]
 pub struct EnvObj<E: Env>(EnvVal<E>);
 
@@ -30,9 +31,10 @@ impl<E: Env> TryFrom<EnvVal<E>> for EnvObj<E> {
     type Error = ();
 
     fn try_from(ev: EnvVal<E>) -> Result<Self, Self::Error> {
-        match ev.val.get_tag() {
-            Tag::Object => Ok(EnvObj(ev)),
-            _ => Err(()),
+        if ev.val.is::<RawObj>() {
+            Ok(EnvObj(ev))
+        } else {
+            Err(())
         }
     }
 }

--- a/stellar-contract-env-common/src/env_obj.rs
+++ b/stellar-contract-env-common/src/env_obj.rs
@@ -3,62 +3,67 @@ use super::{xdr::ScObjectType, Env, EnvVal, HasEnv, RawObj, RawVal, RawValType, 
 // EnvObj is just an EnvVal that is statically guaranteed (by construction) to refer
 // to Tag::Object, so it's safe to call methods on it that are meaningful to objects.
 #[derive(Clone)]
-pub struct EnvObj<E: Env>(EnvVal<E>);
+pub struct EnvObj<E: Env> {
+    pub env: E,
+    pub obj: RawObj,
+}
 
 impl<E: Env> HasEnv<E> for EnvObj<E> {
     fn env(&self) -> &E {
-        &self.0.env
+        &self.env
     }
     fn mut_env(&mut self) -> &mut E {
-        &mut self.0.env
+        &mut self.env
     }
 }
 
-impl<E: Env> AsRef<EnvVal<E>> for EnvObj<E> {
-    fn as_ref(&self) -> &EnvVal<E> {
-        &self.0
-    }
-}
+// impl<E: Env> AsRef<EnvVal<E>> for EnvObj<E> {
+//     fn as_ref(&self) -> &EnvVal<E> {
+//         &self.0
+//     }
+// }
 
-impl<E: Env> AsMut<EnvVal<E>> for EnvObj<E> {
-    fn as_mut(&mut self) -> &mut EnvVal<E> {
-        &mut self.0
-    }
-}
+// impl<E: Env> AsMut<EnvVal<E>> for EnvObj<E> {
+//     fn as_mut(&mut self) -> &mut EnvVal<E> {
+//         &mut self.0
+//     }
+// }
 
 impl<E: Env> TryFrom<EnvVal<E>> for EnvObj<E> {
     type Error = ();
 
     fn try_from(ev: EnvVal<E>) -> Result<Self, Self::Error> {
-        match ev.val.get_tag() {
-            Tag::Object => Ok(EnvObj(ev)),
-            _ => Err(()),
-        }
+        let obj: RawObj = ev.val.try_into()?;
+        Ok(EnvObj { env: ev.env, obj })
     }
 }
 
 impl<E: Env> Into<EnvVal<E>> for EnvObj<E> {
     fn into(self) -> EnvVal<E> {
-        self.0
+        EnvVal {
+            env: self.env,
+            val: self.obj.into(),
+        }
     }
 }
 
 impl<E: Env> Into<RawVal> for EnvObj<E> {
     fn into(self) -> RawVal {
-        self.0.into()
+        self.obj.into()
     }
 }
 
 impl<E: Env> Into<RawObj> for EnvObj<E> {
     fn into(self) -> RawObj {
-        unsafe { <RawObj as RawValType>::unchecked_from_val(self.0.val) }
+        self.obj
     }
 }
 
 impl<E: Env> EnvObj<E> {
     #[inline(always)]
     pub fn get_handle(&self) -> u32 {
-        self.0.val.get_major()
+        let val: &RawVal = self.obj.as_ref();
+        val.get_major()
     }
 
     // NB: we don't provide a "get_type" to avoid casting a bad bit-pattern
@@ -68,11 +73,13 @@ impl<E: Env> EnvObj<E> {
     #[inline(always)]
     pub fn from_type_and_handle(ty: ScObjectType, handle: u32, env: E) -> EnvObj<E> {
         let val = unsafe { RawVal::from_major_minor_and_tag(handle, ty as u32, Tag::Object) };
-        EnvObj(EnvVal { env, val })
+        let obj = unsafe { RawObj::unchecked_from_val(val) };
+        EnvObj { env, obj }
     }
 
     #[inline(always)]
     pub fn is_obj_type(&self, ty: ScObjectType) -> bool {
-        self.0.val.has_minor(ty as u32)
+        let val: &RawVal = self.obj.as_ref();
+        val.has_minor(ty as u32)
     }
 }

--- a/stellar-contract-env-common/src/env_obj.rs
+++ b/stellar-contract-env-common/src/env_obj.rs
@@ -17,18 +17,6 @@ impl<E: Env> HasEnv<E> for EnvObj<E> {
     }
 }
 
-// impl<E: Env> AsRef<EnvVal<E>> for EnvObj<E> {
-//     fn as_ref(&self) -> &EnvVal<E> {
-//         &self.0
-//     }
-// }
-
-// impl<E: Env> AsMut<EnvVal<E>> for EnvObj<E> {
-//     fn as_mut(&mut self) -> &mut EnvVal<E> {
-//         &mut self.0
-//     }
-// }
-
 impl<E: Env> TryFrom<EnvVal<E>> for EnvObj<E> {
     type Error = ();
 

--- a/stellar-contract-env-common/src/env_obj.rs
+++ b/stellar-contract-env-common/src/env_obj.rs
@@ -3,17 +3,26 @@ use super::{xdr::ScObjectType, Env, EnvVal, HasEnv, RawObj, RawVal, RawValType, 
 // EnvObj is just an EnvVal that is statically guaranteed (by construction) to refer
 // to Tag::Object, so it's safe to call methods on it that are meaningful to objects.
 #[derive(Clone)]
-pub struct EnvObj<E: Env> {
-    pub env: E,
-    pub obj: RawObj,
-}
+pub struct EnvObj<E: Env>(EnvVal<E>);
 
 impl<E: Env> HasEnv<E> for EnvObj<E> {
     fn env(&self) -> &E {
-        &self.env
+        &self.0.env
     }
     fn mut_env(&mut self) -> &mut E {
-        &mut self.env
+        &mut self.0.env
+    }
+}
+
+impl<E: Env> AsRef<EnvVal<E>> for EnvObj<E> {
+    fn as_ref(&self) -> &EnvVal<E> {
+        &self.0
+    }
+}
+
+impl<E: Env> AsMut<EnvVal<E>> for EnvObj<E> {
+    fn as_mut(&mut self) -> &mut EnvVal<E> {
+        &mut self.0
     }
 }
 
@@ -21,37 +30,35 @@ impl<E: Env> TryFrom<EnvVal<E>> for EnvObj<E> {
     type Error = ();
 
     fn try_from(ev: EnvVal<E>) -> Result<Self, Self::Error> {
-        let obj: RawObj = ev.val.try_into()?;
-        Ok(EnvObj { env: ev.env, obj })
+        match ev.val.get_tag() {
+            Tag::Object => Ok(EnvObj(ev)),
+            _ => Err(()),
+        }
     }
 }
 
 impl<E: Env> Into<EnvVal<E>> for EnvObj<E> {
     fn into(self) -> EnvVal<E> {
-        EnvVal {
-            env: self.env,
-            val: self.obj.into(),
-        }
+        self.0
     }
 }
 
 impl<E: Env> Into<RawVal> for EnvObj<E> {
     fn into(self) -> RawVal {
-        self.obj.into()
+        self.0.into()
     }
 }
 
 impl<E: Env> Into<RawObj> for EnvObj<E> {
     fn into(self) -> RawObj {
-        self.obj
+        unsafe { <RawObj as RawValType>::unchecked_from_val(self.0.val) }
     }
 }
 
 impl<E: Env> EnvObj<E> {
     #[inline(always)]
     pub fn get_handle(&self) -> u32 {
-        let val: &RawVal = self.obj.as_ref();
-        val.get_major()
+        self.0.val.get_major()
     }
 
     // NB: we don't provide a "get_type" to avoid casting a bad bit-pattern
@@ -61,13 +68,11 @@ impl<E: Env> EnvObj<E> {
     #[inline(always)]
     pub fn from_type_and_handle(ty: ScObjectType, handle: u32, env: E) -> EnvObj<E> {
         let val = unsafe { RawVal::from_major_minor_and_tag(handle, ty as u32, Tag::Object) };
-        let obj = unsafe { RawObj::unchecked_from_val(val) };
-        EnvObj { env, obj }
+        EnvObj(EnvVal { env, val })
     }
 
     #[inline(always)]
     pub fn is_obj_type(&self, ty: ScObjectType) -> bool {
-        let val: &RawVal = self.obj.as_ref();
-        val.has_minor(ty as u32)
+        self.0.val.has_minor(ty as u32)
     }
 }

--- a/stellar-contract-env-common/src/env_obj.rs
+++ b/stellar-contract-env-common/src/env_obj.rs
@@ -26,6 +26,17 @@ impl<E: Env> AsMut<EnvVal<E>> for EnvObj<E> {
     }
 }
 
+impl<E: Env> TryFrom<EnvVal<E>> for EnvObj<E> {
+    type Error = ();
+
+    fn try_from(ev: EnvVal<E>) -> Result<Self, Self::Error> {
+        match ev.val.get_tag() {
+            Tag::Object => Ok(EnvObj(ev)),
+            _ => Err(()),
+        }
+    }
+}
+
 impl<E: Env> Into<EnvVal<E>> for EnvObj<E> {
     fn into(self) -> EnvVal<E> {
         self.0


### PR DESCRIPTION
### What

Allow EnvObj to be created by the sdk.

### Why

The SDK gets RawVal's back from the Env (Host/Guest), but needs to convert them into EnvObjs, but there's no way for it to do that because the type is privately an EnvVal.

### Known limitations

N/A
