### PR TITLE
Add workflow that runs after a commits check suite completes

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - if: ${{ github.event.check_suite.conclusion == 'success' }}
-      run: echo 'The triggering workflow succeeded'
+      run: echo 'The check suite for ${{ github.event.check_suite.head_branch }} (${{ github.event.check_suite.head_sha }}) succeeded'
     - if: ${{ github.event.check_suite.conclusion != 'success' }}
-      run: echo 'The triggering workflow ${{ github.event.check_suite.conclusion }}'; exit 1
+      run: echo 'The check suite ${{ github.event.check_suite.head_branch }} (${{ github.event.check_suite.head_sha }}) ${{ github.event.check_suite.conclusion }}'; exit 1

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -1,0 +1,13 @@
+on:
+  workflow_run:
+    workflows: [Rust]
+    types: [completed]
+
+jobs:
+  on-success:
+    runs-on: ubuntu-latest
+    steps:
+    - if: ${{ github.event.workflow_run.conclusion == 'success' }}
+      run: echo 'The triggering workflow succeeded'
+    - if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+      run: echo 'The triggering workflow failed'

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -10,4 +10,4 @@ jobs:
     - if: ${{ github.event.workflow_run.conclusion == 'success' }}
       run: echo 'The triggering workflow succeeded'
     - if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-      run: echo 'The triggering workflow failed'
+      run: echo 'The triggering workflow failed'; exit 1

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -1,13 +1,18 @@
+# Workflow Check Suite runs after all other checks for a commit or PR. It's
+# completed job can be used as a single check to reference whether all other
+# checks have succeeded.
+
+name: Check Suite
+
 on:
-  workflow_run:
-    workflows: [Rust]
+  check_suite:
     types: [completed]
 
 jobs:
-  on-success:
+  succeeded:
     runs-on: ubuntu-latest
     steps:
-    - if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    - if: ${{ github.event.check_suite.conclusion == 'success' }}
       run: echo 'The triggering workflow succeeded'
-    - if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-      run: echo 'The triggering workflow failed'; exit 1
+    - if: ${{ github.event.check_suite.conclusion != 'success' }}
+      run: echo 'The triggering workflow ${{ github.event.check_suite.conclusion }}'; exit 1


### PR DESCRIPTION
### What

Add workflow that runs after a commits check suite completes.

### Why

We have an issue with terraform / GitHub repo config that changing the required checks is tedious and time consuming. This workflow is an attempt to have a single action workflow/job that will succeed when all others have succeeded, so we can reference this one job instead of having to reference and keep updated many jobs.

### Known limitations

Check suite triggered workflows only run once merged to the default branch, so this is untested until merged.
