### PR TITLE
Change in_env to move

### DIFF
--- a/stellar-contract-env-common/src/raw_val.rs
+++ b/stellar-contract-env-common/src/raw_val.rs
@@ -221,10 +221,10 @@ impl From<i32> for RawVal {
 }
 
 impl RawVal {
-    pub fn in_env<E: Env>(&self, env: &E) -> EnvVal<E, RawVal> {
+    pub fn in_env<E: Env>(self, env: &E) -> EnvVal<E, RawVal> {
         EnvVal {
             env: env.clone(),
-            val: *self,
+            val: self,
         }
     }
 

--- a/stellar-contract-env-common/src/tagged_val.rs
+++ b/stellar-contract-env-common/src/tagged_val.rs
@@ -66,10 +66,10 @@ impl<T: TagType> AsMut<RawVal> for TaggedVal<T> {
 }
 
 impl<T: TagType> TaggedVal<T> {
-    pub fn in_env<E: Env>(&self, env: &E) -> EnvVal<E, Self> {
+    pub fn in_env<E: Env>(self, env: &E) -> EnvVal<E, Self> {
         EnvVal {
             env: env.clone(),
-            val: *self,
+            val: self,
         }
     }
 


### PR DESCRIPTION
### What

Change in_env to move.

### Why

The fact we used a ref for self here is probably a mistake since this fn is taking a value and wrapping it into a new thing.

### Known limitations

This doesn't really matter.