### PR TITLE
Clarify construction modes of storage

### DIFF
--- a/stellar-contract-env-host/src/lib.rs
+++ b/stellar-contract-env-host/src/lib.rs
@@ -14,5 +14,5 @@ pub use host::{Host, HostError};
 pub use stellar_contract_env_common::*;
 
 // TODO: this should become xdr::ContractID when that type arrives.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub struct ContractID(i64);
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct ContractID(xdr::Hash);

--- a/stellar-contract-env-host/src/storage.rs
+++ b/stellar-contract-env-host/src/storage.rs
@@ -77,10 +77,21 @@ pub struct Storage {
 }
 
 impl Storage {
-    pub fn new(footprint: Footprint, mode: FootprintMode) -> Self {
+    pub fn with_enforcing_footprint_and_map(
+        footprint: Footprint,
+        map: OrdMap<Key, Option<ScVal>>,
+    ) -> Self {
         Self {
-            mode,
+            mode: FootprintMode::Enforcing,
             footprint,
+            map,
+        }
+    }
+
+    pub fn with_recording_footprint(src: Rc<dyn SnapshotSource>) -> Self {
+        Self {
+            mode: FootprintMode::Recording(src),
+            footprint: Footprint::default(),
             map: Default::default(),
         }
     }


### PR DESCRIPTION
Small change that updates the ContractID type to a Hash and makes clearer the two different storage footprint modes by splitting the constructor.