### PR TITLE
Fix BigInt gcd fn

### DIFF
--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -142,7 +142,7 @@ macro_rules! call_macro_with_all_host_functions {
                 {"$B", fn bigint_is_zero(x:Object) -> RawVal}
                 {"$C", fn bigint_neg(x:Object) -> Object}
                 {"$D", fn bigint_not(x:Object) -> Object}
-                {"$E", fn bigint_gcd(x:Object) -> Object}
+                {"$E", fn bigint_gcd(x:Object,y:Object) -> Object}
                 {"$F", fn bigint_lcm(x:Object,y:Object) -> Object}
                 {"$G", fn bigint_pow(x:Object,y:Object) -> Object}
                 {"$H", fn bigint_pow_mod(p:Object,q:Object,m:Object) -> Object}

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -599,7 +599,7 @@ impl CheckedEnv for Host {
         todo!()
     }
 
-    fn bigint_gcd(&self, x: Object) -> Result<Object, HostError> {
+    fn bigint_gcd(&self, x: Object, y: Object) -> Result<Object, HostError> {
         todo!()
     }
 


### PR DESCRIPTION
### What

Change arguments to BigInt gcd fn to take a second BigInt.

### Why

The gcd fn finds the greater common divisor of two BigInts.

### Known limitations

N/A

cc @graydon @jayz22 
