### PR TITLE
Implement host-function boilerplate through x-macros.

### DIFF
--- a/stellar-contract-env-common/Cargo.toml
+++ b/stellar-contract-env-common/Cargo.toml
@@ -7,6 +7,11 @@ edition = "2021"
 static_assertions = "1.1.0"
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "1fa7c3ebdefd6c78719ede6b294aa64e13077d2a", default-features = false }
 
+# wasmi is an optional dependency only to let us impl its type conversion
+# trait on RawVal locally in this crate; the VM itself is used in the host. 
+wasmi = { version = "0.11.0", optional = true }
+
 [features]
 std = ["stellar-xdr/std"]
 panic_handler = []
+vm = ["wasmi"]

--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -9,24 +9,63 @@ pub trait EnvBase: Sized + Clone {
     fn check_same_env(&self, other: &Self);
 }
 
-// The set of host functions need to be statically reflected-on in
-// a variety of contexts elsewhere in the guest and host, so we define
-// them through an x-macro (a macro that calls a user-provided macro)
+///////////////////////////////////////////////////////////////////////////////
+/// X-macro definition
+///////////////////////////////////////////////////////////////////////////////
+
+// The set of host functions need to be statically reflected-on in a variety of
+// contexts (both in this crate and elsewhere in the guest and host crates), so
+// we define them through an x-macro (a macro that calls a user-provided macro)
 // and call the x-macro from all such contexts.
