### PR TITLE
Change types of some BigInt fns

### DIFF
--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -127,7 +127,7 @@ macro_rules! call_macro_with_all_host_functions {
             }
 
             mod bigint "b" {
-                {"$_", fn bigint_from_u64(x:Object) -> Object}
+                {"$_", fn bigint_from_u64(x:u64) -> Object}
                 {"$0", fn bigint_add(x:Object,y:Object) -> Object}
                 {"$1", fn bigint_sub(x:Object,y:Object) -> Object}
                 {"$2", fn bigint_mul(x:Object,y:Object) -> Object}
@@ -138,8 +138,8 @@ macro_rules! call_macro_with_all_host_functions {
                 {"$7", fn bigint_xor(x:Object,y:Object) -> Object}
                 {"$8", fn bigint_shl(x:Object,y:RawVal) -> Object}
                 {"$9", fn bigint_shr(x:Object,y:RawVal) -> Object}
-                {"$A", fn bigint_cmp(x:Object,y:Object) -> Object}
-                {"$B", fn bigint_is_zero(x:Object) -> Object}
+                {"$A", fn bigint_cmp(x:Object,y:Object) -> RawVal}
+                {"$B", fn bigint_is_zero(x:Object) -> RawVal}
                 {"$C", fn bigint_neg(x:Object) -> Object}
                 {"$D", fn bigint_not(x:Object) -> Object}
                 {"$E", fn bigint_gcd(x:Object) -> Object}
@@ -147,7 +147,7 @@ macro_rules! call_macro_with_all_host_functions {
                 {"$G", fn bigint_pow(x:Object,y:Object) -> Object}
                 {"$H", fn bigint_pow_mod(p:Object,q:Object,m:Object) -> Object}
                 {"$I", fn bigint_sqrt(x:Object) -> Object}
-                {"$J", fn bigint_bits(x:Object) -> Object}
+                {"$J", fn bigint_bits(x:Object) -> RawVal}
                 {"$K", fn bigint_to_u64(x:Object) -> u64}
                 {"$L", fn bigint_to_i64(x:Object) -> i64}
                 {"$M", fn bigint_from_i64(x:i64) -> Object}

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -539,7 +539,7 @@ impl CheckedEnv for Host {
         todo!()
     }
 
-    fn bigint_from_u64(&self, x: Object) -> Result<Object, HostError> {
+    fn bigint_from_u64(&self, x: u64) -> Result<Object, HostError> {
         todo!()
     }
 
@@ -583,11 +583,11 @@ impl CheckedEnv for Host {
         todo!()
     }
 
-    fn bigint_cmp(&self, x: Object, y: Object) -> Result<Object, HostError> {
+    fn bigint_cmp(&self, x: Object, y: Object) -> Result<RawVal, HostError> {
         todo!()
     }
 
-    fn bigint_is_zero(&self, x: Object) -> Result<Object, HostError> {
+    fn bigint_is_zero(&self, x: Object) -> Result<RawVal, HostError> {
         todo!()
     }
 
@@ -619,7 +619,7 @@ impl CheckedEnv for Host {
         todo!()
     }
 
-    fn bigint_bits(&self, x: Object) -> Result<Object, HostError> {
+    fn bigint_bits(&self, x: Object) -> Result<RawVal, HostError> {
         todo!()
     }
 


### PR DESCRIPTION
### What

Change types of some BigInt fns from Object to RawVal or builtins.

### Why

The values are not objects and are either i32's encoded in RawVals, or they are i64/u64 that can be transmitted over the boundary as they are.

### Known limitations

N/A

cc @graydon @jayz22 