### PR TITLE
Add remaining vec hostfns and tests

### DIFF
--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -424,15 +424,42 @@ impl CheckedEnv for Host {
     }
 
     fn vec_put(&self, v: Object, i: RawVal, x: RawVal) -> Result<Object, HostError> {
-        todo!()
+        let i: u32 = i
+            .try_into()
+            .map_err(|_| HostError::General("i must be u32"))?;
+        let x = self.associate_raw_val(x);
+        let vnew = self.visit_obj(v, move |hv: &HostVec| {
+            let mut vnew = hv.clone();
+            vnew.set(i as usize, x);
+            Ok(vnew)
+        })?;
+        Ok(self.add_host_object(vnew)?.into())
     }
 
     fn vec_get(&self, v: Object, i: RawVal) -> Result<RawVal, HostError> {
-        todo!()
+        let i: u32 = i
+            .try_into()
+            .map_err(|_| HostError::General("i must be u32"))?;
+        let res = self.visit_obj(v, move |hv: &HostVec| match hv.get(i as usize) {
+            None => Err(HostError::General("index out of bound")),
+            Some(hval) => Ok(hval.to_raw()),
+        });
+        res
     }
 
     fn vec_del(&self, v: Object, i: RawVal) -> Result<Object, HostError> {
-        todo!()
+        let i: u32 = i
+            .try_into()
+            .map_err(|_| HostError::General("i must be u32"))?;
+        let vnew = self.visit_obj(v, move |hv: &HostVec| {
+            if i as usize >= hv.len() {
+                return Err(HostError::General("index out of bound"));
+            }
+            let mut vnew = hv.clone();
+            vnew.remove(i as usize);
+            Ok(vnew)
+        })?;
+        Ok(self.add_host_object(vnew)?.into())
     }
 
     fn vec_len(&self, v: Object) -> Result<RawVal, HostError> {
@@ -453,14 +480,25 @@ impl CheckedEnv for Host {
     fn vec_pop(&self, v: Object) -> Result<Object, HostError> {
         let vnew = self.visit_obj(v, move |hv: &HostVec| {
             let mut vnew = hv.clone();
-            vnew.pop_back();
-            Ok(vnew)
+            match vnew.pop_back() {
+                None => Err(HostError::General("value does not exist")),
+                Some(_) => Ok(vnew),
+            }
         })?;
         Ok(self.add_host_object(vnew)?.into())
     }
 
     fn vec_take(&self, v: Object, n: RawVal) -> Result<Object, HostError> {
-        todo!()
+        let n: u32 = n
+            .try_into()
+            .map_err(|_| HostError::General("n must be u32"))?;
+        let vnew = self.visit_obj(v, move |hv: &HostVec| {
+            if n as usize > hv.len() {
+                return Err(HostError::General("index out of bound"));
+            }
+            Ok(hv.take(n as usize))
+        })?;
+        Ok(self.add_host_object(vnew)?.into())
     }
 
     fn vec_drop(&self, v: Object, n: RawVal) -> Result<Object, HostError> {
@@ -484,11 +522,26 @@ impl CheckedEnv for Host {
     }
 
     fn vec_insert(&self, v: Object, i: RawVal, x: RawVal) -> Result<Object, HostError> {
-        todo!()
+        let i: u32 = i
+            .try_into()
+            .map_err(|_| HostError::General("i must be u32"))?;
+        let x = self.associate_raw_val(x);
+        let vnew = self.visit_obj(v, move |hv: &HostVec| {
+            if i as usize > hv.len() {
+                return Err(HostError::General("index out of bound"));
+            }
+            let mut vnew = hv.clone();
+            vnew.insert(i as usize, x);
+            Ok(vnew)
+        })?;
+        Ok(self.add_host_object(vnew)?.into())
     }
 
     fn vec_append(&self, v1: Object, v2: Object) -> Result<Object, HostError> {
-        todo!()
+        let mut vnew = self.visit_obj(v1, |hv: &HostVec| Ok(hv.clone()))?;
+        let v2 = self.visit_obj(v2, |hv: &HostVec| Ok(hv.clone()))?;
+        vnew.append(v2);
+        Ok(self.add_host_object(vnew)?.into())
     }
 
     fn get_current_ledger_num(&self) -> Result<RawVal, HostError> {

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -2,7 +2,7 @@ use stellar_contract_env_common::{CheckedEnv, RawValConvertible};
 
 use crate::{
     xdr::{ScObject, ScObjectType, ScVal, ScVec},
-    Host, IntoEnvVal, Object, Tag,
+    Host, IntoEnvVal, Object, RawVal, Tag,
 };
 
 #[test]
@@ -128,4 +128,227 @@ fn empty_vec_back() {
     let scobj = ScObject::Vec(scvec);
     let obj = host.to_host_obj(&scobj).unwrap();
     host.vec_back(*obj.as_ref()).unwrap();
+}
+
+#[test]
+fn vec_put_and_get() {
+    let mut host = Host::default();
+    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
+        .try_into()
+        .unwrap();
+    let scobj = ScObject::Vec(scvec);
+    let obj = host.to_host_obj(&scobj).unwrap();
+    let i: RawVal = 1_u32.into();
+    let obj1 = host.vec_put(*obj.as_ref(), i, 9_u32.into()).unwrap();
+    let rv = host.vec_get(obj1, i).unwrap();
+    let v = unsafe { <u32 as RawValConvertible>::unchecked_from_val(rv) };
+    assert_eq!(v, 9);
+}
+
+#[test]
+fn vec_push_pop_and_len() {
+    let mut host = Host::default();
+    let scvec: ScVec = vec![].try_into().unwrap();
+    let scobj = ScObject::Vec(scvec);
+    let obj = host.to_host_obj(&scobj).unwrap();
+    let l = unsafe {
+        <u32 as RawValConvertible>::unchecked_from_val(host.vec_len(*obj.as_ref()).unwrap())
+    };
+    assert_eq!(l, 0);
+    let obj1 = host.vec_push(*obj.as_ref(), 1u32.into()).unwrap();
+    let obj2 = host.vec_push(obj1, 2u32.into()).unwrap();
+    let l = unsafe { <u32 as RawValConvertible>::unchecked_from_val(host.vec_len(obj2).unwrap()) };
+    assert_eq!(l, 2);
+    let obj3 = host.vec_pop(obj2).unwrap();
+    let l = unsafe { <u32 as RawValConvertible>::unchecked_from_val(host.vec_len(obj3).unwrap()) };
+    assert_eq!(l, 1);
+    let obj4 = host.vec_pop(obj3).unwrap();
+    let l = unsafe { <u32 as RawValConvertible>::unchecked_from_val(host.vec_len(obj4).unwrap()) };
+    assert_eq!(l, 0);
+}
+
+#[test]
+#[should_panic(expected = "value does not exist")]
+fn vec_pop_empty_vec() {
+    let mut host = Host::default();
+    let scvec: ScVec = vec![].try_into().unwrap();
+    let scobj = ScObject::Vec(scvec);
+    let obj = host.to_host_obj(&scobj).unwrap();
+    host.vec_pop(*obj.as_ref()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "index out of bound")]
+fn vec_get_out_of_bound() {
+    let mut host = Host::default();
+    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
+        .try_into()
+        .unwrap();
+    let scobj = ScObject::Vec(scvec);
+    let obj = host.to_host_obj(&scobj).unwrap();
+    host.vec_get(*obj.as_ref(), 3_u32.into()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "i must be u32")]
+fn vec_get_wrong_index_type() {
+    let mut host = Host::default();
+    let scvec: ScVec = vec![].try_into().unwrap();
+    let scobj = ScObject::Vec(scvec);
+    let obj = host.to_host_obj(&scobj).unwrap();
+    host.vec_get(*obj.as_ref(), (-1_i32).into()).unwrap();
+}
+
+#[test]
+fn vec_del_and_cmp() {
+    let mut host = Host::default();
+    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
+        .try_into()
+        .unwrap();
+    let obj = host.to_host_obj(&ScObject::Vec(scvec)).unwrap();
+    let obj1 = host.vec_del(*obj.as_ref(), 1u32.into()).unwrap();
+    let scvec_ref: ScVec = vec![ScVal::U32(1), ScVal::U32(3)].try_into().unwrap();
+    let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref)).unwrap();
+    assert_eq!(host.obj_cmp(obj1.into(), obj_ref.into()).unwrap(), 0);
+}
+
+#[test]
+#[should_panic(expected = "index out of bound")]
+fn vec_del_out_of_bound() {
+    let mut host = Host::default();
+    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
+        .try_into()
+        .unwrap();
+    let scobj = ScObject::Vec(scvec);
+    let obj = host.to_host_obj(&scobj).unwrap();
+    host.vec_del(*obj.as_ref(), 3_u32.into()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "i must be u32")]
+fn vec_del_wrong_index_type() {
+    let mut host = Host::default();
+    let scvec: ScVec = vec![].try_into().unwrap();
+    let scobj = ScObject::Vec(scvec);
+    let obj = host.to_host_obj(&scobj).unwrap();
+    host.vec_del(*obj.as_ref(), (-1_i32).into()).unwrap();
+}
+
+#[test]
+fn vec_take_and_cmp() {
+    let mut host = Host::default();
+    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
+        .try_into()
+        .unwrap();
+    let obj = host.to_host_obj(&ScObject::Vec(scvec)).unwrap();
+    let obj1 = host.vec_take(*obj.as_ref(), 2u32.into()).unwrap();
+    let scvec_ref: ScVec = vec![ScVal::U32(1), ScVal::U32(2)].try_into().unwrap();
+    let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref)).unwrap();
+    assert_eq!(host.obj_cmp(obj1.into(), obj_ref.into()).unwrap(), 0);
+
+    let obj2 = host.vec_take(*obj.as_ref(), 3u32.into()).unwrap();
+    assert_ne!(obj2.as_ref().get_payload(), obj.as_raw().get_payload());
+    assert_eq!(host.obj_cmp(obj2.into(), obj.into()).unwrap(), 0);
+}
+
+#[test]
+#[should_panic(expected = "index out of bound")]
+fn vec_take_out_of_bound() {
+    let mut host = Host::default();
+    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
+        .try_into()
+        .unwrap();
+    let scobj = ScObject::Vec(scvec);
+    let obj = host.to_host_obj(&scobj).unwrap();
+    host.vec_del(*obj.as_ref(), 4_u32.into()).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "n must be u32")]
+fn vec_take_wrong_index_type() {
+    let mut host = Host::default();
+    let scvec: ScVec = vec![].try_into().unwrap();
+    let scobj = ScObject::Vec(scvec);
+    let obj = host.to_host_obj(&scobj).unwrap();
+    host.vec_take(*obj.as_ref(), (-1_i32).into()).unwrap();
+}
+
+#[test]
+fn vec_insert_and_cmp() {
+    let mut host = Host::default();
+    let scvec: ScVec = vec![ScVal::U32(2)].try_into().unwrap();
+    let obj = host.to_host_obj(&ScObject::Vec(scvec)).unwrap();
+    let obj1 = host
+        .vec_insert(*obj.as_ref(), 0u32.into(), 1u32.into())
+        .unwrap();
+    let scvec_ref: ScVec = vec![ScVal::U32(1), ScVal::U32(2)].try_into().unwrap();
+    let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref)).unwrap();
+    assert_eq!(host.obj_cmp(obj1.into(), obj_ref.into()).unwrap(), 0);
+
+    let obj2 = host.vec_insert(obj1, 2u32.into(), 3u32.into()).unwrap();
+    let scvec_ref: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
+        .try_into()
+        .unwrap();
+    let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref)).unwrap();
+    assert_eq!(host.obj_cmp(obj2.into(), obj_ref.into()).unwrap(), 0);
+}
+
+#[test]
+#[should_panic(expected = "index out of bound")]
+fn vec_insert_out_of_bound() {
+    let mut host = Host::default();
+    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
+        .try_into()
+        .unwrap();
+    let scobj = ScObject::Vec(scvec);
+    let obj = host.to_host_obj(&scobj).unwrap();
+    host.vec_insert(*obj.as_ref(), 4_u32.into(), 9u32.into())
+        .unwrap();
+}
+
+#[test]
+#[should_panic(expected = "i must be u32")]
+fn vec_insert_wrong_index_type() {
+    let mut host = Host::default();
+    let scvec: ScVec = vec![].try_into().unwrap();
+    let scobj = ScObject::Vec(scvec);
+    let obj = host.to_host_obj(&scobj).unwrap();
+    host.vec_insert(*obj.as_ref(), (-1_i32).into(), 9u32.into())
+        .unwrap();
+}
+
+#[test]
+fn vec_append() {
+    let mut host = Host::default();
+    let scvec0: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
+        .try_into()
+        .unwrap();
+    let obj0 = host.to_host_obj(&ScObject::Vec(scvec0)).unwrap();
+    let scvec1: ScVec = vec![ScVal::U32(4), ScVal::U32(5), ScVal::U32(6)]
+        .try_into()
+        .unwrap();
+    let obj1 = host.to_host_obj(&ScObject::Vec(scvec1)).unwrap();
+    let obj2 = host.vec_append(*obj0.as_ref(), *obj1.as_ref()).unwrap();
+    let scvec_ref: ScVec = vec![
+        ScVal::U32(1),
+        ScVal::U32(2),
+        ScVal::U32(3),
+        ScVal::U32(4),
+        ScVal::U32(5),
+        ScVal::U32(6),
+    ]
+    .try_into()
+    .unwrap();
+    let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref)).unwrap();
+    assert_eq!(host.obj_cmp(obj2.into(), obj_ref.into()).unwrap(), 0);
+}
+
+#[test]
+fn vec_append_empty() {
+    let mut host = Host::default();
+    let scvec0: ScVec = vec![].try_into().unwrap();
+    let obj0 = host.to_host_obj(&ScObject::Vec(scvec0)).unwrap();
+    let obj1 = host.vec_append(*obj0.as_ref(), *obj0.as_ref()).unwrap();
+    assert_ne!(obj0.as_raw().get_payload(), obj1.as_ref().get_payload());
+    assert_eq!(host.obj_cmp(obj0.into(), obj1.into()).unwrap(), 0);
 }

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -100,10 +100,10 @@ fn vec_front_and_back() -> Result<(), ()> {
     let scobj = ScObject::Vec(scvec);
     let obj = host.to_host_obj(&scobj).unwrap();
     let front = unsafe {
-        <i32 as RawValConvertible>::unchecked_from_val(host.vec_front(*obj.as_ref()).unwrap())
+        <i32 as RawValConvertible>::unchecked_from_val(host.vec_front(obj.to_object()).unwrap())
     };
     let back = unsafe {
-        <i32 as RawValConvertible>::unchecked_from_val(host.vec_back(*obj.as_ref()).unwrap())
+        <i32 as RawValConvertible>::unchecked_from_val(host.vec_back(obj.to_object()).unwrap())
     };
     assert_eq!(front, 1);
     assert_eq!(back, 3);
@@ -117,7 +117,7 @@ fn empty_vec_front() {
     let scvec: ScVec = vec![].try_into().unwrap();
     let scobj = ScObject::Vec(scvec);
     let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_front(*obj.as_ref()).unwrap();
+    host.vec_front(obj.to_object()).unwrap();
 }
 
 #[test]
@@ -127,7 +127,7 @@ fn empty_vec_back() {
     let scvec: ScVec = vec![].try_into().unwrap();
     let scobj = ScObject::Vec(scvec);
     let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_back(*obj.as_ref()).unwrap();
+    host.vec_back(obj.to_object()).unwrap();
 }
 
 #[test]
@@ -139,7 +139,7 @@ fn vec_put_and_get() {
     let scobj = ScObject::Vec(scvec);
     let obj = host.to_host_obj(&scobj).unwrap();
     let i: RawVal = 1_u32.into();
-    let obj1 = host.vec_put(*obj.as_ref(), i, 9_u32.into()).unwrap();
+    let obj1 = host.vec_put(obj.to_object(), i, 9_u32.into()).unwrap();
     let rv = host.vec_get(obj1, i).unwrap();
     let v = unsafe { <u32 as RawValConvertible>::unchecked_from_val(rv) };
     assert_eq!(v, 9);
@@ -152,10 +152,10 @@ fn vec_push_pop_and_len() {
     let scobj = ScObject::Vec(scvec);
     let obj = host.to_host_obj(&scobj).unwrap();
     let l = unsafe {
-        <u32 as RawValConvertible>::unchecked_from_val(host.vec_len(*obj.as_ref()).unwrap())
+        <u32 as RawValConvertible>::unchecked_from_val(host.vec_len(obj.to_object()).unwrap())
     };
     assert_eq!(l, 0);
-    let obj1 = host.vec_push(*obj.as_ref(), 1u32.into()).unwrap();
+    let obj1 = host.vec_push(obj.to_object(), 1u32.into()).unwrap();
     let obj2 = host.vec_push(obj1, 2u32.into()).unwrap();
     let l = unsafe { <u32 as RawValConvertible>::unchecked_from_val(host.vec_len(obj2).unwrap()) };
     assert_eq!(l, 2);
@@ -174,7 +174,7 @@ fn vec_pop_empty_vec() {
     let scvec: ScVec = vec![].try_into().unwrap();
     let scobj = ScObject::Vec(scvec);
     let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_pop(*obj.as_ref()).unwrap();
+    host.vec_pop(obj.to_object()).unwrap();
 }
 
 #[test]
@@ -186,7 +186,7 @@ fn vec_get_out_of_bound() {
         .unwrap();
     let scobj = ScObject::Vec(scvec);
     let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_get(*obj.as_ref(), 3_u32.into()).unwrap();
+    host.vec_get(obj.to_object(), 3_u32.into()).unwrap();
 }
 
 #[test]
@@ -196,7 +196,7 @@ fn vec_get_wrong_index_type() {
     let scvec: ScVec = vec![].try_into().unwrap();
     let scobj = ScObject::Vec(scvec);
     let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_get(*obj.as_ref(), (-1_i32).into()).unwrap();
+    host.vec_get(obj.to_object(), (-1_i32).into()).unwrap();
 }
 
 #[test]
@@ -206,7 +206,7 @@ fn vec_del_and_cmp() {
         .try_into()
         .unwrap();
     let obj = host.to_host_obj(&ScObject::Vec(scvec)).unwrap();
-    let obj1 = host.vec_del(*obj.as_ref(), 1u32.into()).unwrap();
+    let obj1 = host.vec_del(obj.to_object(), 1u32.into()).unwrap();
     let scvec_ref: ScVec = vec![ScVal::U32(1), ScVal::U32(3)].try_into().unwrap();
     let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref)).unwrap();
     assert_eq!(host.obj_cmp(obj1.into(), obj_ref.into()).unwrap(), 0);
@@ -221,7 +221,7 @@ fn vec_del_out_of_bound() {
         .unwrap();
     let scobj = ScObject::Vec(scvec);
     let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_del(*obj.as_ref(), 3_u32.into()).unwrap();
+    host.vec_del(obj.to_object(), 3_u32.into()).unwrap();
 }
 
 #[test]
@@ -231,7 +231,7 @@ fn vec_del_wrong_index_type() {
     let scvec: ScVec = vec![].try_into().unwrap();
     let scobj = ScObject::Vec(scvec);
     let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_del(*obj.as_ref(), (-1_i32).into()).unwrap();
+    host.vec_del(obj.to_object(), (-1_i32).into()).unwrap();
 }
 
 #[test]
@@ -241,12 +241,12 @@ fn vec_take_and_cmp() {
         .try_into()
         .unwrap();
     let obj = host.to_host_obj(&ScObject::Vec(scvec)).unwrap();
-    let obj1 = host.vec_take(*obj.as_ref(), 2u32.into()).unwrap();
+    let obj1 = host.vec_take(obj.to_object(), 2u32.into()).unwrap();
     let scvec_ref: ScVec = vec![ScVal::U32(1), ScVal::U32(2)].try_into().unwrap();
     let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref)).unwrap();
     assert_eq!(host.obj_cmp(obj1.into(), obj_ref.into()).unwrap(), 0);
 
-    let obj2 = host.vec_take(*obj.as_ref(), 3u32.into()).unwrap();
+    let obj2 = host.vec_take(obj.to_object(), 3u32.into()).unwrap();
     assert_ne!(obj2.as_ref().get_payload(), obj.as_raw().get_payload());
     assert_eq!(host.obj_cmp(obj2.into(), obj.into()).unwrap(), 0);
 }
