### PR TITLE
Add From<EnvVal<E, TaggedVal<T>>> for RawVal

### DIFF
--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -87,6 +87,12 @@ impl<E: Env> From<EnvVal<E, RawVal>> for RawVal {
     }
 }
 
+impl<E: Env, T: TagType> From<EnvVal<E, TaggedVal<T>>> for RawVal {
+    fn from(ev: EnvVal<E, TaggedVal<T>>) -> Self {
+        ev.val.0
+    }
+}
+
 impl<E: Env, T: TagType> From<EnvVal<E, TaggedVal<T>>> for TaggedVal<T> {
     fn from(ev: EnvVal<E, TaggedVal<T>>) -> Self {
         ev.val


### PR DESCRIPTION
### What

Add `From<EnvVal<E, TaggedVal<T>>>` for `RawVal`.

### Why

So that we can conveniently call `.into()` on an `EnvVal` that contains a `TaggedVal` to convert the value directly into a `RawVal. In situations where we can to move a value into a `RawVal` this is more convenient than using the `.as_ref().clone()` route.

### Known limitations

N/A
