### PR TITLE
Remove HasEnv trait

### DIFF
--- a/stellar-contract-env-common/src/env_obj.rs
+++ b/stellar-contract-env-common/src/env_obj.rs
@@ -10,9 +10,6 @@ impl<E: Env> HasEnv<E> for EnvObj<E> {
     fn env(&self) -> &E {
         &self.0.env
     }
-    fn mut_env(&mut self) -> &mut E {
-        &mut self.0.env
-    }
 }
 
 impl<E: Env> AsRef<EnvVal<E>> for EnvObj<E> {

--- a/stellar-contract-env-common/src/env_obj.rs
+++ b/stellar-contract-env-common/src/env_obj.rs
@@ -1,4 +1,4 @@
-use super::{xdr::ScObjectType, Env, EnvVal, HasEnv, RawObj, RawVal, RawValType, Tag};
+use super::{xdr::ScObjectType, Env, EnvVal, RawObj, RawVal, RawValType, Tag};
 
 // EnvObj is just an EnvVal that is statically guaranteed (by construction) to
 // refer to a Tag::Object (RawObj), so it's safe to call methods on it that are
@@ -6,8 +6,8 @@ use super::{xdr::ScObjectType, Env, EnvVal, HasEnv, RawObj, RawVal, RawValType, 
 #[derive(Clone)]
 pub struct EnvObj<E: Env>(EnvVal<E>);
 
-impl<E: Env> HasEnv<E> for EnvObj<E> {
-    fn env(&self) -> &E {
+impl<E: Env> EnvObj<E> {
+    pub fn env(&self) -> &E {
         &self.0.env
     }
 }

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -20,9 +20,6 @@ impl<E: Env> HasEnv<E> for EnvVal<E> {
     fn env(&self) -> &E {
         &self.env
     }
-    fn mut_env(&mut self) -> &mut E {
-        &mut self.env
-    }
 }
 
 impl<E: Env> From<EnvVal<E>> for RawVal {

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -3,7 +3,7 @@ use crate::{BitSet, Status, Symbol, Tag};
 use super::{
     raw_val::{RawVal, RawValType},
     xdr::ScObjectType,
-    Env, HasEnv, RawObj,
+    Env, RawObj,
 };
 use core::{cmp::Ordering, fmt::Debug};
 
@@ -16,8 +16,8 @@ pub struct EnvVal<E: Env> {
     pub val: RawVal,
 }
 
-impl<E: Env> HasEnv<E> for EnvVal<E> {
-    fn env(&self) -> &E {
+impl<E: Env> EnvVal<E> {
+    pub fn env(&self) -> &E {
         &self.env
     }
 }

--- a/stellar-contract-env-common/src/has_env.rs
+++ b/stellar-contract-env-common/src/has_env.rs
@@ -2,5 +2,4 @@ use super::Env;
 
 pub trait HasEnv<E: Env> {
     fn env(&self) -> &E;
-    fn mut_env(&mut self) -> &mut E;
 }

--- a/stellar-contract-env-common/src/has_env.rs
+++ b/stellar-contract-env-common/src/has_env.rs
@@ -1,5 +1,0 @@
-use super::Env;
-
-pub trait HasEnv<E: Env> {
-    fn env(&self) -> &E;
-}

--- a/stellar-contract-env-common/src/lib.rs
+++ b/stellar-contract-env-common/src/lib.rs
@@ -4,7 +4,6 @@ mod bitset;
 mod env;
 mod env_obj;
 mod env_val;
-mod has_env;
 mod or_abort;
 mod raw_obj;
 mod raw_val;
@@ -27,7 +26,6 @@ pub use raw_val::{RawVal, RawValType, Tag};
 pub use env::{Env, EnvBase};
 pub use env_obj::EnvObj;
 pub use env_val::{EnvVal, EnvValType};
-pub use has_env::HasEnv;
 
 // BitSet, Status and Symbol wrap RawVals.
 // TODO: maybe these should wrap EnvVals?


### PR DESCRIPTION
### What

Remove HasEnv trait.

### Why

Nothing depends on the trait itself, there are just unrelated implementations that do not interact with each other. The trait doesn't appear to add anything of value, other than introduce another type that downstream code must know about which is inconvenient. We can always add it back if we need it.

### Known limitations

Learning Rust still.
