### PR TITLE
Move the panic handler impl to its own crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,5 @@ members = [
     "stellar-contract-env-host",
     "stellar-contract-env-guest",
     "stellar-contract-env-common",
+    "stellar-contract-env-panic",
 ]

--- a/stellar-contract-env-common/Cargo.toml
+++ b/stellar-contract-env-common/Cargo.toml
@@ -9,4 +9,3 @@ stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "1fa7c3
 
 [features]
 std = ["stellar-xdr/std"]
-panic_handler = []

--- a/stellar-contract-env-common/src/rt.rs
+++ b/stellar-contract-env-common/src/rt.rs
@@ -10,9 +10,3 @@ pub fn trap() -> ! {
 pub fn trap() -> ! {
     panic!()
 }
-
-#[cfg(feature = "panic_handler")]
-#[panic_handler]
-fn handle_panic(_: &core::panic::PanicInfo) -> ! {
-    trap();
-}

--- a/stellar-contract-env-guest/Cargo.toml
+++ b/stellar-contract-env-guest/Cargo.toml
@@ -5,6 +5,3 @@ edition = "2021"
 
 [dependencies]
 stellar-contract-env-common = { path = "../stellar-contract-env-common" }
-
-[features]
-panic_handler = ["stellar-contract-env-common/panic_handler"]

--- a/stellar-contract-env-panic/Cargo.toml
+++ b/stellar-contract-env-panic/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "stellar-contract-env-panic"
+version = "0.0.0"
+edition = "2021"

--- a/stellar-contract-env-panic/src/lib.rs
+++ b/stellar-contract-env-panic/src/lib.rs
@@ -1,0 +1,7 @@
+#![no_std]
+
+#[cfg(target_family = "wasm")]
+#[panic_handler]
+fn handle_panic(_: &core::panic::PanicInfo) -> ! {
+    core::arch::wasm32::unreachable()
+}


### PR DESCRIPTION
### What

Move the panic handler impl to its own crate.

### Why

I was reading in a blog post (lost the link though 😞) that it can be a helpful thing to keep panic handler impls in their own crates because of the problems they cause getting pulled into builds when they shouldn't be, like in tests, etc. Doesn't seem so bad.

### Known limitations

N/A
