### PR TITLE
Conversions for (T0,T1,...)<>Rawval

### DIFF
--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -220,42 +220,54 @@ impl<E: Env> IntoEnvVal<E, RawVal> for u64 {
     }
 }
 
-impl<E: Env, T0, T1> TryFrom<EnvVal<E, RawVal>> for (T0, T1)
-where
-    T0: TryFrom<EnvVal<E, RawVal>>,
-    T1: TryFrom<EnvVal<E, RawVal>>,
-{
-    type Error = ();
+macro_rules! impl_for_tuple {
+    ( $count:literal $($typ:ident $idx:tt)+ ) => {
+        impl<E: Env, $($typ),*> TryFrom<EnvVal<E, RawVal>> for ($($typ),*)
+        where
+            $($typ: TryFrom<EnvVal<E, RawVal>>),*
+        {
+            type Error = ();
 
-    fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
-        if !Object::val_is_obj_type(ev.val, ScObjectType::Vec) {
-            return Err(());
+            fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
+                if !Object::val_is_obj_type(ev.val, ScObjectType::Vec) {
+                    return Err(());
+                }
+                let env = ev.env.clone();
+                let vec = unsafe { Object::unchecked_from_val(ev.val) };
+                let len: u32 = env.vec_len(vec).try_into()?;
+                if len != $count {
+                    return Err(());
+                }
+                Ok((
+                    $($typ::try_from_val(&env, env.vec_get(vec, $idx.into())).map_err(|_| ())?),*
+                ))
+            }
         }
-        let env = ev.env.clone();
-        let vec = unsafe { Object::unchecked_from_val(ev.val) };
-        let len: u32 = env.vec_len(vec).try_into()?;
-        if len != 2 {
-            return Err(());
-        }
-        let t0 = T0::try_from_val(&env, env.vec_get(vec, 0u32.into())).map_err(|_| ())?;
-        let t1 = T1::try_from_val(&env, env.vec_get(vec, 1u32.into())).map_err(|_| ())?;
-        Ok((t0, t1))
-    }
-}
 
-impl<E: Env, T0, T1> IntoEnvVal<E, TaggedVal<TagObject>> for (T0, T1)
-where
-    T0: IntoEnvVal<E, RawVal>,
-    T1: IntoEnvVal<E, RawVal>,
-{
-    fn into_env_val(self, env: &E) -> EnvVal<E, TaggedVal<TagObject>> {
-        let env = env.clone();
-        let vec = env.vec_new();
-        env.vec_push(vec, self.0.into_val(&env));
-        env.vec_push(vec, self.1.into_val(&env));
-        EnvVal { env, val: vec }
-    }
+        impl<E: Env, $($typ),*> IntoEnvVal<E, TaggedVal<TagObject>> for ($($typ),*)
+        where
+            $($typ: IntoEnvVal<E, RawVal>),*
+        {
+            fn into_env_val(self, env: &E) -> EnvVal<E, TaggedVal<TagObject>> {
+                let env = env.clone();
+                let vec = env.vec_new();
+                $(let vec = env.vec_push(vec, self.$idx.into_val(&env));)*
+                EnvVal { env, val: vec }
+            }
+        }
+    };
 }
+impl_for_tuple! {  2 T0 0 T1 1 }
+impl_for_tuple! {  3 T0 0 T1 1 T2 2 }
+impl_for_tuple! {  4 T0 0 T1 1 T2 2 T3 3 }
+impl_for_tuple! {  5 T0 0 T1 1 T2 2 T3 3 T4 4 }
+impl_for_tuple! {  6 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 }
+impl_for_tuple! {  7 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 }
+impl_for_tuple! {  8 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 }
+impl_for_tuple! {  9 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 }
+impl_for_tuple! { 10 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 }
+impl_for_tuple! { 11 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 T10 10 }
+impl_for_tuple! { 12 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 T10 10 T11 11 }
 
 impl<E: Env + Debug, V: Val> Debug for EnvVal<E, V> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -1,6 +1,6 @@
 use stellar_xdr::ScObjectType;
 
-use crate::{BitSet, Object, Status, Symbol, Tag, TagObject, TagType, TaggedVal, Val};
+use crate::{BitSet, Object, Status, Symbol, Tag, TagType, TaggedVal, Val};
 
 use super::{
     raw_val::{RawVal, RawValConvertible},
@@ -219,55 +219,6 @@ impl<E: Env> IntoEnvVal<E, RawVal> for u64 {
         }
     }
 }
