### PR TITLE
Add impl to `obj_to_u64`, `obj_to_i64`

### DIFF
--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -67,12 +67,12 @@ macro_rules! call_macro_with_all_host_functions {
 
             mod u64 "u" {
                 {"$_", fn obj_from_u64(v:u64) -> Object }
-                {"$0", fn obj_to_u64(v:RawVal) -> u64 }
+                {"$0", fn obj_to_u64(obj:Object) -> u64 }
             }
 
             mod i64 "i" {
                 {"$_", fn obj_from_i64(v:i64) -> Object }
-                {"$0", fn obj_to_i64(v:RawVal) -> i64 }
+                {"$0", fn obj_to_i64(obj:Object) -> i64 }
             }
 
             mod map "m" {

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -168,7 +168,9 @@ impl<E: Env> TryFrom<EnvVal<E, RawVal>> for i64 {
         if ev.val.is_positive_i64() {
             Ok(unsafe { ev.val.unchecked_as_positive_i64() })
         } else if Object::val_is_obj_type(ev.val, ScObjectType::I64) {
-            Ok(ev.env.obj_to_i64(ev.val))
+            Ok(ev
+                .env
+                .obj_to_i64(unsafe { Object::unchecked_from_val(ev.val) }))
         } else {
             Err(())
         }
@@ -196,7 +198,9 @@ impl<E: Env> TryFrom<EnvVal<E, RawVal>> for u64 {
         if ev.val.is_positive_i64() {
             Ok(unsafe { ev.val.unchecked_as_positive_i64() } as u64)
         } else if Object::val_is_obj_type(ev.val, ScObjectType::U64) {
-            Ok(ev.env.obj_to_u64(ev.val))
+            Ok(ev
+                .env
+                .obj_to_u64(unsafe { Object::unchecked_from_val(ev.val) }))
         } else {
             Err(())
         }

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -2,7 +2,6 @@ use crate::{BitSet, Object, Status, Symbol, Tag, TagType, TaggedVal, Val};
 
 use super::{
     raw_val::{RawVal, RawValConvertible},
-    xdr::ScObjectType,
     Env,
 };
 use core::{cmp::Ordering, fmt::Debug};

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -167,12 +167,9 @@ impl<E: Env> TryFrom<EnvVal<E, RawVal>> for i64 {
     fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
         if ev.val.is_positive_i64() {
             Ok(unsafe { ev.val.unchecked_as_positive_i64() })
-        } else if Object::val_is_obj_type(ev.val, ScObjectType::I64) {
-            Ok(ev
-                .env
-                .obj_to_i64(unsafe { Object::unchecked_from_val(ev.val) }))
         } else {
-            Err(())
+            let ev: EnvVal<E, Object> = ev.try_into()?;
+            Ok(ev.env.obj_to_i64(ev.val))
         }
     }
 }
@@ -197,12 +194,9 @@ impl<E: Env> TryFrom<EnvVal<E, RawVal>> for u64 {
     fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
         if ev.val.is_positive_i64() {
             Ok(unsafe { ev.val.unchecked_as_positive_i64() } as u64)
-        } else if Object::val_is_obj_type(ev.val, ScObjectType::U64) {
-            Ok(ev
-                .env
-                .obj_to_u64(unsafe { Object::unchecked_from_val(ev.val) }))
         } else {
-            Err(())
+            let ev: EnvVal<E, Object> = ev.try_into()?;
+            Ok(ev.env.obj_to_u64(ev.val))
         }
     }
 }

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -349,16 +349,16 @@ impl CheckedEnv for Host {
         Ok(self.add_host_object(u)?.into())
     }
 
-    fn obj_to_u64(&self, v: RawVal) -> Result<u64, HostError> {
-        todo!()
+    fn obj_to_u64(&self, obj: Object) -> Result<u64, HostError> {
+        self.visit_obj(obj, |u: &u64| Ok(*u))
     }
 
     fn obj_from_i64(&self, i: i64) -> Result<Object, HostError> {
         Ok(self.add_host_object(i)?.into())
     }
 
-    fn obj_to_i64(&self, v: RawVal) -> Result<i64, HostError> {
-        todo!()
+    fn obj_to_i64(&self, obj: Object) -> Result<i64, HostError> {
+        self.visit_obj(obj, |i: &i64| Ok(*i))
     }
 
     fn map_new(&self) -> Result<Object, HostError> {


### PR DESCRIPTION
### What

Add a couple of host functions:
- `obj_to_u64`
- `obj_to_i64`

### Why
Provide implementation for essential host functions. 

### Known limitations
This is just a start, still many more to do.
