### PR TITLE
Mark HostImpl as RefUnwindSafe

### DIFF
--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -4,6 +4,7 @@
 use core::cell::RefCell;
 use core::cmp::Ordering;
 use core::fmt::Debug;
+use core::panic::RefUnwindSafe;
 use im_rc::{OrdMap, Vector};
 use std::num::TryFromIntError;
 
@@ -58,6 +59,8 @@ impl From<BitSetError> for HostError {
 pub(crate) struct HostImpl {
     objects: RefCell<Vec<HostObject>>,
 }
+
+impl RefUnwindSafe for HostImpl {}
 
 // Host is a newtype on Rc<HostImpl> so we can impl Env for it below.
 #[derive(Default, Clone)]


### PR DESCRIPTION
### What

Mark `HostImpl` as `RefUnwindSafe`.

### Why

I'm writing a test in the sdk that involves having a contract panic, and I want to assert on that panic, which means I need to use the `panic::catch_unwind`. The compiler is erroring telling me that the `HostImpl` type prevents the unwind:
```
   --> examples/proptest/src/lib.rs:40:31
    |
40  |                     let res = panic::catch_unwind(|| {
    |                               ^^^^^^^^^^^^^^^^^^^ `UnsafeCell<std::vec::Vec<stellar_contract_env_host::host_object::HostObject>>` may contain interior mutability and a reference may not be safely transferrable across a catch_unwind boundary
    |
    = help: within `stellar_contract_env_host::host::HostImpl`, the trait `RefUnwindSafe` is not implemented for `UnsafeCell<std::vec::Vec<stellar_contract_env_host::host_object::HostObject>>`
    = note: required because it appears within the type `RefCell<std::vec::Vec<stellar_contract_env_host::host_object::HostObject>>`
    = note: required because it appears within the type `stellar_contract_env_host::host::HostImpl`
    = note: required because of the requirements on the impl of `RefUnwindSafe` for `Rc<stellar_contract_env_host::host::HostImpl>`
    = note: required because it appears within the type `stellar_contract_env_host::host::Host`
    = note: required because of the requirements on the impl of `UnwindSafe` for `&stellar_contract_env_host::host::Host`
    = note: required because it appears within the type `[closure@examples/proptest/src/lib.rs:40:51: 42:22]`
note: required by a bound in `catch_unwind`
   --> /Users/leighmcculloch/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:136:40
    |
136 | pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(f: F) -> Result<R> {
    |                                        ^^^^^^^^^^ required by this bound in `catch_unwind`
```

### Known limitations

Even after reading docs it is unclear to me if there are any undesirable side-effects of marking the type with this trait.
