### PR TITLE
Remove old panic_handler feature

### DIFF
--- a/stellar-contract-env-common/Cargo.toml
+++ b/stellar-contract-env-common/Cargo.toml
@@ -14,5 +14,4 @@ wasmi = { version = "0.11.0", optional = true }
 
 [features]
 std = ["stellar-xdr/std"]
-panic_handler = []
 vm = ["wasmi"]

--- a/stellar-contract-env-guest/Cargo.toml
+++ b/stellar-contract-env-guest/Cargo.toml
@@ -5,6 +5,3 @@ edition = "2021"
 
 [dependencies]
 stellar-contract-env-common = { path = "../stellar-contract-env-common" }
-
-[features]
-panic_handler = ["stellar-contract-env-common/panic_handler"]


### PR DESCRIPTION
### What

Remove old panic_handler feature.

### Why

The panic handler was moved into its own crate that the sdk only depends on in the wasm builds. This is simpler to manage with Cargo than having a multi-crate deep feature.

### Known limitations

N/A
