### PR TITLE
Require all Val impls to be Into<RawVal>

### DIFF
--- a/stellar-contract-env-common/src/val.rs
+++ b/stellar-contract-env-common/src/val.rs
@@ -5,7 +5,7 @@
 /// in Rust.
 use crate::{RawVal, TagType, TaggedVal};
 
-pub trait Val: AsRef<RawVal> + AsMut<RawVal> + Clone {}
+pub trait Val: AsRef<RawVal> + AsMut<RawVal> + Into<RawVal> + Clone {}
 
 impl<T: TagType> Val for TaggedVal<T> {}
 impl Val for RawVal {}


### PR DESCRIPTION
### What

Require all `Val` impls to be `Into<RawVal>`.

### Why

Round out expectations to match the fact that they are all `AsRef<RawVal>`.

### Known limitations

N/A
