### PR TITLE
Add TryFrom<EnvVal<_,RawVal>> for TaggedVal<_>/EnvVal<_,TaggedVal<_>>

### DIFF
--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -106,6 +106,23 @@ impl<E: Env> From<EnvVal<E, RawVal>> for RawVal {
     }
 }
 
+impl<E: Env, T: TagType> TryFrom<EnvVal<E, RawVal>> for TaggedVal<T> {
+    type Error = ();
+
+    fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
+        Ok(ev.to_raw().try_into()?)
+    }
+}
+
+impl<E: Env, T: TagType> TryFrom<EnvVal<E, RawVal>> for EnvVal<E, TaggedVal<T>> {
+    type Error = ();
+
+    fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
+        let tv: TaggedVal<T> = ev.to_raw().try_into()?;
+        Ok(tv.in_env(ev.env()))
+    }
+}
+
 impl<E: Env, T: TagType> From<EnvVal<E, TaggedVal<T>>> for RawVal {
     fn from(ev: EnvVal<E, TaggedVal<T>>) -> Self {
         ev.val.0


### PR DESCRIPTION
### What

Add `TryFrom<EnvVal<_,RawVal>>` for `TaggedVal<_>` and `EnvVal<_,TaggedVal<_>>`.

### Why

For convenient conversions from `EnvVal`s containing `RawVal`s into `TaggedVal`s and their `EnvVal` variant.

### Known limitations

N/A
