### PR TITLE
Move into_val from EnvValConvertible to IntoEnvVal

### DIFF
--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -85,6 +85,9 @@ impl<E: Env, T: TagType> From<EnvVal<E, TaggedVal<T>>> for EnvVal<E, RawVal> {
 
 pub trait IntoEnvVal<E: Env, V: Val>: Sized {
     fn into_env_val(self, env: &E) -> EnvVal<E, V>;
+    fn into_val(self, env: &E) -> V {
+        Self::into_env_val(self, env).val
+    }
 }
 
 // EnvValConvertible is similar to RawValConvertible but also covers types with conversions
@@ -93,9 +96,6 @@ pub trait IntoEnvVal<E: Env, V: Val>: Sized {
 pub trait EnvValConvertible<E: Env, V: Val>:
     Sized + IntoEnvVal<E, V> + TryFrom<EnvVal<E, V>>
 {
-    fn into_val(self, env: &E) -> V {
-        Self::into_env_val(self, env).val
-    }
     fn try_from_val(env: &E, v: V) -> Result<Self, Self::Error> {
         Self::try_from(EnvVal {
             env: env.clone(),

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -85,16 +85,21 @@ impl<E: Env, T: TagType> From<EnvVal<E, TaggedVal<T>>> for EnvVal<E, RawVal> {
 
 pub trait IntoEnvVal<E: Env, V: Val>: Sized {
     fn into_env_val(self, env: &E) -> EnvVal<E, V>;
+}
+
+pub trait IntoVal<E: Env, V: Val>: IntoEnvVal<E, V> {
     fn into_val(self, env: &E) -> V {
         Self::into_env_val(self, env).val
     }
 }
 
+impl<E: Env, V: Val, T> IntoVal<E, V> for T where T: IntoEnvVal<E, V> {}
+
 // EnvValConvertible is similar to RawValConvertible but also covers types with conversions
 // that need an Env to help with the conversion -- those that might require allocating an Object. ValType
 // covers types that can always be directly converted to Val with no Env.
 pub trait EnvValConvertible<E: Env, V: Val>:
-    Sized + IntoEnvVal<E, V> + TryFrom<EnvVal<E, V>>
+    Sized + IntoEnvVal<E, V> + IntoVal<E, V> + TryFrom<EnvVal<E, V>>
 {
     fn try_from_val(env: &E, v: V) -> Result<Self, Self::Error> {
         Self::try_from(EnvVal {

--- a/stellar-contract-env-common/src/lib.rs
+++ b/stellar-contract-env-common/src/lib.rs
@@ -32,7 +32,7 @@ pub use val::Val;
 // RawVal and EnvObj couple raw types to environments.
 pub use checked_env::CheckedEnv;
 pub use env::{Env, EnvBase};
-pub use env_val::{EnvVal, EnvValConvertible, IntoEnvVal};
+pub use env_val::{EnvVal, EnvValConvertible, IntoEnvVal, IntoVal};
 pub use unimplemented_env::UnimplementedEnv;
 
 // BitSet, Status and Symbol wrap RawVals.

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -105,7 +105,7 @@ impl Host {
         HostVal { env, val }
     }
 
-    pub(crate) fn associate_env_val_type<V: Val, CVT: EnvValConvertible<WeakHost, RawVal>>(
+    pub(crate) fn associate_env_val_type<V: Val, CVT: IntoEnvVal<WeakHost, RawVal>>(
         &self,
         v: CVT,
     ) -> HostVal {

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -16,8 +16,8 @@ use std::rc::Rc;
 use crate::host_object::{HostMap, HostObj, HostObject, HostObjectType, HostVal, HostVec};
 use crate::CheckedEnv;
 use crate::{
-    BitSet, BitSetError, EnvBase, EnvValConvertible, IntoEnvVal, Object, RawVal, RawValConvertible,
-    Status, Symbol, SymbolError, Tag, Val,
+    BitSet, BitSetError, EnvBase, IntoEnvVal, Object, RawVal, RawValConvertible, Status, Symbol,
+    SymbolError, Tag, Val,
 };
 
 use thiserror::Error;


### PR DESCRIPTION
### What

Move `into_val` from `EnvValConvertible` to `IntoEnvVal`.

### Why

The fns only dependency is on `IntoEnvVal`, and so it could live in that trait and be available on all impls of that trait independent of the `EnvValConvertible`, so I think it belongs there. It simplifies call sites that do not need to depend on the full convertible and that can specify their constaints as only the into trait.

### Known limitations

[TODO or N/A]