+//
+// How this macro works:
+//  - It exports a higher-order "x-macro" called
+//    call_macro_with_all_host_functions
+//  - The x-macro takes the name of some callback macro to call
+//  - The x-macro invokes the callback macro once, passing a single large token
+//    tree, seen below in the body of the x-macro
+//
+// To use this macro:
+//  - Call sites define a callback macro that matches on the token-tree
+//  - Call sites invoke the x-macro passing their callback macro name
+//
+// The token-tree being passed is arbitrary, but is chosen to satisfy 3
+// criteria:
+//  - It's relatively easy to read, edit and understand its content
+//  - It's easy to decompose with pattern-matching in the callback macros
+//  - It contains everything any callback macro wants to match and use
+//
+// All callback macros have essentially the same token-tree matcher part,
+// only their expansion parts differ.
 
 #[macro_export]
 macro_rules! call_macro_with_all_host_functions {
 
+    // The x-macro takes a single ident, the name of a macro to call ...
     {$macro_to_call_back:ident} => {
 
-        // We call the user-provided macro back with a sequence of token trees
-        // that represent host function modules, each containing a set of token
-        // trees that represent host functions. The format here is arbitrary, it
-        // just has to convey all the relevant metadata we want to convey and be
-        // sufficiently plainly structured that the callee macros can
-        // pattern-match on it relatively easily.
-
+        // ... and just calls it back, passing a single large token-tree.
         $macro_to_call_back! {
+
+            // The token-tree we pass to the callback is a sequence of
+            // blocks that have the following structure:
+            //
+            //  mod $mod_id:ident $mod_str:literal {
+            //     ...
+            //     { $fn_str:literal, fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty }
+            //     ...
+            //  }
+            //
+            // Where the sub token-trees have the following content:
+            //
+            //  - $selfspec:tt is either (&self) or ($mut self)
+            //  - $args:tt is a normal parenthesized argument list
+            //    of comma-separated arg:type pairs
+            //
+            // The selfspec is split off as a separate token-tree from the arg
+            // list for ease of matching in the callback macro, because some
+            // consumers are interested in a concept of host mutability or
+            // non-mutabiity, and others are not.
 
             mod context "x" {
                 {"$_", fn log_value(&mut self)(v:RawVal) -> RawVal }
@@ -125,40 +164,75 @@ macro_rules! call_macro_with_all_host_functions {
     };
 }
 
-macro_rules! host_function {
-    {fn $func_id:ident(&self)() -> $ret:ty} => {fn $func_id(&self) -> $ret;};
-    {fn $func_id:ident(&self)($($arg:ident:$type:ty),*) -> $ret:ty} => {fn $func_id(&self, $($arg:$type),*) -> $ret;};
-    {fn $func_id:ident(&mut self)() -> $ret:ty} => {fn $func_id(&mut self) -> $ret;};
-    {fn $func_id:ident(&mut self)($($arg:ident:$type:ty),*) -> $ret:ty} => {fn $func_id(&mut self, $($arg:$type),*) -> $ret;};
+///////////////////////////////////////////////////////////////////////////////
+/// X-macro use: defining trait Env
+///////////////////////////////////////////////////////////////////////////////
+
+// This is a helper macro used only by generate_env_trait below. It consumes
+// a token-tree of the form:
+//
+//  {fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty}
+//
+// in each of 4 valid forms (self vs. mut-self, empty vs. nonempty trailing args)
+// and produces the the corresponding method declaration to be used in the Env
+// trait.
+macro_rules! host_function_helper {
+    {fn $fn_id:ident(&self)() -> $ret:ty} => {fn $fn_id(&self) -> $ret;};
+    {fn $fn_id:ident(&self)($($arg:ident:$type:ty),*) -> $ret:ty} => {fn $fn_id(&self, $($arg:$type),*) -> $ret;};
+    {fn $fn_id:ident(&mut self)() -> $ret:ty} => {fn $fn_id(&mut self) -> $ret;};
+    {fn $fn_id:ident(&mut self)($($arg:ident:$type:ty),*) -> $ret:ty} => {fn $fn_id(&mut self, $($arg:$type),*) -> $ret;};
 }
 
+// This is a callback macro that pattern-matches the token-tree passed by the
+// x-macro (call_macro_with_all_host_functions) and produces a suite of method
+// declarations, which it places in the body of the declaration of the Env
+// trait.
 macro_rules! generate_env_trait {
     {
         $(
-            mod $mod_name:ident $mod_str:literal
+            // This outer pattern matches a single 'mod' block of the token-tree
+            // passed from the x-macro to this macro. It is embedded in a `$()*`
+            // pattern-repetition matcher so that it will match all provided
+            // 'mod' blocks provided.
+            mod $mod_id:ident $mod_str:literal
             {
                 $(
-                    { $field_str:literal, fn $func_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                    // This inner pattern matches a single function description
+                    // inside a 'mod' block in the token-tree passed from the
+                    // x-macro to this macro. It is embedded in a `$()*`
+                    // pattern-repetition matcher so that it will match all such
+                    // descriptions.
+                    { $fn_str:literal, fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty }
                 )*
             }
         )*
     }
-    =>
+
+    => // The part of the macro above this line is a matcher; below is its expansion.
+
     {
-        // This trait needs to be implemented by any type that plays the role of the
-        // host for a contract. In a contract test or core setting this will be a full
-        // HostContext, whereas in a contract's wasm build it will be an empty
-        // type that calls through to global wasm imports provided at
-        // wasm-module-instantiation time.
+        // This macro expands to a single item: the Env trait used to define the
+        // interface implemented by Host and Guest, and used by client contract
+        // code.
         pub trait Env: EnvBase
         {
             $(
                 $(
-                    host_function!{fn $func_id $selfspec $args -> $ret}
+                    // This invokes the host_function_helper! macro above
+                    // passing only the relevant parts of the declaration
+                    // matched by the inner pattern above. It is embedded in two
+                    // nested `$()*` pattern-repetition expanders that
+                    // correspond to the pattern-repetition matchers in the
+                    // match section, but we ignore the structure of the 'mod'
+                    // block repetition-level from the outer pattern in the
+                    // expansion, flattening all functions from all 'mod' blocks
+                    // into the Env trait.
+                    host_function_helper!{fn $fn_id $selfspec $args -> $ret}
                 )*
             )*
         }
     };
 }
 
+// Here we invoke the x-macro passing generate_env_trait as its callback macro.
 call_macro_with_all_host_functions! { generate_env_trait }

--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -1,57 +1,164 @@
 use super::RawVal;
 use core::any;
 
-// This trait needs to be implemented by any type that plays the role of the
-// host for a contract. In a contract test or core setting this will be a full
-// HostContext, whereas in a contract's wasm build it will be an empty
-// type that calls through to global wasm imports provided at
-// wasm-module-instantiation time.
-pub trait Env: Sized + Clone {
+pub trait EnvBase: Sized + Clone {
     // Used for recovering the concrete type of the Host.
     fn as_mut_any(&mut self) -> &mut dyn any::Any;
 
     // Used to check two environments are the same, trapping if not.
     fn check_same_env(&self, other: &Self);
-
-    // Used to deep-compare objects, result is an -1, 0, 1
-    // value for lt, eq, gt, respectively.
-    fn obj_cmp(&self, a: RawVal, b: RawVal) -> i64;
-
-    fn log_value(&mut self, v: RawVal) -> RawVal;
-    fn get_last_operation_result(&mut self) -> RawVal;
-
-    fn obj_from_u64(&mut self, u: u64) -> RawVal;
-    fn obj_to_u64(&mut self, u: RawVal) -> u64;
-    fn obj_from_i64(&mut self, i: i64) -> RawVal;
-    fn obj_to_i64(&mut self, i: RawVal) -> i64;
-
-    fn map_new(&mut self) -> RawVal;
-    fn map_put(&mut self, m: RawVal, k: RawVal, v: RawVal) -> RawVal;
-    fn map_get(&mut self, m: RawVal, k: RawVal) -> RawVal;
-    fn map_del(&mut self, m: RawVal, k: RawVal) -> RawVal;
-    fn map_len(&mut self, m: RawVal) -> RawVal;
-    fn map_keys(&mut self, m: RawVal) -> RawVal;
-    fn map_has(&mut self, m: RawVal, k: RawVal) -> RawVal;
-
-    fn vec_new(&mut self) -> RawVal;
-    fn vec_put(&mut self, v: RawVal, i: RawVal, x: RawVal) -> RawVal;
-    fn vec_get(&mut self, v: RawVal, i: RawVal) -> RawVal;
-    fn vec_del(&mut self, v: RawVal, i: RawVal) -> RawVal;
-    fn vec_len(&mut self, v: RawVal) -> RawVal;
-    fn vec_push(&mut self, v: RawVal, x: RawVal) -> RawVal;
-    fn vec_pop(&mut self, v: RawVal) -> RawVal;
-    fn vec_take(&mut self, v: RawVal, n: RawVal) -> RawVal;
-    fn vec_drop(&mut self, v: RawVal, n: RawVal) -> RawVal;
-    fn vec_front(&mut self, v: RawVal) -> RawVal;
-    fn vec_back(&mut self, v: RawVal) -> RawVal;
-    fn vec_insert(&mut self, v: RawVal, i: RawVal, n: RawVal) -> RawVal;
-    fn vec_append(&mut self, v1: RawVal, v2: RawVal) -> RawVal;
-
-    fn pay(&mut self, src: RawVal, dst: RawVal, asset: RawVal, amount: RawVal) -> RawVal;
-    fn account_balance(&mut self, acc: RawVal) -> RawVal;
-    fn account_trust_line(&mut self, acc: RawVal, asset: RawVal) -> RawVal;
-    fn trust_line_balance(&mut self, tl: RawVal) -> RawVal;
-    fn get_contract_data(&mut self, k: RawVal) -> RawVal;
-    fn put_contract_data(&mut self, k: RawVal, v: RawVal) -> RawVal;
-    fn has_contract_data(&mut self, k: RawVal) -> RawVal;
 }
+
+// The set of host functions need to be statically reflected-on in
+// a variety of contexts elsewhere in the guest and host, so we define
+// them through an x-macro (a macro that calls a user-provided macro)
+// and call the x-macro from all such contexts.
+
+#[macro_export]
+macro_rules! call_macro_with_all_host_functions {
+
+    {$macro_to_call_back:ident} => {
+
+        // We call the user-provided macro back with a sequence of token trees
+        // that represent host function modules, each containing a set of token
+        // trees that represent host functions. The format here is arbitrary, it
+        // just has to convey all the relevant metadata we want to convey and be
+        // sufficiently plainly structured that the callee macros can
+        // pattern-match on it relatively easily.
+
+        $macro_to_call_back! {
+
+            mod context "x" {
+                {"$_", fn log_value(&mut self)(v:RawVal) -> RawVal }
+                {"$0", fn get_last_operation_result(&self)() -> RawVal }
+                {"$1", fn obj_cmp(&self)(a:RawVal, b:RawVal) -> i64 }
+            }
+
+            mod u64 "u" {
+                {"$_", fn obj_from_u64(&mut self)(v:u64) -> RawVal }
+                {"$0", fn obj_to_u64(&self)(v:RawVal) -> u64 }
+            }
+
+            mod i64 "i" {
+                {"$_", fn obj_from_i64(&mut self)(v:i64) -> RawVal }
+                {"$0", fn obj_to_i64(&self)(v:RawVal) -> i64 }
+            }
+
+            mod map "m" {
+                {"$_", fn map_new(&mut self)() -> RawVal }
+                {"$0", fn map_put(&mut self)(m:RawVal, k:RawVal, v:RawVal) -> RawVal}
+                {"$1", fn map_get(&mut self)(m:RawVal, k:RawVal) -> RawVal}
+                {"$2", fn map_del(&mut self)(m:RawVal, k:RawVal) -> RawVal}
+                {"$3", fn map_len(&mut self)(m:RawVal) -> RawVal}
+                {"$4", fn map_keys(&mut self)(m:RawVal) -> RawVal}
+                {"$5", fn map_has(&mut self)(m:RawVal,k:RawVal) -> RawVal}
+            }
+
+            mod vec "v" {
+                {"$_", fn vec_new(&mut self)() -> RawVal}
+                {"$0", fn vec_put(&mut self)(v:RawVal, i:RawVal, x:RawVal) -> RawVal}
+                {"$1", fn vec_get(&mut self)(v:RawVal, i:RawVal) -> RawVal}
+                {"$2", fn vec_del(&mut self)(v:RawVal, i:RawVal) -> RawVal}
+                {"$3", fn vec_len(&mut self)(v:RawVal) -> RawVal}
+
+                {"$4", fn vec_push(&mut self)(v:RawVal, x:RawVal) -> RawVal}
+                {"$5", fn vec_pop(&mut self)(v:RawVal) -> RawVal}
+                {"$6", fn vec_take(&mut self)(v:RawVal, n:RawVal) -> RawVal}
+                {"$7", fn vec_drop(&mut self)(v:RawVal, n:RawVal) -> RawVal}
+                {"$8", fn vec_front(&mut self)(v:RawVal) -> RawVal}
+                {"$9", fn vec_back(&mut self)(v:RawVal) -> RawVal}
+                {"$A", fn vec_insert(&mut self)(v:RawVal, i:RawVal, x:RawVal) -> RawVal}
+                {"$B", fn vec_append(&mut self)(v1:RawVal, v2:RawVal) -> RawVal}
+            }
+
+            mod ledger "l" {
+                {"$_", fn get_current_ledger_num(&self)() -> RawVal }
+                {"$0", fn get_current_ledger_close_time(&self)() -> RawVal}
+
+                {"$1", fn pay(&mut self)(src:RawVal, dst:RawVal, asset:RawVal, amt:RawVal) -> RawVal}
+
+                {"$2", fn put_contract_data(&mut self)(k:RawVal, v:RawVal) -> RawVal}
+                {"$3", fn has_contract_data(&mut self)(k:RawVal) -> RawVal}
+                {"$4", fn get_contract_data(&mut self)(k:RawVal) -> RawVal}
+                {"$5", fn del_contract_data(&mut self)(k:RawVal) -> RawVal}
+
+                {"$6", fn account_balance(&mut self)(acct:RawVal) -> RawVal}
+                {"$7", fn account_trust_line(&mut self)(acct:RawVal, asset:RawVal) -> RawVal}
+                {"$8", fn trust_line_balance(&mut self)(tl:RawVal) -> RawVal}
+            }
+
+            mod call "c" {
+                {"$_", fn call0(&mut self)(contract:RawVal,func:RawVal) -> RawVal}
+                {"$0", fn call1(&mut self)(contract:RawVal,func:RawVal,a:RawVal) -> RawVal}
+                {"$1", fn call2(&mut self)(contract:RawVal,func:RawVal,a:RawVal,b:RawVal) -> RawVal}
+                {"$2", fn call3(&mut self)(contract:RawVal,func:RawVal,a:RawVal,b:RawVal,c:RawVal) -> RawVal}
+                {"$3", fn call4(&mut self)(contract:RawVal,func:RawVal,a:RawVal,b:RawVal,c:RawVal,d:RawVal) -> RawVal}
+            }
+
+            mod bigint "b" {
+                {"$_", fn bigint_from_u64(&mut self)(x:RawVal) -> RawVal}
+                {"$0", fn bigint_add(&mut self)(x:RawVal,y:RawVal) -> RawVal}
+                {"$1", fn bigint_sub(&mut self)(x:RawVal,y:RawVal) -> RawVal}
+                {"$2", fn bigint_mul(&mut self)(x:RawVal,y:RawVal) -> RawVal}
+                {"$3", fn bigint_div(&mut self)(x:RawVal,y:RawVal) -> RawVal}
+                {"$4", fn bigint_rem(&mut self)(x:RawVal,y:RawVal) -> RawVal}
+                {"$5", fn bigint_and(&mut self)(x:RawVal,y:RawVal) -> RawVal}
+                {"$6", fn bigint_or(&mut self)(x:RawVal,y:RawVal) -> RawVal}
+                {"$7", fn bigint_xor(&mut self)(x:RawVal,y:RawVal) -> RawVal}
+                {"$8", fn bigint_shl(&mut self)(x:RawVal,y:RawVal) -> RawVal}
+                {"$9", fn bigint_shr(&mut self)(x:RawVal,y:RawVal) -> RawVal}
+                {"$A", fn bigint_cmp(&mut self)(x:RawVal,y:RawVal) -> RawVal}
+                {"$B", fn bigint_is_zero(&mut self)(x:RawVal) -> RawVal}
+                {"$C", fn bigint_neg(&mut self)(x:RawVal) -> RawVal}
+                {"$D", fn bigint_not(&mut self)(x:RawVal) -> RawVal}
+                {"$E", fn bigint_gcd(&mut self)(x:RawVal) -> RawVal}
+                {"$F", fn bigint_lcm(&mut self)(x:RawVal,y:RawVal) -> RawVal}
+                {"$G", fn bigint_pow(&mut self)(x:RawVal,y:RawVal) -> RawVal}
+                {"$H", fn bigint_pow_mod(&mut self)(p:RawVal,q:RawVal,m:RawVal) -> RawVal}
+                {"$I", fn bigint_sqrt(&mut self)(x:RawVal) -> RawVal}
+                {"$J", fn bigint_bits(&mut self)(x:RawVal) -> RawVal}
+                {"$K", fn bigint_to_u64(&mut self)(x:RawVal) -> u64}
+                {"$L", fn bigint_to_i64(&mut self)(x:RawVal) -> i64}
+                {"$M", fn bigint_from_i64(&mut self)(x:i64) -> RawVal}
+            }
+        }
+    };
+}
+
+macro_rules! host_function {
+    {fn $func_id:ident(&self)() -> $ret:ty} => {fn $func_id(&self) -> $ret;};
+    {fn $func_id:ident(&self)($($arg:ident:$type:ty),*) -> $ret:ty} => {fn $func_id(&self, $($arg:$type),*) -> $ret;};
+    {fn $func_id:ident(&mut self)() -> $ret:ty} => {fn $func_id(&mut self) -> $ret;};
+    {fn $func_id:ident(&mut self)($($arg:ident:$type:ty),*) -> $ret:ty} => {fn $func_id(&mut self, $($arg:$type),*) -> $ret;};
+}
+
+macro_rules! generate_env_trait {
+    {
+        $(
+            mod $mod_name:ident $mod_str:literal
+            {
+                $(
+                    { $field_str:literal, fn $func_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                )*
+            }
+        )*
+    }
+    =>
+    {
+        // This trait needs to be implemented by any type that plays the role of the
+        // host for a contract. In a contract test or core setting this will be a full
+        // HostContext, whereas in a contract's wasm build it will be an empty
+        // type that calls through to global wasm imports provided at
+        // wasm-module-instantiation time.
+        pub trait Env: EnvBase
+        {
+            $(
+                $(
+                    host_function!{fn $func_id $selfspec $args -> $ret}
+                )*
+            )*
+        }
+    };
+}
+
+call_macro_with_all_host_functions! { generate_env_trait }

--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -52,113 +52,105 @@ macro_rules! call_macro_with_all_host_functions {
             //
             //  mod $mod_id:ident $mod_str:literal {
             //     ...
-            //     { $fn_str:literal, fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty }
+            //     { $fn_str:literal, fn $fn_id:ident $args:tt -> $ret:ty }
             //     ...
             //  }
             //
-            // Where the sub token-trees have the following content:
-            //
-            //  - $selfspec:tt is either (&self) or ($mut self)
-            //  - $args:tt is a normal parenthesized argument list
-            //    of comma-separated arg:type pairs
-            //
-            // The selfspec is split off as a separate token-tree from the arg
-            // list for ease of matching in the callback macro, because some
-            // consumers are interested in a concept of host mutability or
-            // non-mutabiity, and others are not.
+            // Where the sub token-tree $args:tt is a normal parenthesized
+            // argument list of comma-separated arg:type pairs
 
             mod context "x" {
-                {"$_", fn log_value(&mut self)(v:RawVal) -> RawVal }
-                {"$0", fn get_last_operation_result(&self)() -> RawVal }
-                {"$1", fn obj_cmp(&self)(a:RawVal, b:RawVal) -> i64 }
+                {"$_", fn log_value(v:RawVal) -> RawVal }
+                {"$0", fn get_last_operation_result() -> RawVal }
+                {"$1", fn obj_cmp(a:RawVal, b:RawVal) -> i64 }
             }
 
             mod u64 "u" {
-                {"$_", fn obj_from_u64(&mut self)(v:u64) -> RawVal }
-                {"$0", fn obj_to_u64(&self)(v:RawVal) -> u64 }
+                {"$_", fn obj_from_u64(v:u64) -> RawVal }
+                {"$0", fn obj_to_u64(v:RawVal) -> u64 }
             }
 
             mod i64 "i" {
-                {"$_", fn obj_from_i64(&mut self)(v:i64) -> RawVal }
-                {"$0", fn obj_to_i64(&self)(v:RawVal) -> i64 }
+                {"$_", fn obj_from_i64(v:i64) -> RawVal }
+                {"$0", fn obj_to_i64(v:RawVal) -> i64 }
             }
 
             mod map "m" {
-                {"$_", fn map_new(&mut self)() -> RawVal }
-                {"$0", fn map_put(&mut self)(m:RawVal, k:RawVal, v:RawVal) -> RawVal}
-                {"$1", fn map_get(&mut self)(m:RawVal, k:RawVal) -> RawVal}
-                {"$2", fn map_del(&mut self)(m:RawVal, k:RawVal) -> RawVal}
-                {"$3", fn map_len(&mut self)(m:RawVal) -> RawVal}
-                {"$4", fn map_keys(&mut self)(m:RawVal) -> RawVal}
-                {"$5", fn map_has(&mut self)(m:RawVal,k:RawVal) -> RawVal}
+                {"$_", fn map_new() -> RawVal }
+                {"$0", fn map_put(m:RawVal, k:RawVal, v:RawVal) -> RawVal}
+                {"$1", fn map_get(m:RawVal, k:RawVal) -> RawVal}
+                {"$2", fn map_del(m:RawVal, k:RawVal) -> RawVal}
+                {"$3", fn map_len(m:RawVal) -> RawVal}
+                {"$4", fn map_keys(m:RawVal) -> RawVal}
+                {"$5", fn map_has(m:RawVal,k:RawVal) -> RawVal}
             }
 
             mod vec "v" {
-                {"$_", fn vec_new(&mut self)() -> RawVal}
-                {"$0", fn vec_put(&mut self)(v:RawVal, i:RawVal, x:RawVal) -> RawVal}
-                {"$1", fn vec_get(&mut self)(v:RawVal, i:RawVal) -> RawVal}
-                {"$2", fn vec_del(&mut self)(v:RawVal, i:RawVal) -> RawVal}
-                {"$3", fn vec_len(&mut self)(v:RawVal) -> RawVal}
+                {"$_", fn vec_new() -> RawVal}
+                {"$0", fn vec_put(v:RawVal, i:RawVal, x:RawVal) -> RawVal}
+                {"$1", fn vec_get(v:RawVal, i:RawVal) -> RawVal}
+                {"$2", fn vec_del(v:RawVal, i:RawVal) -> RawVal}
+                {"$3", fn vec_len(v:RawVal) -> RawVal}
 
-                {"$4", fn vec_push(&mut self)(v:RawVal, x:RawVal) -> RawVal}
-                {"$5", fn vec_pop(&mut self)(v:RawVal) -> RawVal}
-                {"$6", fn vec_take(&mut self)(v:RawVal, n:RawVal) -> RawVal}
-                {"$7", fn vec_drop(&mut self)(v:RawVal, n:RawVal) -> RawVal}
-                {"$8", fn vec_front(&mut self)(v:RawVal) -> RawVal}
-                {"$9", fn vec_back(&mut self)(v:RawVal) -> RawVal}
-                {"$A", fn vec_insert(&mut self)(v:RawVal, i:RawVal, x:RawVal) -> RawVal}
-                {"$B", fn vec_append(&mut self)(v1:RawVal, v2:RawVal) -> RawVal}
+                {"$4", fn vec_push(v:RawVal, x:RawVal) -> RawVal}
+                {"$5", fn vec_pop(v:RawVal) -> RawVal}
+                {"$6", fn vec_take(v:RawVal, n:RawVal) -> RawVal}
+                {"$7", fn vec_drop(v:RawVal, n:RawVal) -> RawVal}
+                {"$8", fn vec_front(v:RawVal) -> RawVal}
+                {"$9", fn vec_back(v:RawVal) -> RawVal}
+                {"$A", fn vec_insert(v:RawVal, i:RawVal, x:RawVal) -> RawVal}
+                {"$B", fn vec_append(v1:RawVal, v2:RawVal) -> RawVal}
             }
 
             mod ledger "l" {
-                {"$_", fn get_current_ledger_num(&self)() -> RawVal }
-                {"$0", fn get_current_ledger_close_time(&self)() -> RawVal}
+                {"$_", fn get_current_ledger_num() -> RawVal }
+                {"$0", fn get_current_ledger_close_time() -> RawVal}
 
-                {"$1", fn pay(&mut self)(src:RawVal, dst:RawVal, asset:RawVal, amt:RawVal) -> RawVal}
+                {"$1", fn pay(src:RawVal, dst:RawVal, asset:RawVal, amt:RawVal) -> RawVal}
 
-                {"$2", fn put_contract_data(&mut self)(k:RawVal, v:RawVal) -> RawVal}
-                {"$3", fn has_contract_data(&mut self)(k:RawVal) -> RawVal}
-                {"$4", fn get_contract_data(&mut self)(k:RawVal) -> RawVal}
-                {"$5", fn del_contract_data(&mut self)(k:RawVal) -> RawVal}
+                {"$2", fn put_contract_data(k:RawVal, v:RawVal) -> RawVal}
+                {"$3", fn has_contract_data(k:RawVal) -> RawVal}
+                {"$4", fn get_contract_data(k:RawVal) -> RawVal}
+                {"$5", fn del_contract_data(k:RawVal) -> RawVal}
 
-                {"$6", fn account_balance(&mut self)(acct:RawVal) -> RawVal}
-                {"$7", fn account_trust_line(&mut self)(acct:RawVal, asset:RawVal) -> RawVal}
-                {"$8", fn trust_line_balance(&mut self)(tl:RawVal) -> RawVal}
+                {"$6", fn account_balance(acct:RawVal) -> RawVal}
+                {"$7", fn account_trust_line(acct:RawVal, asset:RawVal) -> RawVal}
+                {"$8", fn trust_line_balance(tl:RawVal) -> RawVal}
             }
 
             mod call "c" {
-                {"$_", fn call0(&mut self)(contract:RawVal,func:RawVal) -> RawVal}
-                {"$0", fn call1(&mut self)(contract:RawVal,func:RawVal,a:RawVal) -> RawVal}
-                {"$1", fn call2(&mut self)(contract:RawVal,func:RawVal,a:RawVal,b:RawVal) -> RawVal}
-                {"$2", fn call3(&mut self)(contract:RawVal,func:RawVal,a:RawVal,b:RawVal,c:RawVal) -> RawVal}
-                {"$3", fn call4(&mut self)(contract:RawVal,func:RawVal,a:RawVal,b:RawVal,c:RawVal,d:RawVal) -> RawVal}
+                {"$_", fn call0(contract:RawVal,func:RawVal) -> RawVal}
+                {"$0", fn call1(contract:RawVal,func:RawVal,a:RawVal) -> RawVal}
+                {"$1", fn call2(contract:RawVal,func:RawVal,a:RawVal,b:RawVal) -> RawVal}
+                {"$2", fn call3(contract:RawVal,func:RawVal,a:RawVal,b:RawVal,c:RawVal) -> RawVal}
+                {"$3", fn call4(contract:RawVal,func:RawVal,a:RawVal,b:RawVal,c:RawVal,d:RawVal) -> RawVal}
             }
 
             mod bigint "b" {
-                {"$_", fn bigint_from_u64(&mut self)(x:RawVal) -> RawVal}
-                {"$0", fn bigint_add(&mut self)(x:RawVal,y:RawVal) -> RawVal}
-                {"$1", fn bigint_sub(&mut self)(x:RawVal,y:RawVal) -> RawVal}
-                {"$2", fn bigint_mul(&mut self)(x:RawVal,y:RawVal) -> RawVal}
-                {"$3", fn bigint_div(&mut self)(x:RawVal,y:RawVal) -> RawVal}
-                {"$4", fn bigint_rem(&mut self)(x:RawVal,y:RawVal) -> RawVal}
-                {"$5", fn bigint_and(&mut self)(x:RawVal,y:RawVal) -> RawVal}
-                {"$6", fn bigint_or(&mut self)(x:RawVal,y:RawVal) -> RawVal}
-                {"$7", fn bigint_xor(&mut self)(x:RawVal,y:RawVal) -> RawVal}
-                {"$8", fn bigint_shl(&mut self)(x:RawVal,y:RawVal) -> RawVal}
-                {"$9", fn bigint_shr(&mut self)(x:RawVal,y:RawVal) -> RawVal}
-                {"$A", fn bigint_cmp(&mut self)(x:RawVal,y:RawVal) -> RawVal}
-                {"$B", fn bigint_is_zero(&mut self)(x:RawVal) -> RawVal}
-                {"$C", fn bigint_neg(&mut self)(x:RawVal) -> RawVal}
-                {"$D", fn bigint_not(&mut self)(x:RawVal) -> RawVal}
-                {"$E", fn bigint_gcd(&mut self)(x:RawVal) -> RawVal}
-                {"$F", fn bigint_lcm(&mut self)(x:RawVal,y:RawVal) -> RawVal}
-                {"$G", fn bigint_pow(&mut self)(x:RawVal,y:RawVal) -> RawVal}
-                {"$H", fn bigint_pow_mod(&mut self)(p:RawVal,q:RawVal,m:RawVal) -> RawVal}
-                {"$I", fn bigint_sqrt(&mut self)(x:RawVal) -> RawVal}
-                {"$J", fn bigint_bits(&mut self)(x:RawVal) -> RawVal}
-                {"$K", fn bigint_to_u64(&mut self)(x:RawVal) -> u64}
-                {"$L", fn bigint_to_i64(&mut self)(x:RawVal) -> i64}
-                {"$M", fn bigint_from_i64(&mut self)(x:i64) -> RawVal}
+                {"$_", fn bigint_from_u64(x:RawVal) -> RawVal}
+                {"$0", fn bigint_add(x:RawVal,y:RawVal) -> RawVal}
+                {"$1", fn bigint_sub(x:RawVal,y:RawVal) -> RawVal}
+                {"$2", fn bigint_mul(x:RawVal,y:RawVal) -> RawVal}
+                {"$3", fn bigint_div(x:RawVal,y:RawVal) -> RawVal}
+                {"$4", fn bigint_rem(x:RawVal,y:RawVal) -> RawVal}
+                {"$5", fn bigint_and(x:RawVal,y:RawVal) -> RawVal}
+                {"$6", fn bigint_or(x:RawVal,y:RawVal) -> RawVal}
+                {"$7", fn bigint_xor(x:RawVal,y:RawVal) -> RawVal}
+                {"$8", fn bigint_shl(x:RawVal,y:RawVal) -> RawVal}
+                {"$9", fn bigint_shr(x:RawVal,y:RawVal) -> RawVal}
+                {"$A", fn bigint_cmp(x:RawVal,y:RawVal) -> RawVal}
+                {"$B", fn bigint_is_zero(x:RawVal) -> RawVal}
+                {"$C", fn bigint_neg(x:RawVal) -> RawVal}
+                {"$D", fn bigint_not(x:RawVal) -> RawVal}
+                {"$E", fn bigint_gcd(x:RawVal) -> RawVal}
+                {"$F", fn bigint_lcm(x:RawVal,y:RawVal) -> RawVal}
+                {"$G", fn bigint_pow(x:RawVal,y:RawVal) -> RawVal}
+                {"$H", fn bigint_pow_mod(p:RawVal,q:RawVal,m:RawVal) -> RawVal}
+                {"$I", fn bigint_sqrt(x:RawVal) -> RawVal}
+                {"$J", fn bigint_bits(x:RawVal) -> RawVal}
+                {"$K", fn bigint_to_u64(x:RawVal) -> u64}
+                {"$L", fn bigint_to_i64(x:RawVal) -> i64}
+                {"$M", fn bigint_from_i64(x:i64) -> RawVal}
             }
         }
     };
@@ -171,16 +163,16 @@ macro_rules! call_macro_with_all_host_functions {
 // This is a helper macro used only by generate_env_trait below. It consumes
 // a token-tree of the form:
 //
-//  {fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty}
+//  {fn $fn_id:ident $args:tt -> $ret:ty}
 //
-// in each of 4 valid forms (self vs. mut-self, empty vs. nonempty trailing args)
 // and produces the the corresponding method declaration to be used in the Env
 // trait.
 macro_rules! host_function_helper {
-    {fn $fn_id:ident(&self)() -> $ret:ty} => {fn $fn_id(&self) -> $ret;};
-    {fn $fn_id:ident(&self)($($arg:ident:$type:ty),*) -> $ret:ty} => {fn $fn_id(&self, $($arg:$type),*) -> $ret;};
-    {fn $fn_id:ident(&mut self)() -> $ret:ty} => {fn $fn_id(&mut self) -> $ret;};
-    {fn $fn_id:ident(&mut self)($($arg:ident:$type:ty),*) -> $ret:ty} => {fn $fn_id(&mut self, $($arg:$type),*) -> $ret;};
+    {fn $fn_id:ident($($arg:ident:$type:ty),*) -> $ret:ty}
+    =>
+    {
+        fn $fn_id(&self, $($arg:$type),*) -> $ret;
+    };
 }
 
 // This is a callback macro that pattern-matches the token-tree passed by the
@@ -202,7 +194,7 @@ macro_rules! generate_env_trait {
                     // x-macro to this macro. It is embedded in a `$()*`
                     // pattern-repetition matcher so that it will match all such
                     // descriptions.
-                    { $fn_str:literal, fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                    { $fn_str:literal, fn $fn_id:ident $args:tt -> $ret:ty }
                 )*
             }
         )*
@@ -227,7 +219,7 @@ macro_rules! generate_env_trait {
                     // block repetition-level from the outer pattern in the
                     // expansion, flattening all functions from all 'mod' blocks
                     // into the Env trait.
-                    host_function_helper!{fn $fn_id $selfspec $args -> $ret}
+                    host_function_helper!{fn $fn_id $args -> $ret}
                 )*
             )*
         }

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -77,7 +77,7 @@ impl EnvValType for i64 {
         EnvVal { env, val }
     }
 
-    fn try_from_env_val<E: Env>(mut ev: EnvVal<E>) -> Option<Self> {
+    fn try_from_env_val<E: Env>(ev: EnvVal<E>) -> Option<Self> {
         if ev.val.is_positive_i64() {
             Some(unsafe { ev.val.unchecked_as_positive_i64() })
         } else if RawObj::val_is_obj_type(ev.val, ScObjectType::ScoI64) {
@@ -98,7 +98,7 @@ impl EnvValType for u64 {
         EnvVal { env, val }
     }
 
-    fn try_from_env_val<E: Env>(mut ev: EnvVal<E>) -> Option<Self> {
+    fn try_from_env_val<E: Env>(ev: EnvVal<E>) -> Option<Self> {
         if ev.val.is_positive_i64() {
             Some(unsafe { ev.val.unchecked_as_positive_i64() } as u64)
         } else if RawObj::val_is_obj_type(ev.val, ScObjectType::ScoU64) {

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -68,7 +68,7 @@ impl<V: RawValType> EnvValType for V {
 }
 
 impl EnvValType for i64 {
-    fn into_env_val<E: Env>(self, mut env: E) -> EnvVal<E> {
+    fn into_env_val<E: Env>(self, env: E) -> EnvVal<E> {
         let val = if self >= 0 {
             unsafe { RawVal::unchecked_from_positive_i64(self) }
         } else {
@@ -89,7 +89,7 @@ impl EnvValType for i64 {
 }
 
 impl EnvValType for u64 {
-    fn into_env_val<E: Env>(self, mut env: E) -> EnvVal<E> {
+    fn into_env_val<E: Env>(self, env: E) -> EnvVal<E> {
         let val = if self <= (i64::MAX as u64) {
             unsafe { RawVal::unchecked_from_positive_i64(self as i64) }
         } else {

--- a/stellar-contract-env-common/src/lib.rs
+++ b/stellar-contract-env-common/src/lib.rs
@@ -24,7 +24,7 @@ pub use raw_obj::RawObj;
 pub use raw_val::{RawVal, RawValType, Tag};
 
 // RawVal and EnvObj couple raw types to environments.
-pub use env::Env;
+pub use env::{Env, EnvBase};
 pub use env_obj::EnvObj;
 pub use env_val::{EnvVal, EnvValType};
 pub use has_env::HasEnv;

--- a/stellar-contract-env-common/src/raw_obj.rs
+++ b/stellar-contract-env-common/src/raw_obj.rs
@@ -6,6 +6,24 @@ use super::{xdr::ScObjectType, RawVal, RawValType, Tag};
 #[derive(Copy, Clone)]
 pub struct RawObj(RawVal);
 
+#[cfg(feature = "vm")]
+impl wasmi::FromRuntimeValue for RawObj {
+    fn from_runtime_value(val: wasmi::RuntimeValue) -> Option<Self> {
+        if let Some(rv) = <RawVal as wasmi::FromRuntimeValue>::from_runtime_value(val) {
+            <RawObj as RawValType>::try_convert(rv)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature = "vm")]
+impl From<RawObj> for wasmi::RuntimeValue {
+    fn from(v: RawObj) -> Self {
+        wasmi::RuntimeValue::I64(v.0.get_payload() as i64)
+    }
+}
+
 impl RawValType for RawObj {
     #[inline(always)]
     fn is_val_type(v: RawVal) -> bool {

--- a/stellar-contract-env-common/src/raw_val.rs
+++ b/stellar-contract-env-common/src/raw_val.rs
@@ -95,6 +95,21 @@ declare_tryfrom!(RawObj);
 declare_tryfrom!(BitSet);
 declare_tryfrom!(Status);
 
+#[cfg(feature = "vm")]
+impl wasmi::FromRuntimeValue for RawVal {
+    fn from_runtime_value(val: wasmi::RuntimeValue) -> Option<Self> {
+        let maybe: Option<u64> = val.try_into();
+        maybe.map(|x| Self(x))
+    }
+}
+
+#[cfg(feature = "vm")]
+impl From<RawVal> for wasmi::RuntimeValue {
+    fn from(v: RawVal) -> Self {
+        wasmi::RuntimeValue::I64(v.0 as i64)
+    }
+}
+
 impl RawValType for () {
     #[inline(always)]
     fn is_val_type(v: RawVal) -> bool {

--- a/stellar-contract-env-guest/src/guest.rs
+++ b/stellar-contract-env-guest/src/guest.rs
@@ -19,75 +19,156 @@ impl EnvBase for Guest {
     }
 }
 
-macro_rules! host_function {
-    {$mod_name:ident, fn $func_id:ident(&self)() -> $ret:ty} =>
-    {fn $func_id(&self) -> $ret { unsafe { $mod_name::$func_id() }}};
+///////////////////////////////////////////////////////////////////////////////
+/// X-macro use: impl Env for Guest
+///////////////////////////////////////////////////////////////////////////////
 
-    {$mod_name:ident, fn $func_id:ident(&self)($($arg:ident:$type:ty),*) -> $ret:ty} =>
-    {fn $func_id(&self, $($arg:$type),*) -> $ret { unsafe { $mod_name::$func_id($($arg),*)}}};
+// This is a helper macro used only by impl_env_for_guest below. It consumes a
+// token-tree of the form:
+//
+//  {fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty}
+//
+// in each of 4 valid forms (self vs. mut-self, empty vs. nonempty trailing
+// args) and produces the the corresponding method definition to be used in the
+// Guest implementation of the Env trait (calling through to the corresponding
+// unsafe extern function).
+macro_rules! guest_function_helper {
+    {$mod_id:ident, fn $fn_id:ident(&self)() -> $ret:ty} =>
+    {fn $fn_id(&self) -> $ret { unsafe { $mod_id::$fn_id() }}};
 
-    {$mod_name:ident, fn $func_id:ident(&mut self)() -> $ret:ty} =>
-    {fn $func_id(&mut self) -> $ret { unsafe { $mod_name::$func_id() }}};
+    {$mod_id:ident, fn $fn_id:ident(&self)($($arg:ident:$type:ty),*) -> $ret:ty} =>
+    {fn $fn_id(&self, $($arg:$type),*) -> $ret { unsafe { $mod_id::$fn_id($($arg),*)}}};
 
-    {$mod_name:ident, fn $func_id:ident(&mut self)($($arg:ident:$type:ty),*) -> $ret:ty} =>
-    {fn $func_id(&mut self, $($arg:$type),*) -> $ret { unsafe { $mod_name::$func_id($($arg),*)}}};
+    {$mod_id:ident, fn $fn_id:ident(&mut self)() -> $ret:ty} =>
+    {fn $fn_id(&mut self) -> $ret { unsafe { $mod_id::$fn_id() }}};
+
+    {$mod_id:ident, fn $fn_id:ident(&mut self)($($arg:ident:$type:ty),*) -> $ret:ty} =>
+    {fn $fn_id(&mut self, $($arg:$type),*) -> $ret { unsafe { $mod_id::$fn_id($($arg),*)}}};
 }
 
+// This is a callback macro that pattern-matches the token-tree passed by the
+// x-macro (call_macro_with_all_host_functions) and produces a suite of
+// forwarding-method definitions, which it places in the body of the declaration
+// of the implementation of Env for Guest.
 macro_rules! impl_env_for_guest {
     {
         $(
-            mod $mod_name:ident $mod_str:literal
+            // This outer pattern matches a single 'mod' block of the token-tree
+            // passed from the x-macro to this macro. It is embedded in a `$()*`
+            // pattern-repetition matcher so that it will match all provided
+            // 'mod' blocks provided.
+            mod $mod_id:ident $mod_str:literal
             {
                 $(
-                    { $field_str:literal, fn $func_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                    // This inner pattern matches a single function description
+                    // inside a 'mod' block in the token-tree passed from the
+                    // x-macro to this macro. It is embedded in a `$()*`
+                    // pattern-repetition matcher so that it will match all such
+                    // descriptions.
+                    { $fn_str:literal, fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty }
                 )*
             }
         )*
     }
-    =>
+
+    =>  // The part of the macro above this line is a matcher; below is its expansion.
+
     {
+        // This macro expands to a single item: the implementation of Env for
+        // the Guest struct used by client contract code running in a WASM VM.
         impl Env for Guest
         {
             $(
                 $(
-                    host_function!{$mod_name, fn $func_id $selfspec $args -> $ret}
+                    // This invokes the guest_function_helper! macro above
+                    // passing only the relevant parts of the declaration
+                    // matched by the inner pattern above. It is embedded in two
+                    // nested `$()*` pattern-repetition expanders that
+                    // correspond to the pattern-repetition matchers in the
+                    // match section, but we ignore the structure of the 'mod'
+                    // block repetition-level from the outer pattern in the
+                    // expansion, flattening all functions from all 'mod' blocks
+                    // into the implementation of Env for Guest.
+                    guest_function_helper!{$mod_id, fn $fn_id $selfspec $args -> $ret}
                 )*
             )*
         }
     };
 }
 
+// Here we invoke the x-macro passing generate_env_trait as its callback macro.
 call_macro_with_all_host_functions! { impl_env_for_guest }
 
-macro_rules! host_function {
-    {$field_str:literal, fn $func_id:ident($($arg:ident:$type:ty),*) -> $ret:ty} =>
+///////////////////////////////////////////////////////////////////////////////
+/// X-macro use: extern mod blocks
+///////////////////////////////////////////////////////////////////////////////
+
+// This is a helper macro used only by impl_env_for_guest below. It consumes a
+// token-tree of the form:
+//
+//  {fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty}
+//
+// in each of 4 valid forms (self vs. mut-self, empty vs. nonempty trailing
+// args) and produces the the corresponding method definition to be used in the
+// Guest implementation of the Env trait (calling through to the corresponding
+// unsafe extern function).
+macro_rules! extern_function_helper {
+    {$fn_str:literal, fn $fn_id:ident($($arg:ident:$type:ty),*) -> $ret:ty} =>
     {
-        #[cfg_attr(target_family = "wasm", link_name = $field_str)]
-        pub(crate) fn $func_id($($arg:$type),*) -> $ret;
+        #[cfg_attr(target_family = "wasm", link_name = $fn_str)]
+        pub(crate) fn $fn_id($($arg:$type),*) -> $ret;
     };
 }
 
+// This is a callback macro that pattern-matches the token-tree passed by the
+// x-macro (call_macro_with_all_host_functions) and produces a set of mod
+// items containing extern "C" blocks, each containing extern function
+// declarations.
 macro_rules! generate_extern_modules {
     {
         $(
-            mod $mod_name:ident $mod_str:literal
+            // This outer pattern matches a single 'mod' block of the token-tree
+            // passed from the x-macro to this macro. It is embedded in a `$()*`
+            // pattern-repetition matcher so that it will match all provided
+            // 'mod' blocks provided.
+            mod $mod_id:ident $mod_str:literal
             {
                 $(
-                    { $field_str:literal, fn $func_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                    // This inner pattern matches a single function description
+                    // inside a 'mod' block in the token-tree passed from the
+                    // x-macro to this macro. It is embedded in a `$()*`
+                    // pattern-repetition matcher so that it will match all such
+                    // descriptions.
+                    { $fn_str:literal, fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty }
                 )*
             }
         )*
     }
-    =>
+
+    =>  // The part of the macro above this line is a matcher; below is its expansion.
+
     {
+        // This macro expands to a set of mod items, each declaring all the extern fns
+        // available for the `impl Env for Guest` methods above to call through to.
         $(
-            mod $mod_name {
+            // Unlike the other uses of the x-macro that "flatten" the
+            // mod-and-fn structure of the matched token-tree, this callback
+            // macro's expansion preserves the structure, creating a nested set
+            // of mods and fns. There is therefore a mod declaration between the
+            // outer and inner `$()*` pattern-repetition expanders.
+            mod $mod_id {
                 #[allow(unused_imports)]
                 use crate::{RawVal,RawObj};
                 #[link(wasm_import_module = $mod_str)]
                 extern "C" {
                     $(
-                        host_function!{$field_str, fn $func_id $args -> $ret}
+                        // This invokes the extern_function_helper! macro above
+                        // passing only the relevant parts of the declaration
+                        // matched by the inner pattern above. It is embedded in
+                        // one `$()*` pattern-repetition expander so that it
+                        // repeats only for the part of each mod that the
+                        // corresponding pattern-repetition matcher.
+                        extern_function_helper!{$fn_str, fn $fn_id $args -> $ret}
                     )*
                 }
             }
@@ -95,4 +176,5 @@ macro_rules! generate_extern_modules {
     };
 }
 
+// Here we invoke the x-macro passing generate_extern_modules as its callback macro.
 call_macro_with_all_host_functions! { generate_extern_modules }

--- a/stellar-contract-env-guest/src/guest.rs
+++ b/stellar-contract-env-guest/src/guest.rs
@@ -1,417 +1,98 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 
-use core::any::Any;
+use stellar_contract_env_common::call_macro_with_all_host_functions;
 
-use super::{Env, RawVal};
+use super::{Env, EnvBase, RawVal};
 
 // In guest code the environment is global/implicit, so is represented as a unit struct.
 #[derive(Copy, Clone, Default)]
 pub struct Guest;
 
-impl Env for Guest {
-    fn as_mut_any(&mut self) -> &mut dyn Any {
-        self
+impl EnvBase for Guest {
+    fn as_mut_any(&mut self) -> &mut dyn core::any::Any {
+        return self;
     }
 
     fn check_same_env(&self, other: &Self) {
-        // All guest environments are the same
         ()
     }
-
-    fn obj_cmp(&self, a: RawVal, b: RawVal) -> i64 {
-        todo!()
-    }
-
-    fn log_value(&mut self, v: RawVal) -> RawVal {
-        unsafe { context::log_value(v) }
-    }
-
-    fn get_last_operation_result(&mut self) -> RawVal {
-        unsafe { context::get_last_operation_result() }
-    }
-
-    fn obj_from_u64(&mut self, u: u64) -> RawVal {
-        unsafe { u64::from_u64(u) }
-    }
-
-    fn obj_to_u64(&mut self, u: RawVal) -> u64 {
-        unsafe { u64::to_u64(u) }
-    }
-
-    fn obj_from_i64(&mut self, i: i64) -> RawVal {
-        unsafe { i64::from_i64(i) }
-    }
-
-    fn obj_to_i64(&mut self, i: RawVal) -> i64 {
-        unsafe { i64::to_i64(i) }
-    }
-
-    fn map_new(&mut self) -> RawVal {
-        unsafe { map::new() }
-    }
-
-    fn map_put(&mut self, m: RawVal, k: RawVal, v: RawVal) -> RawVal {
-        unsafe { map::put(m, k, v) }
-    }
-
-    fn map_get(&mut self, m: RawVal, k: RawVal) -> RawVal {
-        unsafe { map::get(m, k) }
-    }
-
-    fn map_del(&mut self, m: RawVal, k: RawVal) -> RawVal {
-        unsafe { map::del(m, k) }
-    }
-
-    fn map_len(&mut self, m: RawVal) -> RawVal {
-        unsafe { map::len(m) }
-    }
-
-    fn map_keys(&mut self, m: RawVal) -> RawVal {
-        unsafe { map::keys(m) }
-    }
-
-    fn map_has(&mut self, m: RawVal, k: RawVal) -> RawVal {
-        unsafe { map::has(m, k) }
-    }
-
-    fn vec_new(&mut self) -> RawVal {
-        unsafe { vec::new() }
-    }
-
-    fn vec_put(&mut self, v: RawVal, i: RawVal, x: RawVal) -> RawVal {
-        unsafe { vec::put(v, i, x) }
-    }
-
-    fn vec_get(&mut self, v: RawVal, i: RawVal) -> RawVal {
-        unsafe { vec::get(v, i) }
-    }
-
-    fn vec_del(&mut self, v: RawVal, i: RawVal) -> RawVal {
-        unsafe { vec::del(v, i) }
-    }
-
-    fn vec_len(&mut self, v: RawVal) -> RawVal {
-        unsafe { vec::len(v) }
-    }
-
-    fn vec_push(&mut self, v: RawVal, x: RawVal) -> RawVal {
-        unsafe { vec::push(v, x) }
-    }
-
-    fn vec_pop(&mut self, v: RawVal) -> RawVal {
-        unsafe { vec::pop(v) }
-    }
-
-    fn vec_take(&mut self, v: RawVal, n: RawVal) -> RawVal {
-        unsafe { vec::take(v, n) }
-    }
-
-    fn vec_drop(&mut self, v: RawVal, n: RawVal) -> RawVal {
-        unsafe { vec::drop(v, n) }
-    }
-
-    fn vec_front(&mut self, v: RawVal) -> RawVal {
-        unsafe { vec::front(v) }
-    }
-
-    fn vec_back(&mut self, v: RawVal) -> RawVal {
-        unsafe { vec::back(v) }
-    }
-
-    fn vec_insert(&mut self, v: RawVal, i: RawVal, n: RawVal) -> RawVal {
-        unsafe { vec::insert(v, i, n) }
-    }
-
-    fn vec_append(&mut self, v1: RawVal, v2: RawVal) -> RawVal {
-        unsafe { vec::append(v1, v2) }
-    }
-
-    fn pay(&mut self, src: RawVal, dst: RawVal, asset: RawVal, amount: RawVal) -> RawVal {
-        unsafe { ledger::pay(src, dst, asset, amount) }
-    }
-
-    fn account_balance(&mut self, acc: RawVal) -> RawVal {
-        unsafe { ledger::account_balance(acc) }
-    }
-
-    fn account_trust_line(&mut self, acc: RawVal, asset: RawVal) -> RawVal {
-        unsafe { ledger::account_trust_line(acc, asset) }
-    }
-
-    fn trust_line_balance(&mut self, tl: RawVal) -> RawVal {
-        unsafe { ledger::trust_line_balance(tl) }
-    }
-
-    fn get_contract_data(&mut self, k: RawVal) -> RawVal {
-        unsafe { ledger::get_contract_data(k) }
-    }
-
-    fn put_contract_data(&mut self, k: RawVal, v: RawVal) -> RawVal {
-        unsafe { ledger::put_contract_data(k, v) }
-    }
-
-    fn has_contract_data(&mut self, k: RawVal) -> RawVal {
-        unsafe { ledger::has_contract_data(k) }
-    }
 }
 
-// Most host functions have strong contractual guarantees from the host: they
-// will either return the correctly-typed objects here, or they will trap. So we
-// do not need to check return types, and we can even unsafely downcast Vals to
-// specific subtypes if we know them.
-//
-// (Recall that there must be no way for the guest to corrupt the host even if
-// the guest does receive unexpected objects -- at worst the host can corrupt or
-// confuse the guest this way, but the guest can never defend itself against a
-// malicious host anyways.)
-//
-// We do this mostly to minimize codesize, and also reduce the chance of users
-// missing an error in a contract binding to another language that doesn't have
-// Result<> types. Every error that can trap this way typically has a way to
-// avoid it by checking some value first (eg. check a map to see if it contains
-// a value before getting it).
-//
-// The exceptions are ledger-interaction calls and especially cross-contract
-// calls: these we project into a Result<> because they are fairly failure-prone
-// and impossible to guard against failure of, typically. We assume users might
-// wish to contain these and, in general, that users won't be doing a _ton_ of
-// them so it's ok that they are a little more expensive code-size-wise.
+macro_rules! host_function {
+    {$mod_name:ident, fn $func_id:ident(&self)() -> $ret:ty} =>
+    {fn $func_id(&self) -> $ret { unsafe { $mod_name::$func_id() }}};
 
-// General context-access functions live in the wasm 'x' module.
-mod context {
-    use crate::RawVal;
-    #[link(wasm_import_module = "x")]
-    extern "C" {
+    {$mod_name:ident, fn $func_id:ident(&self)($($arg:ident:$type:ty),*) -> $ret:ty} =>
+    {fn $func_id(&self, $($arg:$type),*) -> $ret { unsafe { $mod_name::$func_id($($arg),*)}}};
 
-        // link names are chosen to be (a) unrepresentable as rust identifiers so
-        // they cannot collide with exported user functions and (b) very short, so
-        // they do not take up a lot of space in import tables. They consist of a $
-        // symbol followed by a single character category identifier and a single
-        // character function identifier, each drawn from the same 64-character
-        // repertoire as symbol: [_0-9A-Za-z], in that order. If we ever need more
-        // than 64 functions within a category we can just overflow to 2-character
-        // function identifiers; if we ever need more than 64 categories, we can
-        // pick a different prefix-char for the category-overflow space; both of
-        // these possibilities seem unlikely at present, but either way they're
-        // fairly straightforward.
-        #[cfg_attr(target_family = "wasm", link_name = "$_")]
-        pub(crate) fn log_value(v: RawVal) -> RawVal;
+    {$mod_name:ident, fn $func_id:ident(&mut self)() -> $ret:ty} =>
+    {fn $func_id(&mut self) -> $ret { unsafe { $mod_name::$func_id() }}};
 
-        // Fetches an OpResult object for inspection, in the rare case the user
-        // wants more detail than is conveyed in a simple Status.
-        #[cfg_attr(target_family = "wasm", link_name = "$0")]
-        pub(crate) fn get_last_operation_result() -> RawVal;
-    }
+    {$mod_name:ident, fn $func_id:ident(&mut self)($($arg:ident:$type:ty),*) -> $ret:ty} =>
+    {fn $func_id(&mut self, $($arg:$type),*) -> $ret { unsafe { $mod_name::$func_id($($arg),*)}}};
 }
 
-// U64 functions live in the wasm 'u' module
-mod u64 {
-    use crate::RawVal;
-    #[link(wasm_import_module = "u")]
-    extern "C" {
-        #[cfg_attr(target_family = "wasm", link_name = "$_")]
-        pub(crate) fn from_u64(x: u64) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$0")]
-        pub(crate) fn to_u64(x: RawVal) -> u64;
+macro_rules! impl_env_for_guest {
+    {
+        $(
+            mod $mod_name:ident $mod_str:literal
+            {
+                $(
+                    { $field_str:literal, fn $func_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                )*
+            }
+        )*
     }
+    =>
+    {
+        impl Env for Guest
+        {
+            $(
+                $(
+                    host_function!{$mod_name, fn $func_id $selfspec $args -> $ret}
+                )*
+            )*
+        }
+    };
 }
 
-// I64 functions live in the wasm 'i' module
-mod i64 {
-    use crate::RawVal;
-    #[link(wasm_import_module = "i")]
-    extern "C" {
-        #[cfg_attr(target_family = "wasm", link_name = "$_")]
-        pub(crate) fn from_i64(x: i64) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$0")]
-        pub(crate) fn to_i64(x: RawVal) -> i64;
-    }
+call_macro_with_all_host_functions! { impl_env_for_guest }
+
+macro_rules! host_function {
+    {$field_str:literal, fn $func_id:ident($($arg:ident:$type:ty),*) -> $ret:ty} =>
+    {
+        #[cfg_attr(target_family = "wasm", link_name = $field_str)]
+        pub(crate) fn $func_id($($arg:$type),*) -> $ret;
+    };
 }
 
-// Map functions live in the wasm 'm' module
-mod map {
-    use crate::RawVal;
-    #[link(wasm_import_module = "m")]
-    extern "C" {
-        #[cfg_attr(target_family = "wasm", link_name = "$_")]
-        pub(crate) fn new() -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$0")]
-        pub(crate) fn put(m: RawVal, k: RawVal, v: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$1")]
-        pub(crate) fn get(m: RawVal, k: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$2")]
-        pub(crate) fn del(m: RawVal, k: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$3")]
-        pub(crate) fn len(m: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$4")]
-        pub(crate) fn keys(m: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$5")]
-        pub(crate) fn has(m: RawVal, k: RawVal) -> RawVal;
+macro_rules! generate_extern_modules {
+    {
+        $(
+            mod $mod_name:ident $mod_str:literal
+            {
+                $(
+                    { $field_str:literal, fn $func_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                )*
+            }
+        )*
     }
+    =>
+    {
+        $(
+            mod $mod_name {
+                #[allow(unused_imports)]
+                use crate::{RawVal,RawObj};
+                #[link(wasm_import_module = $mod_str)]
+                extern "C" {
+                    $(
+                        host_function!{$field_str, fn $func_id $args -> $ret}
+                    )*
+                }
+            }
+        )*
+    };
 }
 
-// Vec functions live in the wasm 'v' module
-mod vec {
-    use crate::RawVal;
-    #[link(wasm_import_module = "v")]
-    extern "C" {
-        #[cfg_attr(target_family = "wasm", link_name = "$_")]
-        pub(crate) fn new() -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$0")]
-        pub(crate) fn put(v: RawVal, i: RawVal, x: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$1")]
-        pub(crate) fn get(v: RawVal, i: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$2")]
-        pub(crate) fn del(v: RawVal, i: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$3")]
-        pub(crate) fn len(v: RawVal) -> RawVal;
-
-        #[cfg_attr(target_family = "wasm", link_name = "$4")]
-        pub(crate) fn push(v: RawVal, x: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$5")]
-        pub(crate) fn pop(v: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$6")]
-        pub(crate) fn take(v: RawVal, n: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$7")]
-        pub(crate) fn drop(v: RawVal, n: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$8")]
-        pub(crate) fn front(v: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$9")]
-        pub(crate) fn back(v: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$A")]
-        pub(crate) fn insert(v: RawVal, i: RawVal, x: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$B")]
-        pub(crate) fn append(v1: RawVal, v2: RawVal) -> RawVal;
-    }
-}
-
-// Ledger functions live in the wasm 'l' module
-mod ledger {
-    use crate::RawVal;
-    #[link(wasm_import_module = "l")]
-    extern "C" {
-        #[cfg_attr(target_family = "wasm", link_name = "$_")]
-        pub(crate) fn get_current_ledger_num() -> RawVal;
-
-        // NB: this returns a raw/unboxed u64, not a Val union.
-        #[cfg_attr(target_family = "wasm", link_name = "$0")]
-        pub(crate) fn get_current_ledger_close_time() -> u64;
-
-        // NB: returns a Status; details can be fetched with
-        // get_last_operation_result.
-        #[cfg_attr(target_family = "wasm", link_name = "$1")]
-        pub(crate) fn pay(src: RawVal, dst: RawVal, asset: RawVal, amount: RawVal) -> RawVal;
-
-        #[cfg_attr(target_family = "wasm", link_name = "$2")]
-        pub(crate) fn put_contract_data(key: RawVal, val: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$3")]
-        pub(crate) fn has_contract_data(key: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$4")]
-        pub(crate) fn get_contract_data(key: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$5")]
-        pub(crate) fn del_contract_data(key: RawVal) -> RawVal;
-
-        #[cfg_attr(target_family = "wasm", link_name = "$6")]
-        pub(crate) fn account_balance(acc: RawVal) -> RawVal;
-
-        #[cfg_attr(target_family = "wasm", link_name = "$7")]
-        pub(crate) fn account_trust_line(acc: RawVal, asset: RawVal) -> RawVal;
-
-        #[cfg_attr(target_family = "wasm", link_name = "$8")]
-        pub(crate) fn trust_line_balance(tl: RawVal) -> RawVal;
-    }
-}
-
-// Cross-contract functions live in the wasm 'c' module
-mod call {
-    use crate::RawVal;
-    #[link(wasm_import_module = "c")]
-    extern "C" {
-        // NB: returns callee-return-value-or-Status; details can be fetched with
-        // get_last_operation_result.
-        //
-        // TODO: possibly revisit this since it adds ambiguity to whether callee
-        // successfully returned a status, or call failed and failure _generated_ a
-        // status. Possibly this distinction is too fussy to disambiguate.
-        #[cfg_attr(target_family = "wasm", link_name = "$_")]
-        pub(crate) fn call0(contract: RawVal, func: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$0")]
-        pub(crate) fn call1(contract: RawVal, func: RawVal, a: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$1")]
-        pub(crate) fn call2(contract: RawVal, func: RawVal, a: RawVal, b: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$2")]
-        pub(crate) fn call3(
-            contract: RawVal,
-            func: RawVal,
-            a: RawVal,
-            b: RawVal,
-            c: RawVal,
-        ) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$3")]
-        pub(crate) fn call4(
-            contract: RawVal,
-            func: RawVal,
-            a: RawVal,
-            b: RawVal,
-            c: RawVal,
-            d: RawVal,
-        ) -> RawVal;
-    }
-}
-
-// BigNum functions live in the wasm 'b' module
-mod bignum {
-    use crate::RawVal;
-    #[link(wasm_import_module = "b")]
-    extern "C" {
-        #[cfg_attr(target_family = "wasm", link_name = "$_")]
-        pub(crate) fn from_u64(x: u64) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$0")]
-        pub(crate) fn add(lhs: RawVal, rhs: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$1")]
-        pub(crate) fn sub(lhs: RawVal, rhs: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$2")]
-        pub(crate) fn mul(lhs: RawVal, rhs: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$3")]
-        pub(crate) fn div(lhs: RawVal, rhs: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$4")]
-        pub(crate) fn rem(lhs: RawVal, rhs: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$5")]
-        pub(crate) fn and(lhs: RawVal, rhs: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$6")]
-        pub(crate) fn or(lhs: RawVal, rhs: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$7")]
-        pub(crate) fn xor(lhs: RawVal, rhs: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$8")]
-        pub(crate) fn shl(lhs: RawVal, rhs: u64) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$9")]
-        pub(crate) fn shr(lhs: RawVal, rhs: u64) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$A")]
-        pub(crate) fn cmp(lhs: RawVal, rhs: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$B")]
-        pub(crate) fn is_zero(x: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$C")]
-        pub(crate) fn neg(x: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$D")]
-        pub(crate) fn not(x: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$E")]
-        pub(crate) fn gcd(lhs: RawVal, rhs: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$F")]
-        pub(crate) fn lcm(lhs: RawVal, rhs: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$G")]
-        pub(crate) fn pow(lhs: RawVal, rhs: u64) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$H")]
-        pub(crate) fn pow_mod(p: RawVal, q: RawVal, m: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$I")]
-        pub(crate) fn sqrt(x: RawVal) -> RawVal;
-        #[cfg_attr(target_family = "wasm", link_name = "$J")]
-        pub(crate) fn bits(x: RawVal) -> u64;
-        #[cfg_attr(target_family = "wasm", link_name = "$K")]
-        pub(crate) fn to_u64(x: RawVal) -> u64;
-        #[cfg_attr(target_family = "wasm", link_name = "$L")]
-        pub(crate) fn to_i64(x: RawVal) -> i64;
-        #[cfg_attr(target_family = "wasm", link_name = "$M")]
-        pub(crate) fn from_i64(x: i64) -> RawVal;
-    }
-}
+call_macro_with_all_host_functions! { generate_extern_modules }

--- a/stellar-contract-env-guest/src/guest.rs
+++ b/stellar-contract-env-guest/src/guest.rs
@@ -26,24 +26,21 @@ impl EnvBase for Guest {
 // This is a helper macro used only by impl_env_for_guest below. It consumes a
 // token-tree of the form:
 //
-//  {fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty}
+//  {fn $fn_id:ident $args:tt -> $ret:ty}
 //
-// in each of 4 valid forms (self vs. mut-self, empty vs. nonempty trailing
-// args) and produces the the corresponding method definition to be used in the
+// and produces the the corresponding method definition to be used in the
 // Guest implementation of the Env trait (calling through to the corresponding
 // unsafe extern function).
 macro_rules! guest_function_helper {
-    {$mod_id:ident, fn $fn_id:ident(&self)() -> $ret:ty} =>
-    {fn $fn_id(&self) -> $ret { unsafe { $mod_id::$fn_id() }}};
-
-    {$mod_id:ident, fn $fn_id:ident(&self)($($arg:ident:$type:ty),*) -> $ret:ty} =>
-    {fn $fn_id(&self, $($arg:$type),*) -> $ret { unsafe { $mod_id::$fn_id($($arg),*)}}};
-
-    {$mod_id:ident, fn $fn_id:ident(&mut self)() -> $ret:ty} =>
-    {fn $fn_id(&mut self) -> $ret { unsafe { $mod_id::$fn_id() }}};
-
-    {$mod_id:ident, fn $fn_id:ident(&mut self)($($arg:ident:$type:ty),*) -> $ret:ty} =>
-    {fn $fn_id(&mut self, $($arg:$type),*) -> $ret { unsafe { $mod_id::$fn_id($($arg),*)}}};
+    {$mod_id:ident, fn $fn_id:ident($($arg:ident:$type:ty),*) -> $ret:ty}
+    =>
+    {
+        fn $fn_id(&self, $($arg:$type),*) -> $ret {
+            unsafe {
+                $mod_id::$fn_id($($arg),*)
+            }
+        }
+    };
 }
 
 // This is a callback macro that pattern-matches the token-tree passed by the
@@ -65,7 +62,7 @@ macro_rules! impl_env_for_guest {
                     // x-macro to this macro. It is embedded in a `$()*`
                     // pattern-repetition matcher so that it will match all such
                     // descriptions.
-                    { $fn_str:literal, fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                    { $fn_str:literal, fn $fn_id:ident $args:tt -> $ret:ty }
                 )*
             }
         )*
@@ -89,7 +86,7 @@ macro_rules! impl_env_for_guest {
                     // block repetition-level from the outer pattern in the
                     // expansion, flattening all functions from all 'mod' blocks
                     // into the implementation of Env for Guest.
-                    guest_function_helper!{$mod_id, fn $fn_id $selfspec $args -> $ret}
+                    guest_function_helper!{$mod_id, fn $fn_id $args -> $ret}
                 )*
             )*
         }
@@ -106,10 +103,9 @@ call_macro_with_all_host_functions! { impl_env_for_guest }
 // This is a helper macro used only by impl_env_for_guest below. It consumes a
 // token-tree of the form:
 //
-//  {fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty}
+//  {fn $fn_id:ident $args:tt -> $ret:ty}
 //
-// in each of 4 valid forms (self vs. mut-self, empty vs. nonempty trailing
-// args) and produces the the corresponding method definition to be used in the
+// and produces the the corresponding method definition to be used in the
 // Guest implementation of the Env trait (calling through to the corresponding
 // unsafe extern function).
 macro_rules! extern_function_helper {
@@ -139,7 +135,7 @@ macro_rules! generate_extern_modules {
                     // x-macro to this macro. It is embedded in a `$()*`
                     // pattern-repetition matcher so that it will match all such
                     // descriptions.
-                    { $fn_str:literal, fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                    { $fn_str:literal, fn $fn_id:ident $args:tt -> $ret:ty }
                 )*
             }
         )*

--- a/stellar-contract-env-host/Cargo.toml
+++ b/stellar-contract-env-host/Cargo.toml
@@ -12,4 +12,4 @@ num-rational = "0.4"
 wasmi = { version = "0.11.0", optional = true }
 
 [features]
-vm = ["wasmi"]
+vm = ["wasmi", "stellar-contract-env-common/vm"]

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -12,7 +12,9 @@ use super::xdr::{ScMap, ScMapEntry, ScObject, ScStatic, ScStatus, ScStatusType, 
 use std::rc::Rc;
 
 use crate::host_object::{HostMap, HostObj, HostObject, HostObjectType, HostVal, HostVec};
-use crate::{BitSet, Env, EnvObj, EnvValType, RawObj, RawVal, RawValType, Status, Symbol, Tag};
+use crate::{
+    BitSet, Env, EnvBase, EnvObj, EnvValType, RawObj, RawVal, RawValType, Status, Symbol, Tag,
+};
 
 #[derive(Debug)]
 pub enum Error {
@@ -266,13 +268,23 @@ impl Host {
     }
 }
 
-impl Env for Host {
+impl EnvBase for Host {
     fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
         todo!()
     }
 
     fn check_same_env(&self, other: &Self) {
         assert!(Rc::ptr_eq(&self.0, &other.0));
+    }
+}
+
+impl Env for Host {
+    fn log_value(&mut self, v: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn get_last_operation_result(&self) -> RawVal {
+        todo!()
     }
 
     fn obj_cmp(&self, a: RawVal, b: RawVal) -> i64 {
@@ -286,19 +298,11 @@ impl Env for Host {
         }
     }
 
-    fn log_value(&mut self, v: RawVal) -> RawVal {
-        todo!()
-    }
-
-    fn get_last_operation_result(&mut self) -> RawVal {
-        todo!()
-    }
-
     fn obj_from_u64(&mut self, u: u64) -> RawVal {
         self.add_host_object(u).expect("obj_from_u64").into()
     }
 
-    fn obj_to_u64(&mut self, u: RawVal) -> u64 {
+    fn obj_to_u64(&self, u: RawVal) -> u64 {
         todo!()
     }
 
@@ -306,7 +310,7 @@ impl Env for Host {
         self.add_host_object(i).expect("obj_from_i64").into()
     }
 
-    fn obj_to_i64(&mut self, i: RawVal) -> i64 {
+    fn obj_to_i64(&self, i: RawVal) -> i64 {
         todo!()
     }
 
@@ -421,6 +425,18 @@ impl Env for Host {
         todo!()
     }
 
+    fn put_contract_data(&mut self, k: RawVal, v: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn has_contract_data(&mut self, k: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn get_contract_data(&mut self, k: RawVal) -> RawVal {
+        todo!()
+    }
+
     fn account_balance(&mut self, acc: RawVal) -> RawVal {
         todo!()
     }
@@ -433,15 +449,139 @@ impl Env for Host {
         todo!()
     }
 
-    fn get_contract_data(&mut self, k: RawVal) -> RawVal {
+    fn get_current_ledger_num(&self) -> RawVal {
         todo!()
     }
 
-    fn put_contract_data(&mut self, k: RawVal, v: RawVal) -> RawVal {
+    fn get_current_ledger_close_time(&self) -> RawVal {
         todo!()
     }
 
-    fn has_contract_data(&mut self, k: RawVal) -> RawVal {
+    fn del_contract_data(&mut self, k: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn call0(&mut self, contract: RawVal, func: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn call1(&mut self, contract: RawVal, func: RawVal, a: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn call2(&mut self, contract: RawVal, func: RawVal, a: RawVal, b: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn call3(&mut self, contract: RawVal, func: RawVal, a: RawVal, b: RawVal, c: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn call4(
+        &mut self,
+        contract: RawVal,
+        func: RawVal,
+        a: RawVal,
+        b: RawVal,
+        c: RawVal,
+        d: RawVal,
+    ) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_from_u64(&mut self, x: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_add(&mut self, x: RawVal, y: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_sub(&mut self, x: RawVal, y: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_mul(&mut self, x: RawVal, y: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_div(&mut self, x: RawVal, y: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_rem(&mut self, x: RawVal, y: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_and(&mut self, x: RawVal, y: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_or(&mut self, x: RawVal, y: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_xor(&mut self, x: RawVal, y: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_shl(&mut self, x: RawVal, y: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_shr(&mut self, x: RawVal, y: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_cmp(&mut self, x: RawVal, y: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_is_zero(&mut self, x: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_neg(&mut self, x: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_not(&mut self, x: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_gcd(&mut self, x: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_lcm(&mut self, x: RawVal, y: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_pow(&mut self, x: RawVal, y: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_pow_mod(&mut self, p: RawVal, q: RawVal, m: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_sqrt(&mut self, x: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_bits(&mut self, x: RawVal) -> RawVal {
+        todo!()
+    }
+
+    fn bigint_to_u64(&mut self, x: RawVal) -> u64 {
+        todo!()
+    }
+
+    fn bigint_to_i64(&mut self, x: RawVal) -> i64 {
+        todo!()
+    }
+
+    fn bigint_from_i64(&mut self, x: i64) -> RawVal {
         todo!()
     }
 }

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -421,6 +421,14 @@ impl Env for Host {
         todo!()
     }
 
+    fn get_current_ledger_num(&self) -> RawVal {
+        todo!()
+    }
+
+    fn get_current_ledger_close_time(&self) -> RawVal {
+        todo!()
+    }
+
     fn pay(&mut self, src: RawVal, dst: RawVal, asset: RawVal, amount: RawVal) -> RawVal {
         todo!()
     }
@@ -437,6 +445,10 @@ impl Env for Host {
         todo!()
     }
 
+    fn del_contract_data(&mut self, k: RawVal) -> RawVal {
+        todo!()
+    }
+
     fn account_balance(&mut self, acc: RawVal) -> RawVal {
         todo!()
     }
@@ -446,18 +458,6 @@ impl Env for Host {
     }
 
     fn trust_line_balance(&mut self, tl: RawVal) -> RawVal {
-        todo!()
-    }
-
-    fn get_current_ledger_num(&self) -> RawVal {
-        todo!()
-    }
-
-    fn get_current_ledger_close_time(&self) -> RawVal {
-        todo!()
-    }
-
-    fn del_contract_data(&mut self, k: RawVal) -> RawVal {
         todo!()
     }
 

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -253,7 +253,7 @@ impl Host {
         }
     }
 
-    pub(crate) fn add_host_object<HOT: HostObjectType>(&mut self, hot: HOT) -> Result<HostObj, ()> {
+    pub(crate) fn add_host_object<HOT: HostObjectType>(&self, hot: HOT) -> Result<HostObj, ()> {
         let handle = self.0.objects.borrow().len();
         if handle > u32::MAX as usize {
             return Err(());
@@ -279,7 +279,7 @@ impl EnvBase for Host {
 }
 
 impl Env for Host {
-    fn log_value(&mut self, v: RawVal) -> RawVal {
+    fn log_value(&self, v: RawVal) -> RawVal {
         todo!()
     }
 
@@ -298,7 +298,7 @@ impl Env for Host {
         }
     }
 
-    fn obj_from_u64(&mut self, u: u64) -> RawVal {
+    fn obj_from_u64(&self, u: u64) -> RawVal {
         self.add_host_object(u).expect("obj_from_u64").into()
     }
 
@@ -306,7 +306,7 @@ impl Env for Host {
         todo!()
     }
 
-    fn obj_from_i64(&mut self, i: i64) -> RawVal {
+    fn obj_from_i64(&self, i: i64) -> RawVal {
         self.add_host_object(i).expect("obj_from_i64").into()
     }
 
@@ -314,55 +314,55 @@ impl Env for Host {
         todo!()
     }
 
-    fn map_new(&mut self) -> RawVal {
+    fn map_new(&self) -> RawVal {
         self.add_host_object(HostMap::new())
             .expect("map_new")
             .into()
     }
 
-    fn map_put(&mut self, m: RawVal, k: RawVal, v: RawVal) -> RawVal {
+    fn map_put(&self, m: RawVal, k: RawVal, v: RawVal) -> RawVal {
         todo!()
     }
 
-    fn map_get(&mut self, m: RawVal, k: RawVal) -> RawVal {
+    fn map_get(&self, m: RawVal, k: RawVal) -> RawVal {
         todo!()
     }
 
-    fn map_del(&mut self, m: RawVal, k: RawVal) -> RawVal {
+    fn map_del(&self, m: RawVal, k: RawVal) -> RawVal {
         todo!()
     }
 
-    fn map_len(&mut self, m: RawVal) -> RawVal {
+    fn map_len(&self, m: RawVal) -> RawVal {
         todo!()
     }
 
-    fn map_keys(&mut self, m: RawVal) -> RawVal {
+    fn map_keys(&self, m: RawVal) -> RawVal {
         todo!()
     }
 
-    fn map_has(&mut self, m: RawVal, k: RawVal) -> RawVal {
+    fn map_has(&self, m: RawVal, k: RawVal) -> RawVal {
         todo!()
     }
 
-    fn vec_new(&mut self) -> RawVal {
+    fn vec_new(&self) -> RawVal {
         self.add_host_object(HostVec::new())
             .expect("vec_new")
             .into()
     }
 
-    fn vec_put(&mut self, v: RawVal, i: RawVal, x: RawVal) -> RawVal {
+    fn vec_put(&self, v: RawVal, i: RawVal, x: RawVal) -> RawVal {
         todo!()
     }
 
-    fn vec_get(&mut self, v: RawVal, i: RawVal) -> RawVal {
+    fn vec_get(&self, v: RawVal, i: RawVal) -> RawVal {
         todo!()
     }
 
-    fn vec_del(&mut self, v: RawVal, i: RawVal) -> RawVal {
+    fn vec_del(&self, v: RawVal, i: RawVal) -> RawVal {
         todo!()
     }
 
-    fn vec_len(&mut self, v: RawVal) -> RawVal {
+    fn vec_len(&self, v: RawVal) -> RawVal {
         let len = unsafe {
             self.unchecked_visit_val_obj(v, move |ho| {
                 if let Some(HostObject::Vec(vec)) = ho {
@@ -377,7 +377,7 @@ impl Env for Host {
             .into()
     }
 
-    fn vec_push(&mut self, v: RawVal, x: RawVal) -> RawVal {
+    fn vec_push(&self, v: RawVal, x: RawVal) -> RawVal {
         let x = self.associate_raw_val(x);
         let vnew = unsafe {
             self.unchecked_visit_val_obj(v, move |ho| {
@@ -393,31 +393,31 @@ impl Env for Host {
         self.add_host_object(vnew).expect("vec_push").into()
     }
 
-    fn vec_pop(&mut self, v: RawVal) -> RawVal {
+    fn vec_pop(&self, v: RawVal) -> RawVal {
         todo!()
     }
 
-    fn vec_take(&mut self, v: RawVal, n: RawVal) -> RawVal {
+    fn vec_take(&self, v: RawVal, n: RawVal) -> RawVal {
         todo!()
     }
 
-    fn vec_drop(&mut self, v: RawVal, n: RawVal) -> RawVal {
+    fn vec_drop(&self, v: RawVal, n: RawVal) -> RawVal {
         todo!()
     }
 
-    fn vec_front(&mut self, v: RawVal) -> RawVal {
+    fn vec_front(&self, v: RawVal) -> RawVal {
         todo!()
     }
 
-    fn vec_back(&mut self, v: RawVal) -> RawVal {
+    fn vec_back(&self, v: RawVal) -> RawVal {
         todo!()
     }
 
-    fn vec_insert(&mut self, v: RawVal, i: RawVal, n: RawVal) -> RawVal {
+    fn vec_insert(&self, v: RawVal, i: RawVal, n: RawVal) -> RawVal {
         todo!()
     }
 
-    fn vec_append(&mut self, v1: RawVal, v2: RawVal) -> RawVal {
+    fn vec_append(&self, v1: RawVal, v2: RawVal) -> RawVal {
         todo!()
     }
 
@@ -429,56 +429,56 @@ impl Env for Host {
         todo!()
     }
 
-    fn pay(&mut self, src: RawVal, dst: RawVal, asset: RawVal, amount: RawVal) -> RawVal {
+    fn pay(&self, src: RawVal, dst: RawVal, asset: RawVal, amount: RawVal) -> RawVal {
         todo!()
     }
 
-    fn put_contract_data(&mut self, k: RawVal, v: RawVal) -> RawVal {
+    fn put_contract_data(&self, k: RawVal, v: RawVal) -> RawVal {
         todo!()
     }
 
-    fn has_contract_data(&mut self, k: RawVal) -> RawVal {
+    fn has_contract_data(&self, k: RawVal) -> RawVal {
         todo!()
     }
 
-    fn get_contract_data(&mut self, k: RawVal) -> RawVal {
+    fn get_contract_data(&self, k: RawVal) -> RawVal {
         todo!()
     }
 
-    fn del_contract_data(&mut self, k: RawVal) -> RawVal {
+    fn del_contract_data(&self, k: RawVal) -> RawVal {
         todo!()
     }
 
-    fn account_balance(&mut self, acc: RawVal) -> RawVal {
+    fn account_balance(&self, acc: RawVal) -> RawVal {
         todo!()
     }
 
-    fn account_trust_line(&mut self, acc: RawVal, asset: RawVal) -> RawVal {
+    fn account_trust_line(&self, acc: RawVal, asset: RawVal) -> RawVal {
         todo!()
     }
 
-    fn trust_line_balance(&mut self, tl: RawVal) -> RawVal {
+    fn trust_line_balance(&self, tl: RawVal) -> RawVal {
         todo!()
     }
 
-    fn call0(&mut self, contract: RawVal, func: RawVal) -> RawVal {
+    fn call0(&self, contract: RawVal, func: RawVal) -> RawVal {
         todo!()
     }
 
-    fn call1(&mut self, contract: RawVal, func: RawVal, a: RawVal) -> RawVal {
+    fn call1(&self, contract: RawVal, func: RawVal, a: RawVal) -> RawVal {
         todo!()
     }
 
-    fn call2(&mut self, contract: RawVal, func: RawVal, a: RawVal, b: RawVal) -> RawVal {
+    fn call2(&self, contract: RawVal, func: RawVal, a: RawVal, b: RawVal) -> RawVal {
         todo!()
     }
 
-    fn call3(&mut self, contract: RawVal, func: RawVal, a: RawVal, b: RawVal, c: RawVal) -> RawVal {
+    fn call3(&self, contract: RawVal, func: RawVal, a: RawVal, b: RawVal, c: RawVal) -> RawVal {
         todo!()
     }
 
     fn call4(
-        &mut self,
+        &self,
         contract: RawVal,
         func: RawVal,
         a: RawVal,
@@ -489,99 +489,99 @@ impl Env for Host {
         todo!()
     }
 
-    fn bigint_from_u64(&mut self, x: RawVal) -> RawVal {
+    fn bigint_from_u64(&self, x: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_add(&mut self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_add(&self, x: RawVal, y: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_sub(&mut self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_sub(&self, x: RawVal, y: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_mul(&mut self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_mul(&self, x: RawVal, y: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_div(&mut self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_div(&self, x: RawVal, y: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_rem(&mut self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_rem(&self, x: RawVal, y: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_and(&mut self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_and(&self, x: RawVal, y: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_or(&mut self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_or(&self, x: RawVal, y: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_xor(&mut self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_xor(&self, x: RawVal, y: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_shl(&mut self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_shl(&self, x: RawVal, y: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_shr(&mut self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_shr(&self, x: RawVal, y: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_cmp(&mut self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_cmp(&self, x: RawVal, y: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_is_zero(&mut self, x: RawVal) -> RawVal {
+    fn bigint_is_zero(&self, x: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_neg(&mut self, x: RawVal) -> RawVal {
+    fn bigint_neg(&self, x: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_not(&mut self, x: RawVal) -> RawVal {
+    fn bigint_not(&self, x: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_gcd(&mut self, x: RawVal) -> RawVal {
+    fn bigint_gcd(&self, x: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_lcm(&mut self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_lcm(&self, x: RawVal, y: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_pow(&mut self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_pow(&self, x: RawVal, y: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_pow_mod(&mut self, p: RawVal, q: RawVal, m: RawVal) -> RawVal {
+    fn bigint_pow_mod(&self, p: RawVal, q: RawVal, m: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_sqrt(&mut self, x: RawVal) -> RawVal {
+    fn bigint_sqrt(&self, x: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_bits(&mut self, x: RawVal) -> RawVal {
+    fn bigint_bits(&self, x: RawVal) -> RawVal {
         todo!()
     }
 
-    fn bigint_to_u64(&mut self, x: RawVal) -> u64 {
+    fn bigint_to_u64(&self, x: RawVal) -> u64 {
         todo!()
     }
 
-    fn bigint_to_i64(&mut self, x: RawVal) -> i64 {
+    fn bigint_to_i64(&self, x: RawVal) -> i64 {
         todo!()
     }
 
-    fn bigint_from_i64(&mut self, x: i64) -> RawVal {
+    fn bigint_from_i64(&self, x: i64) -> RawVal {
         todo!()
     }
 }

--- a/stellar-contract-env-host/src/vm.rs
+++ b/stellar-contract-env-host/src/vm.rs
@@ -37,7 +37,7 @@ impl ImportResolver for Host {
         signature: &wasmi::Signature,
     ) -> Result<wasmi::FuncRef, wasmi::Error> {
         for (i, hf) in HOST_FUNCTIONS.iter().enumerate() {
-            if module_name == hf.mod_name && field_name == hf.field_name {
+            if module_name == hf.mod_str && field_name == hf.fn_str {
                 if signature.params().len() != hf.arity
                     || !signature.params().iter().all(|p| *p == ValueType::I64)
                     || signature.return_type() != Some(ValueType::I64)

--- a/stellar-contract-env-host/src/vm/dispatch.rs
+++ b/stellar-contract-env-host/src/vm/dispatch.rs
@@ -89,7 +89,7 @@ macro_rules! generate_dispatch_functions {
                     // x-macro to this macro. It is embedded in a `$()*`
                     // pattern-repetition matcher so that it will match all such
                     // descriptions.
-                    { $fn_str:literal, fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                    { $fn_str:literal, fn $fn_id:ident $args:tt -> $ret:ty }
                 )*
             }
         )*

--- a/stellar-contract-env-host/src/vm/dispatch.rs
+++ b/stellar-contract-env-host/src/vm/dispatch.rs
@@ -2,85 +2,123 @@ use crate::{Env, Host, RawVal};
 use stellar_contract_env_common::call_macro_with_all_host_functions;
 use wasmi::{RuntimeArgs, RuntimeValue};
 
-// Probably there is a way to do this with recursive macros and accumulators but
-// it seems tolerable (and much easier to understand) to just write the cases out.
-macro_rules! dispatch_call {
+// This is a helper macro used only by generate_dispatch_functions below. It
+// consumes a token-tree of the form:
+//
+//  {$host:expr, $vmargs:expr, fn $fn_id:ident $args:tt }
+//
+// in each of 6 valid forms (with 0, 1, ... 6 possible arguments) and produces a
+// function-call expression that extracts and converts the correct number of
+// arguments from the $vmargs argument (a wasmi::RuntimeArgs structure) and
+// forwards them to the corresponding $host.$fn_id function (a method on Host).
+macro_rules! dispatch_function_helper {
 
-    {$host:ident, $args:ident, fn $func_id:ident() } =>
-    { $host.$func_id() };
+    {$host:expr, $vmargs:expr, fn $fn_id:ident()} =>
+    {$host.$fn_id()};
 
-    {$host:ident, $args:ident, fn $func_id:ident($a0:ident:$t0:ty) } =>
-    { $host.$func_id($args.nth_checked::<$t0>(0)?) };
+    {$host:expr, $vmargs:expr, fn $fn_id:ident($a0:ident:$t0:ty)} =>
+    {$host.$fn_id($vmargs.nth_checked::<$t0>(0)?)};
 
-    {$host:ident, $args:ident, fn $func_id:ident($a0:ident:$t0:ty,
-                                                 $a1:ident:$t1:ty) } =>
-    { $host.$func_id($args.nth_checked::<$t0>(0)?,
-                     $args.nth_checked::<$t1>(1)?) };
+    {$host:expr, $vmargs:expr, fn $fn_id:ident($a0:ident:$t0:ty,
+                                                 $a1:ident:$t1:ty)} =>
+    {$host.$fn_id($vmargs.nth_checked::<$t0>(0)?,
+                  $vmargs.nth_checked::<$t1>(1)?)};
 
-    {$host:ident, $args:ident, fn $func_id:ident($a0:ident:$t0:ty,
+    {$host:expr, $vmargs:expr, fn $fn_id:ident($a0:ident:$t0:ty,
                                                  $a1:ident:$t1:ty,
-                                                 $a2:ident:$t2:ty) } =>
-    { $host.$func_id($args.nth_checked::<$t0>(0)?,
-                     $args.nth_checked::<$t1>(1)?,
-                     $args.nth_checked::<$t2>(2)?) };
+                                                 $a2:ident:$t2:ty)} =>
+    {$host.$fn_id($vmargs.nth_checked::<$t0>(0)?,
+                  $vmargs.nth_checked::<$t1>(1)?,
+                  $vmargs.nth_checked::<$t2>(2)?)};
 
 
-    {$host:ident, $args:ident, fn $func_id:ident($a0:ident:$t0:ty,
+    {$host:expr, $vmargs:expr, fn $fn_id:ident($a0:ident:$t0:ty,
                                                  $a1:ident:$t1:ty,
                                                  $a2:ident:$t2:ty,
-                                                 $a3:ident:$t3:ty) } =>
-    { $host.$func_id($args.nth_checked::<$t0>(0)?,
-                     $args.nth_checked::<$t1>(1)?,
-                     $args.nth_checked::<$t2>(2)?,
-                     $args.nth_checked::<$t3>(3)?) };
+                                                 $a3:ident:$t3:ty)} =>
+    {$host.$fn_id($vmargs.nth_checked::<$t0>(0)?,
+                  $vmargs.nth_checked::<$t1>(1)?,
+                  $vmargs.nth_checked::<$t2>(2)?,
+                  $vmargs.nth_checked::<$t3>(3)?)};
 
-    {$host:ident, $args:ident, fn $func_id:ident($a0:ident:$t0:ty,
+    {$host:expr, $vmargs:expr, fn $fn_id:ident($a0:ident:$t0:ty,
                                                  $a1:ident:$t1:ty,
                                                  $a2:ident:$t2:ty,
                                                  $a3:ident:$t3:ty,
-                                                 $a4:ident:$t4:ty) } =>
-    { $host.$func_id($args.nth_checked::<$t0>(0)?,
-                     $args.nth_checked::<$t1>(1)?,
-                     $args.nth_checked::<$t2>(2)?,
-                     $args.nth_checked::<$t3>(3)?,
-                     $args.nth_checked::<$t4>(4)?) };
+                                                 $a4:ident:$t4:ty)} =>
+    {$host.$fn_id($vmargs.nth_checked::<$t0>(0)?,
+                  $vmargs.nth_checked::<$t1>(1)?,
+                  $vmargs.nth_checked::<$t2>(2)?,
+                  $vmargs.nth_checked::<$t3>(3)?,
+                  $vmargs.nth_checked::<$t4>(4)?)};
 
 
-    {$host:ident, $args:ident, fn $func_id:ident($a0:ident:$t0:ty,
+    {$host:expr, $vmargs:expr, fn $fn_id:ident($a0:ident:$t0:ty,
                                                  $a1:ident:$t1:ty,
                                                  $a2:ident:$t2:ty,
                                                  $a3:ident:$t3:ty,
                                                  $a4:ident:$t4:ty,
-                                                 $a5:ident:$t5:ty) } =>
-    { $host.$func_id($args.nth_checked::<$t0>(0)?,
-                     $args.nth_checked::<$t1>(1)?,
-                     $args.nth_checked::<$t2>(2)?,
-                     $args.nth_checked::<$t3>(3)?,
-                     $args.nth_checked::<$t4>(4)?,
-                     $args.nth_checked::<$t5>(5)?) };
+                                                 $a5:ident:$t5:ty)} =>
+    {$host.$fn_id($vmargs.nth_checked::<$t0>(0)?,
+                  $vmargs.nth_checked::<$t1>(1)?,
+                  $vmargs.nth_checked::<$t2>(2)?,
+                  $vmargs.nth_checked::<$t3>(3)?,
+                  $vmargs.nth_checked::<$t4>(4)?,
+                  $vmargs.nth_checked::<$t5>(5)?)};
 }
 
+// This is a callback macro that pattern-matches the token-tree passed by the
+// x-macro (call_macro_with_all_host_functions) and produces a suite of
+// dispatch-function definitions.
 macro_rules! generate_dispatch_functions {
     {
         $(
+            // This outer pattern matches a single 'mod' block of the token-tree
+            // passed from the x-macro to this macro. It is embedded in a `$()*`
+            // pattern-repetition matcher so that it will match all provided
+            // 'mod' blocks provided.
             mod $mod_name:ident $mod_str:literal
             {
                 $(
-                    { $field_str:literal, fn $func_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                    // This inner pattern matches a single function description
+                    // inside a 'mod' block in the token-tree passed from the
+                    // x-macro to this macro. It is embedded in a `$()*`
+                    // pattern-repetition matcher so that it will match all such
+                    // descriptions.
+                    { $field_str:literal, fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty }
                 )*
             }
         )*
     }
-        =>
+
+    =>  // The part of the macro above this line is a matcher; below is its expansion.
+
     {
+        // This macro expands to multiple items: a set of free functions in the
+        // current module, which are called by functions registered with the VM
+        // to forward calls to the host.
         $(
             $(
-                pub(crate) fn $func_id(host: &mut Host, _args: RuntimeArgs) -> Result<RuntimeValue, wasmi::Trap> {
-                    Ok(dispatch_call!{host, _args, fn $func_id $args }.into())
+                // This defines a function containing a body that includes the
+                // expansion of a macro call to the dispatch_function_helper!
+                // macro above, called with some expressions from the enclosing
+                // function (host and vmargs) as well as the relevant parts of
+                // the token-tree function declaration matched by the inner
+                // pattern above. It is embedded in two nested `$()*`
+                // pattern-repetition expanders that correspond to the
+                // pattern-repetition matchers in the match section, but we
+                // ignore the structure of the 'mod' block repetition-level from
+                // the outer pattern in the expansion, flattening all functions
+                // from all 'mod' blocks into a set of functions.
+                pub(crate) fn $fn_id(host: &mut Host, _vmargs: RuntimeArgs) ->
+                    Result<RuntimeValue, wasmi::Trap>
+                {
+                    Ok(dispatch_function_helper!{host, _vmargs, fn $fn_id $args }.into())
                 }
             )*
         )*
     };
 }
 
+// Here we invoke the x-macro passing generate_dispatch_functions as its callback macro.
 call_macro_with_all_host_functions! { generate_dispatch_functions }

--- a/stellar-contract-env-host/src/vm/dispatch.rs
+++ b/stellar-contract-env-host/src/vm/dispatch.rs
@@ -1,0 +1,86 @@
+use crate::{Env, Host, RawVal};
+use stellar_contract_env_common::call_macro_with_all_host_functions;
+use wasmi::{RuntimeArgs, RuntimeValue};
+
+// Probably there is a way to do this with recursive macros and accumulators but
+// it seems tolerable (and much easier to understand) to just write the cases out.
+macro_rules! dispatch_call {
+
+    {$host:ident, $args:ident, fn $func_id:ident() } =>
+    { $host.$func_id() };
+
+    {$host:ident, $args:ident, fn $func_id:ident($a0:ident:$t0:ty) } =>
+    { $host.$func_id($args.nth_checked::<$t0>(0)?) };
+
+    {$host:ident, $args:ident, fn $func_id:ident($a0:ident:$t0:ty,
+                                                 $a1:ident:$t1:ty) } =>
+    { $host.$func_id($args.nth_checked::<$t0>(0)?,
+                     $args.nth_checked::<$t1>(1)?) };
+
+    {$host:ident, $args:ident, fn $func_id:ident($a0:ident:$t0:ty,
+                                                 $a1:ident:$t1:ty,
+                                                 $a2:ident:$t2:ty) } =>
+    { $host.$func_id($args.nth_checked::<$t0>(0)?,
+                     $args.nth_checked::<$t1>(1)?,
+                     $args.nth_checked::<$t2>(2)?) };
+
+
+    {$host:ident, $args:ident, fn $func_id:ident($a0:ident:$t0:ty,
+                                                 $a1:ident:$t1:ty,
+                                                 $a2:ident:$t2:ty,
+                                                 $a3:ident:$t3:ty) } =>
+    { $host.$func_id($args.nth_checked::<$t0>(0)?,
+                     $args.nth_checked::<$t1>(1)?,
+                     $args.nth_checked::<$t2>(2)?,
+                     $args.nth_checked::<$t3>(3)?) };
+
+    {$host:ident, $args:ident, fn $func_id:ident($a0:ident:$t0:ty,
+                                                 $a1:ident:$t1:ty,
+                                                 $a2:ident:$t2:ty,
+                                                 $a3:ident:$t3:ty,
+                                                 $a4:ident:$t4:ty) } =>
+    { $host.$func_id($args.nth_checked::<$t0>(0)?,
+                     $args.nth_checked::<$t1>(1)?,
+                     $args.nth_checked::<$t2>(2)?,
+                     $args.nth_checked::<$t3>(3)?,
+                     $args.nth_checked::<$t4>(4)?) };
+
+
+    {$host:ident, $args:ident, fn $func_id:ident($a0:ident:$t0:ty,
+                                                 $a1:ident:$t1:ty,
+                                                 $a2:ident:$t2:ty,
+                                                 $a3:ident:$t3:ty,
+                                                 $a4:ident:$t4:ty,
+                                                 $a5:ident:$t5:ty) } =>
+    { $host.$func_id($args.nth_checked::<$t0>(0)?,
+                     $args.nth_checked::<$t1>(1)?,
+                     $args.nth_checked::<$t2>(2)?,
+                     $args.nth_checked::<$t3>(3)?,
+                     $args.nth_checked::<$t4>(4)?,
+                     $args.nth_checked::<$t5>(5)?) };
+}
+
+macro_rules! generate_dispatch_functions {
+    {
+        $(
+            mod $mod_name:ident $mod_str:literal
+            {
+                $(
+                    { $field_str:literal, fn $func_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                )*
+            }
+        )*
+    }
+        =>
+    {
+        $(
+            $(
+                pub(crate) fn $func_id(host: &mut Host, _args: RuntimeArgs) -> Result<RuntimeValue, wasmi::Trap> {
+                    Ok(dispatch_call!{host, _args, fn $func_id $args }.into())
+                }
+            )*
+        )*
+    };
+}
+
+call_macro_with_all_host_functions! { generate_dispatch_functions }

--- a/stellar-contract-env-host/src/vm/dispatch.rs
+++ b/stellar-contract-env-host/src/vm/dispatch.rs
@@ -89,7 +89,7 @@ macro_rules! generate_dispatch_functions {
                     // x-macro to this macro. It is embedded in a `$()*`
                     // pattern-repetition matcher so that it will match all such
                     // descriptions.
-                    { $field_str:literal, fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                    { $fn_str:literal, fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty }
                 )*
             }
         )*

--- a/stellar-contract-env-host/src/vm/dispatch.rs
+++ b/stellar-contract-env-host/src/vm/dispatch.rs
@@ -2,6 +2,10 @@ use crate::{Env, Host, RawVal};
 use stellar_contract_env_common::call_macro_with_all_host_functions;
 use wasmi::{RuntimeArgs, RuntimeValue};
 
+///////////////////////////////////////////////////////////////////////////////
+/// X-macro use: dispatch functions
+///////////////////////////////////////////////////////////////////////////////
+
 // This is a helper macro used only by generate_dispatch_functions below. It
 // consumes a token-tree of the form:
 //

--- a/stellar-contract-env-host/src/vm/func_info.rs
+++ b/stellar-contract-env-host/src/vm/func_info.rs
@@ -1,0 +1,52 @@
+use super::dispatch;
+use crate::Host;
+use stellar_contract_env_common::call_macro_with_all_host_functions;
+use wasmi::{RuntimeArgs, RuntimeValue};
+
+pub(crate) struct HostFuncInfo {
+    pub(crate) mod_name: &'static str,
+    pub(crate) field_name: &'static str,
+    pub(crate) arity: usize,
+    pub(crate) dispatch: fn(&mut Host, RuntimeArgs) -> Result<RuntimeValue, wasmi::Trap>,
+}
+
+macro_rules! arity_of {
+    { () } => { 0 };
+    { ($a0:ident:$t0:ty) } => { 1 };
+    { ($a0:ident:$t0:ty, $a1:ident:$t1:ty) } => { 2 };
+    { ($a0:ident:$t0:ty, $a1:ident:$t1:ty, $a2:ident:$t2:ty) } => { 3 };
+    { ($a0:ident:$t0:ty, $a1:ident:$t1:ty, $a2:ident:$t2:ty, $a3:ident:$t3:ty) } => { 4 };
+    { ($a0:ident:$t0:ty, $a1:ident:$t1:ty, $a2:ident:$t2:ty, $a3:ident:$t3:ty, $a4:ident:$t4:ty) } => { 5 };
+    { ($a0:ident:$t0:ty, $a1:ident:$t1:ty, $a2:ident:$t2:ty, $a3:ident:$t3:ty, $a4:ident:$t4:ty, $a5:ident:$t5:ty) } => { 6 };
+}
+
+macro_rules! generate_host_function_infos {
+    {
+        $(
+            mod $mod_name:ident $mod_str:literal
+            {
+                $(
+                    { $field_str:literal, fn $func_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                )*
+            }
+        )*
+    }
+    =>
+    {
+        &[
+           $(
+                $(
+                    HostFuncInfo {
+                        mod_name: $mod_str,
+                        field_name: $field_str,
+                        arity: arity_of!{$args},
+                        dispatch: dispatch::$func_id,
+                    },
+                )*
+            )*
+        ]
+    };
+}
+
+pub(crate) static HOST_FUNCTIONS: &[HostFuncInfo] =
+    call_macro_with_all_host_functions! { generate_host_function_infos };

--- a/stellar-contract-env-host/src/vm/func_info.rs
+++ b/stellar-contract-env-host/src/vm/func_info.rs
@@ -4,13 +4,21 @@ use stellar_contract_env_common::call_macro_with_all_host_functions;
 use wasmi::{RuntimeArgs, RuntimeValue};
 
 pub(crate) struct HostFuncInfo {
-    pub(crate) mod_name: &'static str,
+    pub(crate) mod_id: &'static str,
     pub(crate) field_name: &'static str,
     pub(crate) arity: usize,
     pub(crate) dispatch: fn(&mut Host, RuntimeArgs) -> Result<RuntimeValue, wasmi::Trap>,
 }
 
-macro_rules! arity_of {
+///////////////////////////////////////////////////////////////////////////////
+/// X-macro use: static HOST_FUNCTIONS array of HostFuncInfo
+///////////////////////////////////////////////////////////////////////////////
+
+// This is a helper macro that matches simple ident:ty argument list token-trees
+// and returns a literal token that is the arity (number of arguments) in the
+// list. It is used to convert the supplied token-tree pattern to an arity number
+// stored in the HostFuncInfo.
+macro_rules! arity_helper {
     { () } => { 0 };
     { ($a0:ident:$t0:ty) } => { 1 };
     { ($a0:ident:$t0:ty, $a1:ident:$t1:ty) } => { 2 };
@@ -20,33 +28,68 @@ macro_rules! arity_of {
     { ($a0:ident:$t0:ty, $a1:ident:$t1:ty, $a2:ident:$t2:ty, $a3:ident:$t3:ty, $a4:ident:$t4:ty, $a5:ident:$t5:ty) } => { 6 };
 }
 
+// This is a callback macro that pattern-matches the token-tree passed by the
+// x-macro (call_macro_with_all_host_functions) and produces a suite of
+// dispatch-function definitions.
 macro_rules! generate_host_function_infos {
     {
         $(
-            mod $mod_name:ident $mod_str:literal
+            // This outer pattern matches a single 'mod' block of the token-tree
+            // passed from the x-macro to this macro. It is embedded in a `$()*`
+            // pattern-repetition matcher so that it will match all provided
+            // 'mod' blocks provided.
+            mod $mod_id:ident $mod_str:literal
             {
                 $(
-                    { $field_str:literal, fn $func_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                    // This inner pattern matches a single function description
+                    // inside a 'mod' block in the token-tree passed from the
+                    // x-macro to this macro. It is embedded in a `$()*`
+                    // pattern-repetition matcher so that it will match all such
+                    // descriptions.
+                    { $fn_id:literal, fn $func_id:ident $selfspec:tt $args:tt -> $ret:ty }
                 )*
             }
         )*
     }
-    =>
+
+    =>   // The part of the macro above this line is a matcher; below is its expansion.
+
     {
+        // This macro expands to a single item: a static array of HostFuncInfo, used by
+        // two places:
+        //
+        //   1. The VM WASM-module instantiation step to resolve all import functions to numbers
+        //       and typecheck their signatures (represented here by a simple arity number, since
+        //       every host function we have just takes N i64 values and returns an i64).
+        //
+        //   2. The function dispatch path when guest code calls out of the VM, where we
+        //      look up the numbered function the guest is requesting in this array and
+        //      call its associated dispatch function.
+        pub(crate) static HOST_FUNCTIONS: &[HostFuncInfo] =
         &[
            $(
                 $(
+                    // This generates a HostFuncInfo struct directly
+                    // for each function matched in the token-tree (invoking
+                    // the arity_helper! macro above to calculate the arity
+                    // of each function along the way). It is embedded in two
+                    // nested `$()*` pattern-repetition expanders that
+                    // correspond to the pattern-repetition matchers in the
+                    // match section, but we ignore the structure of the 'mod'
+                    // block repetition-level from the outer pattern in the
+                    // expansion, flattening all functions from all 'mod' blocks
+                    // into the a single array of HostFuncInfo structs.
                     HostFuncInfo {
-                        mod_name: $mod_str,
-                        field_name: $field_str,
-                        arity: arity_of!{$args},
+                        mod_id: $mod_str,
+                        field_name: $fn_id,
+                        arity: arity_helper!{$args},
                         dispatch: dispatch::$func_id,
                     },
                 )*
             )*
-        ]
+        ];
     };
 }
 
-pub(crate) static HOST_FUNCTIONS: &[HostFuncInfo] =
-    call_macro_with_all_host_functions! { generate_host_function_infos };
+// Here we invoke the x-macro passing generate_host_function_infos as its callback macro.
+call_macro_with_all_host_functions! { generate_host_function_infos }

--- a/stellar-contract-env-host/src/vm/func_info.rs
+++ b/stellar-contract-env-host/src/vm/func_info.rs
@@ -4,9 +4,19 @@ use stellar_contract_env_common::call_macro_with_all_host_functions;
 use wasmi::{RuntimeArgs, RuntimeValue};
 
 pub(crate) struct HostFuncInfo {
-    pub(crate) mod_id: &'static str,
-    pub(crate) field_name: &'static str,
+    /// String name of the WASM module this host function is importable from.
+    pub(crate) mod_str: &'static str,
+
+    /// String name of the WASM function that the host function is importable
+    /// as.
+    pub(crate) fn_str: &'static str,
+
+    /// Number of u64 arguments the host function takes.
     pub(crate) arity: usize,
+
+    /// Dispatch function for this host function, that takes a Host and some
+    /// RuntimeArgs, unpacks and converts the appropriate set of arguments from
+    /// RuntimeArgs, and calls the corresponding method on Host.
     pub(crate) dispatch: fn(&mut Host, RuntimeArgs) -> Result<RuntimeValue, wasmi::Trap>,
 }
 
@@ -46,7 +56,7 @@ macro_rules! generate_host_function_infos {
                     // x-macro to this macro. It is embedded in a `$()*`
                     // pattern-repetition matcher so that it will match all such
                     // descriptions.
-                    { $fn_id:literal, fn $func_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                    { $fn_id:literal, fn $func_id:ident $args:tt -> $ret:ty }
                 )*
             }
         )*
@@ -80,8 +90,8 @@ macro_rules! generate_host_function_infos {
                     // expansion, flattening all functions from all 'mod' blocks
                     // into the a single array of HostFuncInfo structs.
                     HostFuncInfo {
-                        mod_id: $mod_str,
-                        field_name: $fn_id,
+                        mod_str: $mod_str,
+                        fn_str: $fn_id,
                         arity: arity_helper!{$args},
                         dispatch: dispatch::$func_id,
                     },

--- a/stellar-contract-env-host/src/weak_host.rs
+++ b/stellar-contract-env-host/src/weak_host.rs
@@ -50,24 +50,19 @@ impl EnvBase for WeakHost {
 // This is a helper macro used only by impl_env_for_host below. It consumes a
 // token-tree of the form:
 //
-//  {fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty}
+//  {fn $fn_id:ident $args:tt -> $ret:ty}
 //
-// in each of 4 valid forms (self vs. mut-self, empty vs. nonempty trailing
-// args) and produces the the corresponding method definition to be used in the
+// and produces the the corresponding method definition to be used in the
 // Host implementation of the Env trait (calling through to the corresponding
 // function on Host after upgrading the Weak ref to an Rc via get_host()).
 macro_rules! weakhost_function_helper {
-    {$mod_id:ident, fn $fn_id:ident(&self)() -> $ret:ty} =>
-    {fn $fn_id(&self) -> $ret { self.get_host().$fn_id() }};
-
-    {$mod_id:ident, fn $fn_id:ident(&self)($($arg:ident:$type:ty),*) -> $ret:ty} =>
-    {fn $fn_id(&self, $($arg:$type),*) -> $ret { self.get_host().$fn_id($($arg),*) }};
-
-    {$mod_id:ident, fn $fn_id:ident(&mut self)() -> $ret:ty} =>
-    {fn $fn_id(&mut self) -> $ret { self.get_host().$fn_id() }};
-
-    {$mod_id:ident, fn $fn_id:ident(&mut self)($($arg:ident:$type:ty),*) -> $ret:ty} =>
-    {fn $fn_id(&mut self, $($arg:$type),*) -> $ret { self.get_host().$fn_id($($arg),*) }};
+    {$mod_id:ident, fn $fn_id:ident($($arg:ident:$type:ty),*) -> $ret:ty}
+    =>
+    {
+        fn $fn_id(&self, $($arg:$type),*) -> $ret {
+            self.get_host().$fn_id($($arg),*)
+        }
+    };
 }
 
 // This is a callback macro that pattern-matches the token-tree passed by the
@@ -89,7 +84,7 @@ macro_rules! impl_env_for_weakhost {
                     // x-macro to this macro. It is embedded in a `$()*`
                     // pattern-repetition matcher so that it will match all such
                     // descriptions.
-                    { $fn_str:literal, fn $fn_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                    { $fn_str:literal, fn $fn_id:ident $args:tt -> $ret:ty }
                 )*
             }
         )*
@@ -114,7 +109,7 @@ macro_rules! impl_env_for_weakhost {
                     // block repetition-level from the outer pattern in the
                     // expansion, flattening all functions from all 'mod' blocks
                     // into the implementation of Env for WeakHost.
-                     weakhost_function_helper!{$mod_id, fn $fn_id $selfspec $args -> $ret}
+                     weakhost_function_helper!{$mod_id, fn $fn_id  $args -> $ret}
                 )*
             )*
         }

--- a/stellar-contract-env-host/src/weak_host.rs
+++ b/stellar-contract-env-host/src/weak_host.rs
@@ -1,4 +1,6 @@
-use crate::{host::HostImpl, Env, Host, RawVal};
+use stellar_contract_env_common::call_macro_with_all_host_functions;
+
+use crate::{host::HostImpl, Env, EnvBase, Host, RawVal};
 use core::fmt::Debug;
 use std::rc::Weak;
 
@@ -35,7 +37,7 @@ impl WeakHost {
     }
 }
 
-impl Env for WeakHost {
+impl EnvBase for WeakHost {
     fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
         self as &mut dyn std::any::Any
     }
@@ -43,140 +45,44 @@ impl Env for WeakHost {
     fn check_same_env(&self, other: &Self) {
         self.get_host().check_same_env(&other.get_host())
     }
-
-    fn obj_cmp(&self, a: RawVal, b: RawVal) -> i64 {
-        self.get_host().obj_cmp(a, b)
-    }
-
-    fn log_value(&mut self, v: RawVal) -> RawVal {
-        self.get_host().log_value(v)
-    }
-
-    fn get_last_operation_result(&mut self) -> RawVal {
-        self.get_host().get_last_operation_result()
-    }
-
-    fn obj_from_u64(&mut self, u: u64) -> RawVal {
-        self.get_host().obj_from_u64(u)
-    }
-
-    fn obj_to_u64(&mut self, u: RawVal) -> u64 {
-        self.get_host().obj_to_u64(u)
-    }
-
-    fn obj_from_i64(&mut self, i: i64) -> RawVal {
-        self.get_host().obj_from_i64(i)
-    }
-
-    fn obj_to_i64(&mut self, i: RawVal) -> i64 {
-        self.get_host().obj_to_i64(i)
-    }
-
-    fn map_new(&mut self) -> RawVal {
-        self.get_host().map_new()
-    }
-
-    fn map_put(&mut self, m: RawVal, k: RawVal, v: RawVal) -> RawVal {
-        self.get_host().map_put(m, k, v)
-    }
-
-    fn map_get(&mut self, m: RawVal, k: RawVal) -> RawVal {
-        self.get_host().map_get(m, k)
-    }
-
-    fn map_del(&mut self, m: RawVal, k: RawVal) -> RawVal {
-        self.get_host().map_del(m, k)
-    }
-
-    fn map_len(&mut self, m: RawVal) -> RawVal {
-        self.get_host().map_len(m)
-    }
-
-    fn map_keys(&mut self, m: RawVal) -> RawVal {
-        self.get_host().map_keys(m)
-    }
-
-    fn map_has(&mut self, m: RawVal, k: RawVal) -> RawVal {
-        self.get_host().map_has(m, k)
-    }
-
-    fn vec_new(&mut self) -> RawVal {
-        self.get_host().vec_new()
-    }
-
-    fn vec_put(&mut self, v: RawVal, i: RawVal, x: RawVal) -> RawVal {
-        self.get_host().vec_put(v, i, x)
-    }
-
-    fn vec_get(&mut self, v: RawVal, i: RawVal) -> RawVal {
-        self.get_host().vec_get(v, i)
-    }
-
-    fn vec_del(&mut self, v: RawVal, i: RawVal) -> RawVal {
-        self.get_host().vec_del(v, i)
-    }
-
-    fn vec_len(&mut self, v: RawVal) -> RawVal {
-        self.get_host().vec_len(v)
-    }
-
-    fn vec_push(&mut self, v: RawVal, x: RawVal) -> RawVal {
-        self.get_host().vec_push(v, x)
-    }
-
-    fn vec_pop(&mut self, v: RawVal) -> RawVal {
-        self.get_host().vec_pop(v)
-    }
-
-    fn vec_take(&mut self, v: RawVal, n: RawVal) -> RawVal {
-        self.get_host().vec_take(v, n)
-    }
-
-    fn vec_drop(&mut self, v: RawVal, n: RawVal) -> RawVal {
-        self.get_host().vec_drop(v, n)
-    }
-
-    fn vec_front(&mut self, v: RawVal) -> RawVal {
-        self.get_host().vec_front(v)
-    }
-
-    fn vec_back(&mut self, v: RawVal) -> RawVal {
-        self.get_host().vec_back(v)
-    }
-
-    fn vec_insert(&mut self, v: RawVal, i: RawVal, n: RawVal) -> RawVal {
-        self.get_host().vec_insert(v, i, n)
-    }
-
-    fn vec_append(&mut self, v1: RawVal, v2: RawVal) -> RawVal {
-        self.get_host().vec_append(v1, v2)
-    }
-
-    fn pay(&mut self, src: RawVal, dst: RawVal, asset: RawVal, amount: RawVal) -> RawVal {
-        self.get_host().pay(src, dst, asset, amount)
-    }
-
-    fn account_balance(&mut self, acc: RawVal) -> RawVal {
-        self.get_host().account_balance(acc)
-    }
-
-    fn account_trust_line(&mut self, acc: RawVal, asset: RawVal) -> RawVal {
-        self.get_host().account_trust_line(acc, asset)
-    }
-
-    fn trust_line_balance(&mut self, tl: RawVal) -> RawVal {
-        self.get_host().trust_line_balance(tl)
-    }
-
-    fn get_contract_data(&mut self, k: RawVal) -> RawVal {
-        self.get_host().get_contract_data(k)
-    }
-
-    fn put_contract_data(&mut self, k: RawVal, v: RawVal) -> RawVal {
-        self.get_host().put_contract_data(k, v)
-    }
-
-    fn has_contract_data(&mut self, k: RawVal) -> RawVal {
-        self.get_host().has_contract_data(k)
-    }
 }
+
+macro_rules! host_function {
+    {$mod_name:ident, fn $func_id:ident(&self)() -> $ret:ty} =>
+    {fn $func_id(&self) -> $ret { self.get_host().$func_id() }};
+
+    {$mod_name:ident, fn $func_id:ident(&self)($($arg:ident:$type:ty),*) -> $ret:ty} =>
+    {fn $func_id(&self, $($arg:$type),*) -> $ret { self.get_host().$func_id($($arg),*) }};
+
+    {$mod_name:ident, fn $func_id:ident(&mut self)() -> $ret:ty} =>
+    {fn $func_id(&mut self) -> $ret { self.get_host().$func_id() }};
+
+    {$mod_name:ident, fn $func_id:ident(&mut self)($($arg:ident:$type:ty),*) -> $ret:ty} =>
+    {fn $func_id(&mut self, $($arg:$type),*) -> $ret { self.get_host().$func_id($($arg),*) }};
+}
+
+macro_rules! impl_env_for_weakhost {
+    {
+        $(
+            mod $mod_name:ident $mod_str:literal
+            {
+                $(
+                    { $field_str:literal, fn $func_id:ident $selfspec:tt $args:tt -> $ret:ty }
+                )*
+            }
+        )*
+    }
+    =>
+    {
+        impl Env for WeakHost
+        {
+            $(
+                $(
+                    host_function!{$mod_name, fn $func_id $selfspec $args -> $ret}
+                )*
+            )*
+        }
+    };
+}
+
+call_macro_with_all_host_functions! { impl_env_for_weakhost }

--- a/stellar-contract-env-host/tests/integration.rs
+++ b/stellar-contract-env-host/tests/integration.rs
@@ -2,7 +2,7 @@ use stellar_contract_env_host::{xdr::ScObjectType, Env, Host, RawObj};
 
 #[test]
 fn vec_as_seen_by_user() -> Result<(), ()> {
-    let mut host = Host::default();
+    let host = Host::default();
     let int1 = host.obj_from_i64(5).in_env(&host);
 
     let vec1a = host.vec_new().in_env(&host);
@@ -22,7 +22,7 @@ fn vec_as_seen_by_user() -> Result<(), ()> {
 
 #[test]
 fn vec_host_fn() {
-    let mut host = Host::default();
+    let host = Host::default();
     let m = host.map_new();
     assert!(RawObj::val_is_obj_type(m, ScObjectType::ScoMap));
 }


### PR DESCRIPTION
This moves the declaration of host function information (names, type signatures, mutability-of-self, enclosing module, wasm import names, etc.) into a single x-macro (higher-order macro) that then calls back several different site-specific macros where the information is used:

  1. The site of `trait Env` being declared
  2. The site of all guest `extern "C"` native module decls.
  3. The site of the `impl Env for Guest` that forwards all methods through to the `extern "C"` modules.
  4. The site of `impl Env for WeakHost` that forwards all methods through to `Host`
  5. A new site of resolving imports during WASM module instantiation in the VM.
  6. A new site of dispatch functions that unpack args and forward the call to `Host` when the VM calls a resolved import.

It does not change implementations of host functions. They are still to be written manually, though the `Env` trait that _declares_ them all (which `Host` has to implement) is now generated from the macro, so you are always required to implement all the functions everything else in the system knows about. This accounts for a lot of the "new code" (`todo!()`s) in the PR.

I know this is a macro-based solution. I know macros detract from comprehensibility, and x-macros doubly so. I tried to make it a fairly clear set implementation, that does not lose or obscure important surface information, but there's no escaping the reality of what's being done. I ask that those negatives be balanced against the following negatives if we follow the non-macro status quo:

  1. The labor of adding, removing and keeping-in-sync edits to 6 different sites as we add/remove/adjust host functions.
  2. The odds of introducing subtle errors due to mismatches in them.
  3. The fact that we are identifying imports by otherwise-unchecked string names in 2 places that must be kept in sync.
  4. The fact that we are identifying imports by otherwise-unchecked integer indexes in 2 places that must be kept in sync.
  5. The possibility there will be _more_ such sites and must-be-kept-in-sync places in the future.

Given these concerns I am advocating this solution. This is exactly the sort of thing macros are in Rust to support.