### PR TITLE
Add as_ and to_ fns to EnvVal

### DIFF
--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -22,12 +22,31 @@ impl<E: Env, V: Val> EnvVal<E, V> {
     }
 }
 
-impl<E: Env, T: TagType> EnvVal<E, TaggedVal<T>> {
-    // This just lets callers disambiguate by name when they call as_ref()
-    // in a context that might want &TaggedVal<T> or &RawRef; it saves
-    // them writing <_ as AsRef<RawVal>>::as_ref(foo)
-    pub fn as_raw_ref(&self) -> &RawVal {
+impl<E: Env> EnvVal<E, RawVal> {
+    pub fn as_raw(&self) -> &RawVal {
         self.val.as_ref()
+    }
+    pub fn to_raw(&self) -> RawVal {
+        self.val
+    }
+}
+
+impl<E: Env, T: TagType> EnvVal<E, TaggedVal<T>> {
+    // These fns let callers disambiguate by name when they call as_ref() in a
+    // context that might want &TaggedVal<T> or &RawRef; it saves them writing
+    // <_ as AsRef<RawVal>>::as_ref(foo)
+
+    pub fn as_raw(&self) -> &RawVal {
+        &self.val.0
+    }
+    pub fn to_raw(&self) -> RawVal {
+        self.val.0
+    }
+    pub fn as_tagged(&self) -> &TaggedVal<T> {
+        &self.val
+    }
+    pub fn to_tagged(&self) -> TaggedVal<T> {
+        self.val
     }
 }
 

--- a/stellar-contract-env-host/tests/integration.rs
+++ b/stellar-contract-env-host/tests/integration.rs
@@ -9,20 +9,20 @@ fn vec_as_seen_by_user() -> Result<(), ()> {
     let vec1b = host.vec_push(*vec1a.as_ref(), *int1.as_ref()).in_env(&host);
 
     assert_ne!(
-        vec1a.as_raw_ref().get_payload(),
-        vec1b.as_raw_ref().get_payload()
+        vec1a.as_raw().get_payload(),
+        vec1b.as_raw().get_payload()
     );
 
     let vec2a = host.vec_new().in_env(&host);
     let vec2b = host.vec_push(*vec2a.as_ref(), *int1.as_ref()).in_env(&host);
 
     assert_ne!(
-        vec2a.as_raw_ref().get_payload(),
-        vec2b.as_raw_ref().get_payload()
+        vec2a.as_raw().get_payload(),
+        vec2b.as_raw().get_payload()
     );
     assert_ne!(
-        vec1b.as_raw_ref().get_payload(),
-        vec2b.as_raw_ref().get_payload()
+        vec1b.as_raw().get_payload(),
+        vec2b.as_raw().get_payload()
     );
     assert_eq!(vec1a, vec2a);
     assert_eq!(vec1b, vec2b);

--- a/stellar-contract-env-host/tests/integration.rs
+++ b/stellar-contract-env-host/tests/integration.rs
@@ -8,22 +8,13 @@ fn vec_as_seen_by_user() -> Result<(), ()> {
     let vec1a = host.vec_new().in_env(&host);
     let vec1b = host.vec_push(*vec1a.as_ref(), *int1.as_ref()).in_env(&host);
 
-    assert_ne!(
-        vec1a.as_raw().get_payload(),
-        vec1b.as_raw().get_payload()
-    );
+    assert_ne!(vec1a.as_raw().get_payload(), vec1b.as_raw().get_payload());
 
     let vec2a = host.vec_new().in_env(&host);
     let vec2b = host.vec_push(*vec2a.as_ref(), *int1.as_ref()).in_env(&host);
 
-    assert_ne!(
-        vec2a.as_raw().get_payload(),
-        vec2b.as_raw().get_payload()
-    );
-    assert_ne!(
-        vec1b.as_raw().get_payload(),
-        vec2b.as_raw().get_payload()
-    );
+    assert_ne!(vec2a.as_raw().get_payload(), vec2b.as_raw().get_payload());
+    assert_ne!(vec1b.as_raw().get_payload(), vec2b.as_raw().get_payload());
     assert_eq!(vec1a, vec2a);
     assert_eq!(vec1b, vec2b);
     Ok(())


### PR DESCRIPTION
### What

Add `as_` and `to_` fns to `EnvVal`. Also, remove the `_ref` suffix from the existing `as_` fns.

### Why

The `as_` and `to_` fns are helpful in situations where the trait is ambiguous, and having all the different variations makes the API feel more complete and accessible.

The `_ref` is unnecessary on the tail of the `as_` functions, since the convention is that `as_` fns return borrowed values, and so the ref is implied.

See this link for the conventions:
https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv

### Known limitations

N/A