### PR TITLE
Make Envs passed around refs and clone downstream

### DIFF
--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -65,7 +65,7 @@ impl Host {
 
     pub(crate) fn associate_env_val_type<V: EnvValType>(&self, v: V) -> HostVal {
         let env = self.get_weak();
-        v.into_env_val(env)
+        v.into_env_val(&env)
     }
 
     pub(crate) fn from_host_val(&self, val: RawVal) -> Result<ScVal, ()> {


### PR DESCRIPTION
### What

Make Envs passed around as refs and clone downstream.

### Why

It reduces the clones that need to be littered throughout code upstream. In many other functions like in_env we're passing references and cloning internally. This brings more fns into consistency with this pattern.

### Known limitations

N/A