-
-macro_rules! impl_for_tuple {
-    ( $count:literal $($typ:ident $idx:tt)+ ) => {
-        impl<E: Env, $($typ),*> TryFrom<EnvVal<E, RawVal>> for ($($typ),*)
-        where
-            $($typ: TryFrom<EnvVal<E, RawVal>>),*
-        {
-            type Error = ();
-
-            fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
-                if !Object::val_is_obj_type(ev.val, ScObjectType::Vec) {
-                    return Err(());
-                }
-                let env = ev.env.clone();
-                let vec = unsafe { Object::unchecked_from_val(ev.val) };
-                let len: u32 = env.vec_len(vec).try_into()?;
-                if len != $count {
-                    return Err(());
-                }
-                Ok((
-                    $($typ::try_from_val(&env, env.vec_get(vec, $idx.into())).map_err(|_| ())?),*
-                ))
-            }
-        }
-
-        impl<E: Env, $($typ),*> IntoEnvVal<E, TaggedVal<TagObject>> for ($($typ),*)
-        where
-            $($typ: IntoEnvVal<E, RawVal>),*
-        {
-            fn into_env_val(self, env: &E) -> EnvVal<E, TaggedVal<TagObject>> {
-                let env = env.clone();
-                let vec = env.vec_new();
-                $(let vec = env.vec_push(vec, self.$idx.into_val(&env));)*
-                EnvVal { env, val: vec }
-            }
-        }
-    };
-}
-impl_for_tuple! {  2 T0 0 T1 1 }
-impl_for_tuple! {  3 T0 0 T1 1 T2 2 }
-impl_for_tuple! {  4 T0 0 T1 1 T2 2 T3 3 }
-impl_for_tuple! {  5 T0 0 T1 1 T2 2 T3 3 T4 4 }
-impl_for_tuple! {  6 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 }
-impl_for_tuple! {  7 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 }
-impl_for_tuple! {  8 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 }
-impl_for_tuple! {  9 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 }
-impl_for_tuple! { 10 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 }
-impl_for_tuple! { 11 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 T10 10 }
-impl_for_tuple! { 12 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 T10 10 T11 11 }
 
 impl<E: Env + Debug, V: Val> Debug for EnvVal<E, V> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/stellar-contract-env-common/src/lib.rs
+++ b/stellar-contract-env-common/src/lib.rs
@@ -9,6 +9,7 @@ mod raw_val;
 mod status;
 mod symbol;
 mod tagged_val;
+mod tuple;
 mod unimplemented_env;
 mod val;
 

--- a/stellar-contract-env-common/src/tuple.rs
+++ b/stellar-contract-env-common/src/tuple.rs
@@ -1,0 +1,55 @@
+use stellar_xdr::ScObjectType;
+
+use crate::{
+    raw_val::{RawVal, RawValConvertible},
+    Env, EnvVal, IntoEnvVal, IntoVal, Object, TagObject, TaggedVal, TryFromVal,
+};
+
+macro_rules! impl_for_tuple {
+    ( $count:literal $($typ:ident $idx:tt)+ ) => {
+        impl<E: Env, $($typ),*> TryFrom<EnvVal<E, RawVal>> for ($($typ),*)
+        where
+            $($typ: TryFrom<EnvVal<E, RawVal>>),*
+        {
+            type Error = ();
+
+            fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
+                if !Object::val_is_obj_type(ev.val, ScObjectType::Vec) {
+                    return Err(());
+                }
+                let env = ev.env.clone();
+                let vec = unsafe { Object::unchecked_from_val(ev.val) };
+                let len: u32 = env.vec_len(vec).try_into()?;
+                if len != $count {
+                    return Err(());
+                }
+                Ok((
+                    $($typ::try_from_val(&env, env.vec_get(vec, $idx.into())).map_err(|_| ())?),*
+                ))
+            }
+        }
+
+        impl<E: Env, $($typ),*> IntoEnvVal<E, TaggedVal<TagObject>> for ($($typ),*)
+        where
+            $($typ: IntoEnvVal<E, RawVal>),*
+        {
+            fn into_env_val(self, env: &E) -> EnvVal<E, TaggedVal<TagObject>> {
+                let env = env.clone();
+                let vec = env.vec_new();
+                $(let vec = env.vec_push(vec, self.$idx.into_val(&env));)*
+                EnvVal { env, val: vec }
+            }
+        }
+    };
+}
+impl_for_tuple! {  2 T0 0 T1 1 }
+impl_for_tuple! {  3 T0 0 T1 1 T2 2 }
+impl_for_tuple! {  4 T0 0 T1 1 T2 2 T3 3 }
+impl_for_tuple! {  5 T0 0 T1 1 T2 2 T3 3 T4 4 }
+impl_for_tuple! {  6 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 }
+impl_for_tuple! {  7 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 }
+impl_for_tuple! {  8 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 }
+impl_for_tuple! {  9 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 }
+impl_for_tuple! { 10 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 }
+impl_for_tuple! { 11 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 T10 10 }
+impl_for_tuple! { 12 T0 0 T1 1 T2 2 T3 3 T4 4 T5 5 T6 6 T7 7 T8 8 T9 9 T10 10 T11 11 }


### PR DESCRIPTION
### What

Add conversions for tuples to and from RawVal.

### Why

To make it convenient to pass tuples across the host/guest boundary, without having to manually craft vecs.

Close stellar/rs-stellar-contract-sdk#107

cc @jonjove 

### Known limitations

N/A
