### PR TITLE
Rename VM to Vm

### DIFF
--- a/stellar-contract-env-host/src/lib.rs
+++ b/stellar-contract-env-host/src/lib.rs
@@ -5,7 +5,7 @@ pub(crate) mod weak_host;
 #[cfg(feature = "vm")]
 pub mod vm;
 #[cfg(feature = "vm")]
-pub use vm::VM;
+pub use vm::Vm;
 #[cfg(test)]
 mod test;
 

--- a/stellar-contract-env-host/src/vm.rs
+++ b/stellar-contract-env-host/src/vm.rs
@@ -109,11 +109,11 @@ impl ImportResolver for Host {
 //
 // Any lookups on any tables other than import functions will fail, and only
 // those import functions listed above will succeed.
-pub struct VM {
+pub struct Vm {
     instance: ModuleRef, // this is a cloneable Rc<ModuleInstance>
 }
 
-impl VM {
+impl Vm {
     pub fn new(host: &Host, module_wasm_code: &[u8]) -> Result<Self, Box<dyn Error>> {
         let module = Module::from_buffer(module_wasm_code)?;
         module.deny_floating_point()?;


### PR DESCRIPTION
### What

Rename `VM` to `Vm`.

### Why

Editors like VSCode think the `VM` type is a constant or static if it is all capitalized, because Rust naming conventions reserve all caps for consts and statics. The conventions say to only capitalize the first letter of words in type names and to treat acronyms as a single word where only the first letter is capitalized. https://rust-lang.github.io/api-guidelines/naming.html

### Known limitations

N/A
