### PR TITLE
Change Env trait to take mostly refs

### DIFF
--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -60,96 +60,96 @@ macro_rules! call_macro_with_all_host_functions {
             // argument list of comma-separated arg:type pairs
 
             mod context "x" {
-                {"$_", fn log_value(v:RawVal) -> RawVal }
+                {"$_", fn log_value(v:&RawVal) -> RawVal }
                 {"$0", fn get_last_operation_result() -> RawVal }
-                {"$1", fn obj_cmp(a:RawVal, b:RawVal) -> i64 }
+                {"$1", fn obj_cmp(a:&RawVal, b:&RawVal) -> i64 }
             }
 
             mod u64 "u" {
                 {"$_", fn obj_from_u64(v:u64) -> Object }
-                {"$0", fn obj_to_u64(v:RawVal) -> u64 }
+                {"$0", fn obj_to_u64(v:&RawVal) -> u64 }
             }
 
             mod i64 "i" {
                 {"$_", fn obj_from_i64(v:i64) -> Object }
-                {"$0", fn obj_to_i64(v:RawVal) -> i64 }
+                {"$0", fn obj_to_i64(v:&RawVal) -> i64 }
             }
 
             mod map "m" {
                 {"$_", fn map_new() -> Object }
-                {"$0", fn map_put(m:Object, k:RawVal, v:RawVal) -> Object}
-                {"$1", fn map_get(m:Object, k:RawVal) -> RawVal}
-                {"$2", fn map_del(m:Object, k:RawVal) -> Object}
-                {"$3", fn map_len(m:Object) -> RawVal}
-                {"$4", fn map_keys(m:Object) -> Object}
-                {"$5", fn map_has(m:Object,k:RawVal) -> RawVal}
+                {"$0", fn map_put(m:&Object, k:&RawVal, v:&RawVal) -> Object}
+                {"$1", fn map_get(m:&Object, k:&RawVal) -> RawVal}
+                {"$2", fn map_del(m:&Object, k:&RawVal) -> Object}
+                {"$3", fn map_len(m:&Object) -> RawVal}
+                {"$4", fn map_keys(m:&Object) -> Object}
+                {"$5", fn map_has(m:&Object,k:&RawVal) -> RawVal}
             }
 
             mod vec "v" {
                 {"$_", fn vec_new() -> Object}
-                {"$0", fn vec_put(v:Object, i:RawVal, x:RawVal) -> Object}
-                {"$1", fn vec_get(v:Object, i:RawVal) -> RawVal}
-                {"$2", fn vec_del(v:Object, i:RawVal) -> Object}
-                {"$3", fn vec_len(v:Object) -> RawVal}
+                {"$0", fn vec_put(v:&Object, i:&RawVal, x:&RawVal) -> Object}
+                {"$1", fn vec_get(v:&Object, i:&RawVal) -> RawVal}
+                {"$2", fn vec_del(v:&Object, i:&RawVal) -> Object}
+                {"$3", fn vec_len(v:&Object) -> RawVal}
 
-                {"$4", fn vec_push(v:Object, x:RawVal) -> Object}
-                {"$5", fn vec_pop(v:Object) -> Object}
-                {"$6", fn vec_take(v:Object, n:RawVal) -> Object}
-                {"$7", fn vec_drop(v:Object, n:RawVal) -> Object}
-                {"$8", fn vec_front(v:Object) -> RawVal}
-                {"$9", fn vec_back(v:Object) -> RawVal}
-                {"$A", fn vec_insert(v:Object, i:RawVal, x:RawVal) -> Object}
-                {"$B", fn vec_append(v1:Object, v2:Object) -> Object}
+                {"$4", fn vec_push(v:&Object, x:&RawVal) -> Object}
+                {"$5", fn vec_pop(v:&Object) -> Object}
+                {"$6", fn vec_take(v:&Object, n:&RawVal) -> Object}
+                {"$7", fn vec_drop(v:&Object, n:&RawVal) -> Object}
+                {"$8", fn vec_front(v:&Object) -> RawVal}
+                {"$9", fn vec_back(v:&Object) -> RawVal}
+                {"$A", fn vec_insert(v:&Object, i:&RawVal, x:&RawVal) -> Object}
+                {"$B", fn vec_append(v1:&Object, v2:&Object) -> Object}
             }
 
             mod ledger "l" {
                 {"$_", fn get_current_ledger_num() -> RawVal }
                 {"$0", fn get_current_ledger_close_time() -> RawVal}
 
-                {"$1", fn pay(src:RawVal, dst:RawVal, asset:RawVal, amt:RawVal) -> RawVal}
+                {"$1", fn pay(src:&RawVal, dst:&RawVal, asset:&RawVal, amt:&RawVal) -> RawVal}
 
-                {"$2", fn put_contract_data(k:RawVal, v: RawVal) -> RawVal}
-                {"$3", fn has_contract_data(k:RawVal) -> RawVal}
-                {"$4", fn get_contract_data(k:RawVal) -> RawVal}
-                {"$5", fn del_contract_data(k:RawVal) -> RawVal}
+                {"$2", fn put_contract_data(k:&RawVal, v:&RawVal) -> RawVal}
+                {"$3", fn has_contract_data(k:&RawVal) -> RawVal}
+                {"$4", fn get_contract_data(k:&RawVal) -> RawVal}
+                {"$5", fn del_contract_data(k:&RawVal) -> RawVal}
 
-                {"$6", fn account_balance(acct:RawVal) -> RawVal}
-                {"$7", fn account_trust_line(acct:RawVal, asset:RawVal) -> RawVal}
-                {"$8", fn trust_line_balance(tl:RawVal) -> RawVal}
+                {"$6", fn account_balance(acct:&RawVal) -> RawVal}
+                {"$7", fn account_trust_line(acct:&RawVal, asset:&RawVal) -> RawVal}
+                {"$8", fn trust_line_balance(tl:&RawVal) -> RawVal}
             }
 
             mod call "c" {
-                {"$_", fn call0(contract:RawVal,func:RawVal) -> RawVal}
-                {"$0", fn call1(contract:RawVal,func:RawVal,a:RawVal) -> RawVal}
-                {"$1", fn call2(contract:RawVal,func:RawVal,a:RawVal,b:RawVal) -> RawVal}
-                {"$2", fn call3(contract:RawVal,func:RawVal,a:RawVal,b:RawVal,c:RawVal) -> RawVal}
-                {"$3", fn call4(contract:RawVal,func:RawVal,a:RawVal,b:RawVal,c:RawVal,d:RawVal) -> RawVal}
+                {"$_", fn call0(contract:&RawVal,func:&RawVal) -> RawVal}
+                {"$0", fn call1(contract:&RawVal,func:&RawVal,a:&RawVal) -> RawVal}
+                {"$1", fn call2(contract:&RawVal,func:&RawVal,a:&RawVal,b:&RawVal) -> RawVal}
+                {"$2", fn call3(contract:&RawVal,func:&RawVal,a:&RawVal,b:&RawVal,c:&RawVal) -> RawVal}
+                {"$3", fn call4(contract:&RawVal,func:&RawVal,a:&RawVal,b:&RawVal,c:&RawVal,d:&RawVal) -> RawVal}
             }
 
             mod bigint "b" {
-                {"$_", fn bigint_from_u64(x:Object) -> Object}
-                {"$0", fn bigint_add(x:Object,y:Object) -> Object}
-                {"$1", fn bigint_sub(x:Object,y:Object) -> Object}
-                {"$2", fn bigint_mul(x:Object,y:Object) -> Object}
-                {"$3", fn bigint_div(x:Object,y:Object) -> Object}
-                {"$4", fn bigint_rem(x:Object,y:Object) -> Object}
-                {"$5", fn bigint_and(x:Object,y:Object) -> Object}
-                {"$6", fn bigint_or(x:Object,y:Object) -> Object}
-                {"$7", fn bigint_xor(x:Object,y:Object) -> Object}
-                {"$8", fn bigint_shl(x:Object,y:Object) -> Object}
-                {"$9", fn bigint_shr(x:Object,y:Object) -> Object}
-                {"$A", fn bigint_cmp(x:Object,y:Object) -> Object}
-                {"$B", fn bigint_is_zero(x:Object) -> Object}
-                {"$C", fn bigint_neg(x:Object) -> Object}
-                {"$D", fn bigint_not(x:Object) -> Object}
-                {"$E", fn bigint_gcd(x:Object) -> Object}
-                {"$F", fn bigint_lcm(x:Object,y:Object) -> Object}
-                {"$G", fn bigint_pow(x:Object,y:Object) -> Object}
-                {"$H", fn bigint_pow_mod(p:Object,q:Object,m:Object) -> Object}
-                {"$I", fn bigint_sqrt(x:Object) -> Object}
-                {"$J", fn bigint_bits(x:Object) -> Object}
-                {"$K", fn bigint_to_u64(x:Object) -> u64}
-                {"$L", fn bigint_to_i64(x:Object) -> i64}
+                {"$_", fn bigint_from_u64(x:&Object) -> Object}
+                {"$0", fn bigint_add(x:&Object,y:&Object) -> Object}
+                {"$1", fn bigint_sub(x:&Object,y:&Object) -> Object}
+                {"$2", fn bigint_mul(x:&Object,y:&Object) -> Object}
+                {"$3", fn bigint_div(x:&Object,y:&Object) -> Object}
+                {"$4", fn bigint_rem(x:&Object,y:&Object) -> Object}
+                {"$5", fn bigint_and(x:&Object,y:&Object) -> Object}
+                {"$6", fn bigint_or(x:&Object,y:&Object) -> Object}
+                {"$7", fn bigint_xor(x:&Object,y:&Object) -> Object}
+                {"$8", fn bigint_shl(x:&Object,y:&Object) -> Object}
+                {"$9", fn bigint_shr(x:&Object,y:&Object) -> Object}
+                {"$A", fn bigint_cmp(x:&Object,y:&Object) -> Object}
+                {"$B", fn bigint_is_zero(x:&Object) -> Object}
+                {"$C", fn bigint_neg(x:&Object) -> Object}
+                {"$D", fn bigint_not(x:&Object) -> Object}
+                {"$E", fn bigint_gcd(x:&Object) -> Object}
+                {"$F", fn bigint_lcm(x:&Object,y:&Object) -> Object}
+                {"$G", fn bigint_pow(x:&Object,y:&Object) -> Object}
+                {"$H", fn bigint_pow_mod(p:&Object,q:&Object,m:&Object) -> Object}
+                {"$I", fn bigint_sqrt(x:&Object) -> Object}
+                {"$J", fn bigint_bits(x:&Object) -> Object}
+                {"$K", fn bigint_to_u64(x:&Object) -> u64}
+                {"$L", fn bigint_to_i64(x:&Object) -> i64}
                 {"$M", fn bigint_from_i64(x:i64) -> Object}
             }
         }

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -150,7 +150,7 @@ impl<E: Env> EnvValConvertible<E, RawVal> for i64 {
         if ev.val.is_positive_i64() {
             Some(unsafe { ev.val.unchecked_as_positive_i64() })
         } else if Object::val_is_obj_type(ev.val, ScObjectType::ScoI64) {
-            Some(ev.env.obj_to_i64(ev.val))
+            Some(ev.env.obj_to_i64(&ev.val))
         } else {
             None
         }
@@ -174,7 +174,7 @@ impl<E: Env> EnvValConvertible<E, RawVal> for u64 {
         if ev.val.is_positive_i64() {
             Some(unsafe { ev.val.unchecked_as_positive_i64() } as u64)
         } else if Object::val_is_obj_type(ev.val, ScObjectType::ScoU64) {
-            Some(ev.env.obj_to_u64(ev.val))
+            Some(ev.env.obj_to_u64(&ev.val))
         } else {
             None
         }
@@ -204,7 +204,7 @@ impl<E: Env, V: Val> PartialEq for EnvVal<E, V> {
             false
         } else {
             // Slow path: deep object comparison via the environment.
-            let v = self.env.obj_cmp(*self.as_ref(), *other.as_ref());
+            let v = self.env.obj_cmp(self.as_ref(), other.as_ref());
             v == 0
         }
     }
@@ -252,7 +252,7 @@ impl<E: Env, V: Val> Ord for EnvVal<E, V> {
                     .get_body()
                     .cmp(&other.val.as_ref().get_body()),
                 Tag::Object => {
-                    let v = self.env.obj_cmp(*self.val.as_ref(), *other.val.as_ref());
+                    let v = self.env.obj_cmp(self.val.as_ref(), other.val.as_ref());
                     if v == 0 {
                         Ordering::Equal
                     } else if v < 0 {

--- a/stellar-contract-env-host/tests/integration.rs
+++ b/stellar-contract-env-host/tests/integration.rs
@@ -6,7 +6,7 @@ fn vec_as_seen_by_user() -> Result<(), ()> {
     let int1 = host.obj_from_i64(5).in_env(&host);
 
     let vec1a = host.vec_new().in_env(&host);
-    let vec1b = host.vec_push(*vec1a.as_ref(), *int1.as_ref()).in_env(&host);
+    let vec1b = host.vec_push(vec1a.as_ref(), int1.as_ref()).in_env(&host);
 
     assert_ne!(
         vec1a.as_raw_ref().get_payload(),
@@ -14,7 +14,7 @@ fn vec_as_seen_by_user() -> Result<(), ()> {
     );
 
     let vec2a = host.vec_new().in_env(&host);
-    let vec2b = host.vec_push(*vec2a.as_ref(), *int1.as_ref()).in_env(&host);
+    let vec2b = host.vec_push(vec2a.as_ref(), int1.as_ref()).in_env(&host);
 
     assert_ne!(
         vec2a.as_raw_ref().get_payload(),


### PR DESCRIPTION
### What

Change Env trait to take mostly refs/borrows, rather than accept values that are moved into the trait impl.

### Why

@graydon's recent change #45 made it so much more convenient to use `.as_ref()` in many places, but the `Env` interface moves values into itself on most of its fns, so this results in clones in places. Also, the very nature of the concepts being provided by the Env trait really lend themselves to borrowing rather than cloning/copying. Take the vec_append method. There's little reason for it to take ownership of the Vec's passed in because the Vec's are immutable and a new Vec is returned. In concept they are really just being borrowed.

Not all arguments are changed to be references. For example `obj_from_u64` makes little sense to be a reference because it is `Copy`able.

### Known limitations

This change is incomplete. The `Guest` extern fns are being generated with `&` args, but the extern fns need to be i64/u64 values. The extern fn macro helper needs updating to strip the `&` from any values, and at the call site into the extern fn to match the `&arg` args to `*arg`. I haven't figured out how to do this yet.

@graydon Do you see any downsides with doing this? Do you have any ideas how to get the macro to do ☝🏻?