### PR TITLE
Make ret values RawObj that are guaranteed to be

### DIFF
--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -1,4 +1,4 @@
-use super::RawVal;
+use super::{RawObj, RawVal};
 use core::any;
 
 pub trait EnvBase: Sized + Clone {
@@ -66,40 +66,40 @@ macro_rules! call_macro_with_all_host_functions {
             }
 
             mod u64 "u" {
-                {"$_", fn obj_from_u64(v:u64) -> RawVal }
+                {"$_", fn obj_from_u64(v:u64) -> RawObj }
                 {"$0", fn obj_to_u64(v:RawVal) -> u64 }
             }
 
             mod i64 "i" {
-                {"$_", fn obj_from_i64(v:i64) -> RawVal }
+                {"$_", fn obj_from_i64(v:i64) -> RawObj }
                 {"$0", fn obj_to_i64(v:RawVal) -> i64 }
             }
 
             mod map "m" {
-                {"$_", fn map_new() -> RawVal }
-                {"$0", fn map_put(m:RawVal, k:RawVal, v:RawVal) -> RawVal}
+                {"$_", fn map_new() -> RawObj }
+                {"$0", fn map_put(m:RawVal, k:RawVal, v:RawVal) -> RawObj}
                 {"$1", fn map_get(m:RawVal, k:RawVal) -> RawVal}
-                {"$2", fn map_del(m:RawVal, k:RawVal) -> RawVal}
+                {"$2", fn map_del(m:RawVal, k:RawVal) -> RawObj}
                 {"$3", fn map_len(m:RawVal) -> RawVal}
-                {"$4", fn map_keys(m:RawVal) -> RawVal}
+                {"$4", fn map_keys(m:RawVal) -> RawObj}
                 {"$5", fn map_has(m:RawVal,k:RawVal) -> RawVal}
             }
 
             mod vec "v" {
-                {"$_", fn vec_new() -> RawVal}
-                {"$0", fn vec_put(v:RawVal, i:RawVal, x:RawVal) -> RawVal}
+                {"$_", fn vec_new() -> RawObj}
+                {"$0", fn vec_put(v:RawVal, i:RawVal, x:RawVal) -> RawObj}
                 {"$1", fn vec_get(v:RawVal, i:RawVal) -> RawVal}
-                {"$2", fn vec_del(v:RawVal, i:RawVal) -> RawVal}
+                {"$2", fn vec_del(v:RawVal, i:RawVal) -> RawObj}
                 {"$3", fn vec_len(v:RawVal) -> RawVal}
 
-                {"$4", fn vec_push(v:RawVal, x:RawVal) -> RawVal}
-                {"$5", fn vec_pop(v:RawVal) -> RawVal}
-                {"$6", fn vec_take(v:RawVal, n:RawVal) -> RawVal}
-                {"$7", fn vec_drop(v:RawVal, n:RawVal) -> RawVal}
+                {"$4", fn vec_push(v:RawVal, x:RawVal) -> RawObj}
+                {"$5", fn vec_pop(v:RawVal) -> RawObj}
+                {"$6", fn vec_take(v:RawVal, n:RawVal) -> RawObj}
+                {"$7", fn vec_drop(v:RawVal, n:RawVal) -> RawObj}
                 {"$8", fn vec_front(v:RawVal) -> RawVal}
                 {"$9", fn vec_back(v:RawVal) -> RawVal}
-                {"$A", fn vec_insert(v:RawVal, i:RawVal, x:RawVal) -> RawVal}
-                {"$B", fn vec_append(v1:RawVal, v2:RawVal) -> RawVal}
+                {"$A", fn vec_insert(v:RawVal, i:RawVal, x:RawVal) -> RawObj}
+                {"$B", fn vec_append(v1:RawVal, v2:RawVal) -> RawObj}
             }
 
             mod ledger "l" {
@@ -127,30 +127,30 @@ macro_rules! call_macro_with_all_host_functions {
             }
 
             mod bigint "b" {
-                {"$_", fn bigint_from_u64(x:RawVal) -> RawVal}
-                {"$0", fn bigint_add(x:RawVal,y:RawVal) -> RawVal}
-                {"$1", fn bigint_sub(x:RawVal,y:RawVal) -> RawVal}
-                {"$2", fn bigint_mul(x:RawVal,y:RawVal) -> RawVal}
-                {"$3", fn bigint_div(x:RawVal,y:RawVal) -> RawVal}
-                {"$4", fn bigint_rem(x:RawVal,y:RawVal) -> RawVal}
-                {"$5", fn bigint_and(x:RawVal,y:RawVal) -> RawVal}
-                {"$6", fn bigint_or(x:RawVal,y:RawVal) -> RawVal}
-                {"$7", fn bigint_xor(x:RawVal,y:RawVal) -> RawVal}
-                {"$8", fn bigint_shl(x:RawVal,y:RawVal) -> RawVal}
-                {"$9", fn bigint_shr(x:RawVal,y:RawVal) -> RawVal}
-                {"$A", fn bigint_cmp(x:RawVal,y:RawVal) -> RawVal}
+                {"$_", fn bigint_from_u64(x:RawVal) -> RawObj}
+                {"$0", fn bigint_add(x:RawVal,y:RawVal) -> RawObj}
+                {"$1", fn bigint_sub(x:RawVal,y:RawVal) -> RawObj}
+                {"$2", fn bigint_mul(x:RawVal,y:RawVal) -> RawObj}
+                {"$3", fn bigint_div(x:RawVal,y:RawVal) -> RawObj}
+                {"$4", fn bigint_rem(x:RawVal,y:RawVal) -> RawObj}
+                {"$5", fn bigint_and(x:RawVal,y:RawVal) -> RawObj}
+                {"$6", fn bigint_or(x:RawVal,y:RawVal) -> RawObj}
+                {"$7", fn bigint_xor(x:RawVal,y:RawVal) -> RawObj}
+                {"$8", fn bigint_shl(x:RawVal,y:RawVal) -> RawObj}
+                {"$9", fn bigint_shr(x:RawVal,y:RawVal) -> RawObj}
+                {"$A", fn bigint_cmp(x:RawVal,y:RawVal) -> RawObj}
                 {"$B", fn bigint_is_zero(x:RawVal) -> RawVal}
-                {"$C", fn bigint_neg(x:RawVal) -> RawVal}
-                {"$D", fn bigint_not(x:RawVal) -> RawVal}
-                {"$E", fn bigint_gcd(x:RawVal) -> RawVal}
-                {"$F", fn bigint_lcm(x:RawVal,y:RawVal) -> RawVal}
-                {"$G", fn bigint_pow(x:RawVal,y:RawVal) -> RawVal}
-                {"$H", fn bigint_pow_mod(p:RawVal,q:RawVal,m:RawVal) -> RawVal}
-                {"$I", fn bigint_sqrt(x:RawVal) -> RawVal}
-                {"$J", fn bigint_bits(x:RawVal) -> RawVal}
+                {"$C", fn bigint_neg(x:RawVal) -> RawObj}
+                {"$D", fn bigint_not(x:RawVal) -> RawObj}
+                {"$E", fn bigint_gcd(x:RawVal) -> RawObj}
+                {"$F", fn bigint_lcm(x:RawVal,y:RawVal) -> RawObj}
+                {"$G", fn bigint_pow(x:RawVal,y:RawVal) -> RawObj}
+                {"$H", fn bigint_pow_mod(p:RawVal,q:RawVal,m:RawVal) -> RawObj}
+                {"$I", fn bigint_sqrt(x:RawVal) -> RawObj}
+                {"$J", fn bigint_bits(x:RawVal) -> RawObj}
                 {"$K", fn bigint_to_u64(x:RawVal) -> u64}
                 {"$L", fn bigint_to_i64(x:RawVal) -> i64}
-                {"$M", fn bigint_from_i64(x:i64) -> RawVal}
+                {"$M", fn bigint_from_i64(x:i64) -> RawObj}
             }
         }
     };

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -72,7 +72,7 @@ impl EnvValType for i64 {
         let val = if self >= 0 {
             unsafe { RawVal::unchecked_from_positive_i64(self) }
         } else {
-            env.obj_from_i64(self)
+            env.obj_from_i64(self).into()
         };
         EnvVal {
             env: env.clone(),
@@ -96,7 +96,7 @@ impl EnvValType for u64 {
         let val = if self <= (i64::MAX as u64) {
             unsafe { RawVal::unchecked_from_positive_i64(self as i64) }
         } else {
-            env.obj_from_u64(self)
+            env.obj_from_u64(self).into()
         };
         EnvVal {
             env: env.clone(),

--- a/stellar-contract-env-common/src/raw_obj.rs
+++ b/stellar-contract-env-common/src/raw_obj.rs
@@ -1,4 +1,4 @@
-use super::{xdr::ScObjectType, RawVal, RawValType, Tag};
+use super::{xdr::ScObjectType, Env, EnvObj, RawVal, RawValType, Tag};
 
 // RawObj is just an RawVal that is statically guaranteed (by construction) to refer
 // to Tag::Object, so it's safe to call methods on it that are meaningful to objects.
@@ -58,6 +58,10 @@ impl AsMut<RawVal> for RawObj {
 }
 
 impl RawObj {
+    pub fn in_env<E: Env>(self, env: &E) -> EnvObj<E> {
+        EnvObj::from_raw_obj(env, self)
+    }
+
     // NB: we don't provide a "get_type" to avoid casting a bad bit-pattern into
     // an ScStatusType. Instead we provide an "is_type" to check any specific
     // bit-pattern.

--- a/stellar-contract-env-guest/src/guest.rs
+++ b/stellar-contract-env-guest/src/guest.rs
@@ -3,7 +3,7 @@
 
 use stellar_contract_env_common::call_macro_with_all_host_functions;
 
-use super::{Env, EnvBase, RawVal};
+use super::{Env, EnvBase, RawObj, RawVal};
 
 // In guest code the environment is global/implicit, so is represented as a unit struct.
 #[derive(Copy, Clone, Default)]

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -298,7 +298,7 @@ impl Env for Host {
         }
     }
 
-    fn obj_from_u64(&self, u: u64) -> RawVal {
+    fn obj_from_u64(&self, u: u64) -> RawObj {
         self.add_host_object(u).expect("obj_from_u64").into()
     }
 
@@ -306,7 +306,7 @@ impl Env for Host {
         todo!()
     }
 
-    fn obj_from_i64(&self, i: i64) -> RawVal {
+    fn obj_from_i64(&self, i: i64) -> RawObj {
         self.add_host_object(i).expect("obj_from_i64").into()
     }
 
@@ -314,13 +314,13 @@ impl Env for Host {
         todo!()
     }
 
-    fn map_new(&self) -> RawVal {
+    fn map_new(&self) -> RawObj {
         self.add_host_object(HostMap::new())
             .expect("map_new")
             .into()
     }
 
-    fn map_put(&self, m: RawVal, k: RawVal, v: RawVal) -> RawVal {
+    fn map_put(&self, m: RawVal, k: RawVal, v: RawVal) -> RawObj {
         todo!()
     }
 
@@ -328,7 +328,7 @@ impl Env for Host {
         todo!()
     }
 
-    fn map_del(&self, m: RawVal, k: RawVal) -> RawVal {
+    fn map_del(&self, m: RawVal, k: RawVal) -> RawObj {
         todo!()
     }
 
@@ -336,7 +336,7 @@ impl Env for Host {
         todo!()
     }
 
-    fn map_keys(&self, m: RawVal) -> RawVal {
+    fn map_keys(&self, m: RawVal) -> RawObj {
         todo!()
     }
 
@@ -344,13 +344,13 @@ impl Env for Host {
         todo!()
     }
 
-    fn vec_new(&self) -> RawVal {
+    fn vec_new(&self) -> RawObj {
         self.add_host_object(HostVec::new())
             .expect("vec_new")
             .into()
     }
 
-    fn vec_put(&self, v: RawVal, i: RawVal, x: RawVal) -> RawVal {
+    fn vec_put(&self, v: RawVal, i: RawVal, x: RawVal) -> RawObj {
         todo!()
     }
 
@@ -358,7 +358,7 @@ impl Env for Host {
         todo!()
     }
 
-    fn vec_del(&self, v: RawVal, i: RawVal) -> RawVal {
+    fn vec_del(&self, v: RawVal, i: RawVal) -> RawObj {
         todo!()
     }
 
@@ -377,7 +377,7 @@ impl Env for Host {
             .into()
     }
 
-    fn vec_push(&self, v: RawVal, x: RawVal) -> RawVal {
+    fn vec_push(&self, v: RawVal, x: RawVal) -> RawObj {
         let x = self.associate_raw_val(x);
         let vnew = unsafe {
             self.unchecked_visit_val_obj(v, move |ho| {
@@ -393,15 +393,15 @@ impl Env for Host {
         self.add_host_object(vnew).expect("vec_push").into()
     }
 
-    fn vec_pop(&self, v: RawVal) -> RawVal {
+    fn vec_pop(&self, v: RawVal) -> RawObj {
         todo!()
     }
 
-    fn vec_take(&self, v: RawVal, n: RawVal) -> RawVal {
+    fn vec_take(&self, v: RawVal, n: RawVal) -> RawObj {
         todo!()
     }
 
-    fn vec_drop(&self, v: RawVal, n: RawVal) -> RawVal {
+    fn vec_drop(&self, v: RawVal, n: RawVal) -> RawObj {
         todo!()
     }
 
@@ -413,11 +413,11 @@ impl Env for Host {
         todo!()
     }
 
-    fn vec_insert(&self, v: RawVal, i: RawVal, n: RawVal) -> RawVal {
+    fn vec_insert(&self, v: RawVal, i: RawVal, n: RawVal) -> RawObj {
         todo!()
     }
 
-    fn vec_append(&self, v1: RawVal, v2: RawVal) -> RawVal {
+    fn vec_append(&self, v1: RawVal, v2: RawVal) -> RawObj {
         todo!()
     }
 
@@ -489,51 +489,51 @@ impl Env for Host {
         todo!()
     }
 
-    fn bigint_from_u64(&self, x: RawVal) -> RawVal {
+    fn bigint_from_u64(&self, x: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_add(&self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_add(&self, x: RawVal, y: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_sub(&self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_sub(&self, x: RawVal, y: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_mul(&self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_mul(&self, x: RawVal, y: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_div(&self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_div(&self, x: RawVal, y: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_rem(&self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_rem(&self, x: RawVal, y: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_and(&self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_and(&self, x: RawVal, y: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_or(&self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_or(&self, x: RawVal, y: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_xor(&self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_xor(&self, x: RawVal, y: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_shl(&self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_shl(&self, x: RawVal, y: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_shr(&self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_shr(&self, x: RawVal, y: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_cmp(&self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_cmp(&self, x: RawVal, y: RawVal) -> RawObj {
         todo!()
     }
 
@@ -541,35 +541,35 @@ impl Env for Host {
         todo!()
     }
 
-    fn bigint_neg(&self, x: RawVal) -> RawVal {
+    fn bigint_neg(&self, x: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_not(&self, x: RawVal) -> RawVal {
+    fn bigint_not(&self, x: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_gcd(&self, x: RawVal) -> RawVal {
+    fn bigint_gcd(&self, x: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_lcm(&self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_lcm(&self, x: RawVal, y: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_pow(&self, x: RawVal, y: RawVal) -> RawVal {
+    fn bigint_pow(&self, x: RawVal, y: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_pow_mod(&self, p: RawVal, q: RawVal, m: RawVal) -> RawVal {
+    fn bigint_pow_mod(&self, p: RawVal, q: RawVal, m: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_sqrt(&self, x: RawVal) -> RawVal {
+    fn bigint_sqrt(&self, x: RawVal) -> RawObj {
         todo!()
     }
 
-    fn bigint_bits(&self, x: RawVal) -> RawVal {
+    fn bigint_bits(&self, x: RawVal) -> RawObj {
         todo!()
     }
 
@@ -581,7 +581,7 @@ impl Env for Host {
         todo!()
     }
 
-    fn bigint_from_i64(&self, x: i64) -> RawVal {
+    fn bigint_from_i64(&self, x: i64) -> RawObj {
         todo!()
     }
 }

--- a/stellar-contract-env-host/src/weak_host.rs
+++ b/stellar-contract-env-host/src/weak_host.rs
@@ -1,6 +1,6 @@
 use stellar_contract_env_common::call_macro_with_all_host_functions;
 
-use crate::{host::HostImpl, Env, EnvBase, Host, RawVal};
+use crate::{host::HostImpl, Env, EnvBase, Host, RawObj, RawVal};
 use core::fmt::Debug;
 use std::rc::Weak;
 

--- a/stellar-contract-env-host/tests/integration.rs
+++ b/stellar-contract-env-host/tests/integration.rs
@@ -6,15 +6,28 @@ fn vec_as_seen_by_user() -> Result<(), ()> {
     let int1 = host.obj_from_i64(5).in_env(&host);
 
     let vec1a = host.vec_new().in_env(&host);
-    let vec1b = host.vec_push(vec1a.val, int1.val).in_env(&host);
+    let vec1b = host
+        .vec_push(vec1a.as_ref().val, int1.as_ref().val)
+        .in_env(&host);
 
-    assert_ne!(vec1a.val.get_payload(), vec1b.val.get_payload());
+    assert_ne!(
+        vec1a.as_ref().val.get_payload(),
+        vec1b.as_ref().val.get_payload()
+    );
 
     let vec2a = host.vec_new().in_env(&host);
-    let vec2b = host.vec_push(vec2a.val, int1.val).in_env(&host);
+    let vec2b = host
+        .vec_push(vec2a.as_ref().val, int1.as_ref().val)
+        .in_env(&host);
 
-    assert_ne!(vec2a.val.get_payload(), vec2b.val.get_payload());
-    assert_ne!(vec1b.val.get_payload(), vec2b.val.get_payload());
+    assert_ne!(
+        vec2a.as_ref().val.get_payload(),
+        vec2b.as_ref().val.get_payload()
+    );
+    assert_ne!(
+        vec1b.as_ref().val.get_payload(),
+        vec2b.as_ref().val.get_payload()
+    );
     assert_eq!(vec1a, vec2a);
     assert_eq!(vec1b, vec2b);
     Ok(())
@@ -24,5 +37,5 @@ fn vec_as_seen_by_user() -> Result<(), ()> {
 fn vec_host_fn() {
     let host = Host::default();
     let m = host.map_new();
-    assert!(RawObj::val_is_obj_type(m, ScObjectType::ScoMap));
+    assert!(RawObj::val_is_obj_type(m.into(), ScObjectType::ScoMap));
 }


### PR DESCRIPTION
### What

Make return values `RawObj` that are guaranteed to be that type.

### Why

It simplifies the SDK since the SDK will be assuming the values are RawObj's anyway, and this allows it to do so without unchecked/unsafe blocks of code.

Note that it is important that host fn inputs are only `RawVal`s because the host should not make any assumptions about what the guest has provided as arguments.

### Known limitations

N/A
