### PR TITLE
Split EnvValConvertible into Into<EnvVal>, IntoEnvVal, TryFrom<EnvVal>

### DIFF
--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -96,12 +96,11 @@ pub trait EnvValConvertible<E: Env, V: Val>:
     fn into_val(self, env: &E) -> V {
         Self::into_env_val(self, env).val
     }
-    fn try_from_val(env: &E, v: V) -> Option<Self> {
+    fn try_from_val(env: &E, v: V) -> Result<Self, Self::Error> {
         Self::try_from(EnvVal {
             env: env.clone(),
             val: v,
         })
-        .ok()
     }
 }
 

--- a/stellar-contract-env-common/src/lib.rs
+++ b/stellar-contract-env-common/src/lib.rs
@@ -32,7 +32,7 @@ pub use val::Val;
 // RawVal and EnvObj couple raw types to environments.
 pub use checked_env::CheckedEnv;
 pub use env::{Env, EnvBase};
-pub use env_val::{EnvVal, EnvValConvertible};
+pub use env_val::{EnvVal, EnvValConvertible, IntoEnvVal};
 pub use unimplemented_env::UnimplementedEnv;
 
 // BitSet, Status and Symbol wrap RawVals.

--- a/stellar-contract-env-common/src/raw_val.rs
+++ b/stellar-contract-env-common/src/raw_val.rs
@@ -95,6 +95,13 @@ macro_rules! declare_tryfrom {
                 }
             }
         }
+        impl<E: Env> TryFrom<EnvVal<E, RawVal>> for $T {
+            type Error = ();
+            #[inline(always)]
+            fn try_from(v: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
+                Self::try_from(v.to_raw())
+            }
+        }
     };
 }
 

--- a/stellar-contract-env-common/src/raw_val.rs
+++ b/stellar-contract-env-common/src/raw_val.rs
@@ -1,4 +1,4 @@
-use super::{Env, EnvVal, Symbol};
+use super::{Env, EnvVal, IntoEnvVal, Symbol};
 use core::fmt::Debug;
 
 extern crate static_assertions as sa;
@@ -100,6 +100,14 @@ macro_rules! declare_tryfrom {
             #[inline(always)]
             fn try_from(v: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
                 Self::try_from(v.to_raw())
+            }
+        }
+        impl<E: Env> IntoEnvVal<E, RawVal> for $T {
+            fn into_env_val(self, env: &E) -> EnvVal<E, RawVal> {
+                EnvVal {
+                    env: env.clone(),
+                    val: self.into(),
+                }
             }
         }
     };

--- a/stellar-contract-env-common/src/tagged_val.rs
+++ b/stellar-contract-env-common/src/tagged_val.rs
@@ -1,5 +1,6 @@
 use crate::Env;
 use crate::EnvVal;
+use crate::IntoEnvVal;
 /// TaggedVal and TaggedEnvVal are a RawVal and EnvVal wrappers that are statically known to be of a specific tag-case.
 /// Additional tag-case-specific methods can be hung off such a value, while still allowing access
 /// to its inner RawVal/EnvVal using AsRef/AsMut.
@@ -90,6 +91,21 @@ macro_rules! impl_tagged_from {
         impl From<$fromty> for TaggedVal<$tagty> {
             fn from(x: $fromty) -> Self {
                 Self(x.into(), PhantomData)
+            }
+        }
+        impl<E: Env> TryFrom<EnvVal<E, TaggedVal<$tagty>>> for $fromty {
+            type Error = ();
+            #[inline(always)]
+            fn try_from(v: EnvVal<E, TaggedVal<$tagty>>) -> Result<Self, Self::Error> {
+                Self::try_from(v.to_raw())
+            }
+        }
+        impl<E: Env> IntoEnvVal<E, TaggedVal<$tagty>> for $fromty {
+            fn into_env_val(self, env: &E) -> EnvVal<E, TaggedVal<$tagty>> {
+                EnvVal {
+                    env: env.clone(),
+                    val: self.into(),
+                }
             }
         }
     };

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -16,8 +16,8 @@ use std::rc::Rc;
 use crate::host_object::{HostMap, HostObj, HostObject, HostObjectType, HostVal, HostVec};
 use crate::CheckedEnv;
 use crate::{
-    BitSet, BitSetError, EnvBase, EnvValConvertible, Object, RawVal, RawValConvertible, Status,
-    Symbol, SymbolError, Tag, Val,
+    BitSet, BitSetError, EnvBase, EnvValConvertible, IntoEnvVal, Object, RawVal, RawValConvertible,
+    Status, Symbol, SymbolError, Tag, Val,
 };
 
 use thiserror::Error;

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -1,6 +1,6 @@
 use crate::{
     xdr::{ScObject, ScObjectType, ScVal, ScVec},
-    EnvValConvertible, Host, Object, OrAbort,
+    Host, IntoEnvVal, Object, OrAbort,
 };
 
 #[test]
@@ -8,7 +8,7 @@ fn i64_roundtrip() {
     let host = Host::default();
     let i = 12345_i64;
     let v = i.into_env_val(&host);
-    let j = i64::try_from_env_val(&v).unwrap();
+    let j = i64::try_from(v).unwrap();
     assert_eq!(i, j);
 }
 


### PR DESCRIPTION
### What

Make `EnvValConvertible` blanket impl:

- `IntoEnvVal`, which is blanket impl for all `Into<EnvVal>`
- `TryFrom<EnvVal>`

And add explicit `IntoEnvVal` impls for all `RawVal`s and `TaggedVal`s.

### Why

I noticed that in the SDK I was implementing both TryFrom and EnvValConvertible with the same logic for types. We should just ask types to implement each fn once, and EnvValConvertible can rely on the presence of the TryFrom when going from EnvVal to an impl of EnvValConvertible since the entire value, including the Env, is held in a single value. All types should be able to provide a TryFrom in this direction.

I also noticed that most types in the SDK are going to be able to impl the reverse by simply implementing `Into<EnvVal>`.

Overall this simplifies the SDK because we can use a blanket impl to provide the `EnvValConvertible` for types implementing the `Into` and `TryFrom`.

There is a small increased code for `RawVal` and `TaggedVal` as each have to manually impl `IntoEnvVal`, and `TryFrom`, but that is not a big deal considering they are both limited to a small number of types that will not change or grow. Unlikely the SDK that is likely to have many new types.

### Known limitations

We used Option<> on the EnvValConvertible type, or RawValConvertible type, because it saved like 1 byte of code size. By introducing From's into the path I think we omit that saving, but we are using the From trait in so many places I think we're probably splitting hairs worrying about this level of optimization and it'll be lost in the noise of other things anyway.