### PR TITLE
Use resolver v2 for workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "stellar-contract-env-host",


### PR DESCRIPTION
### What

Use resolver v2 for workspace.

### Why

Cargo uses v2 for individual projects, or for workspaces where the root of the workspace is a module. For "virtual workspaces," which are workspaces that do not contain a crate at the root, v1 is the default. Both versions of Cargo's resolver are problematic (https://github.com/rust-lang/cargo/issues/10636, https://github.com/rust-lang/cargo/issues/4463) because neither consistently build individual crates in a workspace. However, v1 is particularly worse because it will not isolate target specific directives from each other. This means that if you use v1, dependencies that are intended only for an x86 target may be linked into a build that is only targeting wasm32. Even though v2 is not perfect, it will isolate targets properly.

This doesn't cause any problems in this repo today, but it is causing problems in the stellar-contract-sdk, and adding this now will prevent us from having problems like this in the future.

### Known limitations

N/A

fyi @graydon @MonsieurNicolas 