### PR TITLE
Add conversion as/to_object fns to EnvVal

### DIFF
--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -51,6 +51,15 @@ impl<E: Env, T: TagType> EnvVal<E, TaggedVal<T>> {
     }
 }
 
+impl<E: Env> EnvVal<E, Object> {
+    pub fn as_object(&self) -> &Object {
+        &self.val
+    }
+    pub fn to_object(&self) -> Object {
+        self.val
+    }
+}
+
 impl<E: Env, V: Val> AsRef<RawVal> for EnvVal<E, V> {
     fn as_ref(&self) -> &RawVal {
         self.val.as_ref()


### PR DESCRIPTION
### What

Add conversion as/to_object fns to EnvVal when EnvVal contains an Object.

### Why

We have conversion functions in the form of as/to_raw and as/to_tagged, but the tagged function may not be super obvious that it returns an object when EnvVal contains an object. To increase code readability having another version of this function that is identical but adds that 'object' context to the reading should make some code clearer.

### Known limitations

N/A