@@ -260,7 +260,7 @@ fn vec_take_out_of_bound() {
         .unwrap();
     let scobj = ScObject::Vec(scvec);
     let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_del(*obj.as_ref(), 4_u32.into()).unwrap();
+    host.vec_del(obj.to_object(), 4_u32.into()).unwrap();
 }
 
 #[test]
@@ -270,7 +270,7 @@ fn vec_take_wrong_index_type() {
     let scvec: ScVec = vec![].try_into().unwrap();
     let scobj = ScObject::Vec(scvec);
     let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_take(*obj.as_ref(), (-1_i32).into()).unwrap();
+    host.vec_take(obj.to_object(), (-1_i32).into()).unwrap();
 }
 
 #[test]
@@ -279,7 +279,7 @@ fn vec_insert_and_cmp() {
     let scvec: ScVec = vec![ScVal::U32(2)].try_into().unwrap();
     let obj = host.to_host_obj(&ScObject::Vec(scvec)).unwrap();
     let obj1 = host
-        .vec_insert(*obj.as_ref(), 0u32.into(), 1u32.into())
+        .vec_insert(obj.to_object(), 0u32.into(), 1u32.into())
         .unwrap();
     let scvec_ref: ScVec = vec![ScVal::U32(1), ScVal::U32(2)].try_into().unwrap();
     let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref)).unwrap();
@@ -302,7 +302,7 @@ fn vec_insert_out_of_bound() {
         .unwrap();
     let scobj = ScObject::Vec(scvec);
     let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_insert(*obj.as_ref(), 4_u32.into(), 9u32.into())
+    host.vec_insert(obj.to_object(), 4_u32.into(), 9u32.into())
         .unwrap();
 }
 
@@ -313,7 +313,7 @@ fn vec_insert_wrong_index_type() {
     let scvec: ScVec = vec![].try_into().unwrap();
     let scobj = ScObject::Vec(scvec);
     let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_insert(*obj.as_ref(), (-1_i32).into(), 9u32.into())
+    host.vec_insert(obj.to_object(), (-1_i32).into(), 9u32.into())
         .unwrap();
 }
 


### PR DESCRIPTION
### What

Add remaining `vec` hostfns:
- put
- get
- del
- take
- insert
- append

Fixed:
- pop

The only one omitted is `vec_drop` which is redundant with `vec_take`.

Add their corresponding test cases.

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
