### PR TITLE
Change bigint_sh* fns to i32/RawVal shift arg

### DIFF
--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -136,8 +136,8 @@ macro_rules! call_macro_with_all_host_functions {
                 {"$5", fn bigint_and(x:Object,y:Object) -> Object}
                 {"$6", fn bigint_or(x:Object,y:Object) -> Object}
                 {"$7", fn bigint_xor(x:Object,y:Object) -> Object}
-                {"$8", fn bigint_shl(x:Object,y:Object) -> Object}
-                {"$9", fn bigint_shr(x:Object,y:Object) -> Object}
+                {"$8", fn bigint_shl(x:Object,y:RawVal) -> Object}
+                {"$9", fn bigint_shr(x:Object,y:RawVal) -> Object}
                 {"$A", fn bigint_cmp(x:Object,y:Object) -> Object}
                 {"$B", fn bigint_is_zero(x:Object) -> Object}
                 {"$C", fn bigint_neg(x:Object) -> Object}

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -575,11 +575,11 @@ impl CheckedEnv for Host {
         todo!()
     }
 
-    fn bigint_shl(&self, x: Object, y: Object) -> Result<Object, HostError> {
+    fn bigint_shl(&self, x: Object, y: RawVal) -> Result<Object, HostError> {
         todo!()
     }
 
-    fn bigint_shr(&self, x: Object, y: Object) -> Result<Object, HostError> {
+    fn bigint_shr(&self, x: Object, y: RawVal) -> Result<Object, HostError> {
         todo!()
     }
 


### PR DESCRIPTION
### What

Change `bigint_sh*` fns to `i32`/`RawVal` shift arg.

### Why

In the words of @graydon, if anyone has more bits than that to shift, they're in trouble resource wise.

### Known limitations

N/A
