### PR TITLE
Shift generic param from EnvValType fns to type

### DIFF
--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -105,7 +105,7 @@ impl Host {
         HostVal { env, val }
     }
 
-    pub(crate) fn associate_env_val_type<V: EnvValType>(&self, v: V) -> HostVal {
+    pub(crate) fn associate_env_val_type<V: EnvValType<WeakHost>>(&self, v: V) -> HostVal {
         let env = self.get_weak();
         v.into_env_val(&env)
     }

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -8,7 +8,7 @@ fn i64_roundtrip() {
     let host = Host::default();
     let i = 12345_i64;
     let v = host.associate_env_val_type(i);
-    let j = <i64 as EnvValType>::try_from_env_val(v).unwrap();
+    let j = i64::try_from_env_val(v).unwrap();
     assert_eq!(i, j);
 }
 


### PR DESCRIPTION
### What

Shift generic param from EnvValType fns to type.

### Why

It lends itself to some better ergonomics in the SDK when implementing EnvValType for SDK types across all Envs values.

### Known limitations

N/A
