### PR TITLE
Reserve pos i64 type for i64 typed values

### DIFF
--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -192,9 +192,7 @@ impl<E: Env> TryFrom<EnvVal<E, RawVal>> for u64 {
     type Error = ();
 
     fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
-        if ev.val.is_positive_i64() {
-            Ok(unsafe { ev.val.unchecked_as_positive_i64() } as u64)
-        } else if Object::val_is_obj_type(ev.val, ScObjectType::U64) {
+        if Object::val_is_obj_type(ev.val, ScObjectType::U64) {
             let obj = unsafe { Object::unchecked_from_val(ev.val) };
             Ok(ev.env.obj_to_u64(obj))
         } else {
@@ -205,14 +203,10 @@ impl<E: Env> TryFrom<EnvVal<E, RawVal>> for u64 {
 
 impl<E: Env> IntoEnvVal<E, RawVal> for u64 {
     fn into_env_val(self, env: &E) -> EnvVal<E, RawVal> {
-        let val = if self <= (i64::MAX as u64) {
-            unsafe { RawVal::unchecked_from_positive_i64(self as i64) }
-        } else {
-            env.obj_from_u64(self).as_ref().clone()
-        };
+        let env = env.clone();
         EnvVal {
-            env: env.clone(),
-            val,
+            val: env.obj_from_u64(self).as_ref().clone(),
+            env,
         }
     }
 }

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -8,16 +8,19 @@ use crate::{
 #[test]
 fn u64_roundtrip() {
     let host = Host::default();
-    let u: u64 = 38473_u64; // This will be treated as a ScVal::I64
+    let u: u64 = 38473_u64; // This will be treated as a ScVal::Object::U64
     let v = u.into_env_val(&host);
+    let obj: Object = v.val.try_into().unwrap();
+    assert!(obj.is_obj_type(ScObjectType::U64));
+    assert_eq!(obj.get_handle(), 0);
     let j = u64::try_from(v).unwrap();
     assert_eq!(u, j);
 
-    let u2: u64 = u64::MAX; // This will be treated as ScVal::Object::U64
+    let u2: u64 = u64::MAX; // This will be treated as a ScVal::Object::U64
     let v2 = u2.into_env_val(&host);
     let obj: Object = v2.val.try_into().unwrap();
     assert!(obj.is_obj_type(ScObjectType::U64));
-    assert_eq!(obj.get_handle(), 0);
+    assert_eq!(obj.get_handle(), 1);
     let k = u64::try_from(v2).unwrap();
     assert_eq!(u2, k);
 }


### PR DESCRIPTION
### What

Reserve pos i64 type for i64 typed values, making u64 always transmitted as an object.

### Why

The existing u64 impl that uses the pos i64 type for small values is an optimization at a cost of type safety. 

The problem is a user could invoke a contract with an `i64` or an `u64`, and the value could be consumed as either on the contract side if the value was positive and fit into 63-bits. This lack of determinism could make it easier to introduce bugs into contracts or into applications calling contracts.

For example, an application developer might test their application with values that fit into 63-bits, and they might call a contract with an argument using the `u64` type. However, the contract might have been written to assume an `i64` input. The application developer might think everything is swell until someday in the future they finally send a value that requires use of all 64-bits. When the `u64` value using all 64-bits is transmitted it would likely cause an abort in the contract because the contract would see that it is a `u64` value and reject converting it into an `i64`.

Even if this problem is addressed at the contract call boundary with manifests, this problem remains with writing and reading contract data.

I don't think the u63 optimization on u64s is worth these types of problems. The u63 optimization can still be used on the i64 type, but a u63 is always a signed value that just happens to be positive.

If we want a similar optimization for u64 and we want symmetric costs for use of i64 and u64 we should probably instead make two types that hold 62 bits that use the extra bit for distinguishing between them.

This change was previously made in the sdk in https://github.com/stellar/rs-stellar-contract-sdk/pull/31, but then lost when the logic was ported from the sdk to the env crate.

### Known limitations

N/A
