### PR TITLE
Add TryFrom<RawVal> to RawValType

### DIFF
--- a/stellar-contract-env-common/src/raw_val.rs
+++ b/stellar-contract-env-common/src/raw_val.rs
@@ -51,7 +51,7 @@ pub enum Static {
 #[derive(Copy, Clone)]
 pub struct RawVal(u64);
 
-pub trait RawValType: Into<RawVal> {
+pub trait RawValType: Into<RawVal> + TryFrom<RawVal> {
     fn is_val_type(v: RawVal) -> bool;
     unsafe fn unchecked_from_val(v: RawVal) -> Self;
 


### PR DESCRIPTION
### What

Add TryFrom<RawVal> to RawValType.

### Why

So that anywhere RawValType is used as a generic parameter we can assume that the type specified for the parameter also has TryFrom<RawVal>, which all RawValType's do.

### Known limitations

N/A
