### PR TITLE
Undo change that increased wasm size

### DIFF
--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -165,7 +165,7 @@ impl<E: Env> TryFrom<EnvVal<E, RawVal>> for i64 {
     fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
         if ev.val.is_positive_i64() {
             Ok(unsafe { ev.val.unchecked_as_positive_i64() })
-        } else if Object::val_is_obj_type(ev.val, stellar_xdr::ScObjectType::I64) {
+        } else if Object::val_is_obj_type(ev.val, SObjectType::I64) {
             let obj = unsafe { Object::unchecked_from_val(ev.val) };
             Ok(ev.env.obj_to_i64(obj))
         } else {
@@ -194,7 +194,7 @@ impl<E: Env> TryFrom<EnvVal<E, RawVal>> for u64 {
     fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
         if ev.val.is_positive_i64() {
             Ok(unsafe { ev.val.unchecked_as_positive_i64() } as u64)
-        } else if Object::val_is_obj_type(ev.val, stellar_xdr::ScObjectType::U64) {
+        } else if Object::val_is_obj_type(ev.val, ScObjectType::U64) {
             let obj = unsafe { Object::unchecked_from_val(ev.val) };
             Ok(ev.env.obj_to_u64(obj))
         } else {

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -165,7 +165,7 @@ impl<E: Env> TryFrom<EnvVal<E, RawVal>> for i64 {
     fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
         if ev.val.is_positive_i64() {
             Ok(unsafe { ev.val.unchecked_as_positive_i64() })
-        } else if Object::val_is_obj_type(ev.val, SObjectType::I64) {
+        } else if Object::val_is_obj_type(ev.val, ScObjectType::I64) {
             let obj = unsafe { Object::unchecked_from_val(ev.val) };
             Ok(ev.env.obj_to_i64(obj))
         } else {

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -1,3 +1,5 @@
+use stellar_xdr::ScObjectType;
+
 use crate::{BitSet, Object, Status, Symbol, Tag, TagType, TaggedVal, Val};
 
 use super::{
@@ -163,9 +165,11 @@ impl<E: Env> TryFrom<EnvVal<E, RawVal>> for i64 {
     fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
         if ev.val.is_positive_i64() {
             Ok(unsafe { ev.val.unchecked_as_positive_i64() })
+        } else if Object::val_is_obj_type(ev.val, stellar_xdr::ScObjectType::I64) {
+            let obj = unsafe { Object::unchecked_from_val(ev.val) };
+            Ok(ev.env.obj_to_i64(obj))
         } else {
-            let ev: EnvVal<E, Object> = ev.try_into()?;
-            Ok(ev.env.obj_to_i64(ev.val))
+            Err(())
         }
     }
 }
@@ -190,9 +194,11 @@ impl<E: Env> TryFrom<EnvVal<E, RawVal>> for u64 {
     fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
         if ev.val.is_positive_i64() {
             Ok(unsafe { ev.val.unchecked_as_positive_i64() } as u64)
+        } else if Object::val_is_obj_type(ev.val, stellar_xdr::ScObjectType::U64) {
+            let obj = unsafe { Object::unchecked_from_val(ev.val) };
+            Ok(ev.env.obj_to_u64(obj))
         } else {
-            let ev: EnvVal<E, Object> = ev.try_into()?;
-            Ok(ev.env.obj_to_u64(ev.val))
+            Err(())
         }
     }
 }


### PR DESCRIPTION
### What

Undo the recent change where we used try_into between RawVal and TaggedVal inside the i64 conversion fn.

### Why

It increased the size of the wasm by 20-30 bytes per invocation. 

### Known limitations

It's unclear why.
