### PR TITLE
Experiment with Into/TryFrom EnvVal impls that target the tagged type

### DIFF
--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -168,6 +168,17 @@ impl<E: Env, T: TagType> IntoEnvVal<E, TaggedVal<T>> for TaggedVal<T> {
     }
 }
 
+impl<E: Env> TryFrom<EnvVal<E, TaggedVal<TagObject>>> for i64 {
+    type Error = ();
+
+    fn try_from(ev: EnvVal<E, TaggedVal<TagObject>>) -> Result<Self, Self::Error> {
+        if ev.val.is_obj_type(ScObjectType::I64) {
+            Ok(ev.env.obj_to_i64(ev.val))
+        } else {
+            Err(())
+        }
+    }
+}
 impl<E: Env> TryFrom<EnvVal<E, RawVal>> for i64 {
     type Error = ();
 
@@ -190,6 +201,15 @@ impl<E: Env> IntoEnvVal<E, RawVal> for i64 {
         } else {
             env.obj_from_i64(self).to_raw()
         };
+        EnvVal {
+            env: env.clone(),
+            val,
+        }
+    }
+}
+impl<E: Env> IntoEnvVal<E, TaggedVal<TagObject>> for i64 {
+    fn into_env_val(self, env: &E) -> EnvVal<E, TaggedVal<TagObject>> {
+        let val = env.obj_from_i64(self);
         EnvVal {
             env: env.clone(),
             val,

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -2,7 +2,7 @@ use stellar_contract_env_common::{CheckedEnv, EnvVal, RawValConvertible};
 
 use crate::{
     xdr::{ScObject, ScObjectType, ScVal, ScVec},
-    Host, IntoEnvVal, IntoVal, Object, RawVal, Tag,
+    Host, IntoEnvVal, Object, RawVal, Tag,
 };
 
 #[test]

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -1,4 +1,4 @@
-use stellar_contract_env_common::{CheckedEnv, RawValConvertible, EnvVal};
+use stellar_contract_env_common::{CheckedEnv, EnvVal, RawValConvertible};
 
 use crate::{
     xdr::{ScObject, ScObjectType, ScVal, ScVec},

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -29,12 +29,12 @@ fn u64_roundtrip() {
 fn i64_roundtrip() {
     let host = Host::default();
     let i: i64 = 12345_i64; // Will be treated as ScVal::I64
-    let v = i.into_env_val(&host);
+    let v: EnvVal<_, RawVal> = i.into_env_val(&host);
     let j = i64::try_from(v).unwrap();
     assert_eq!(i, j);
 
     let i2: i64 = -13234_i64; // WIll be treated as ScVal::Object::I64
-    let v2 = i2.into_env_val(&host);
+    let v2: EnvVal<_, RawVal> = i2.into_env_val(&host);
     let obj: Object = v2.val.try_into().unwrap();
     assert!(obj.is_obj_type(ScObjectType::I64));
     assert_eq!(obj.get_handle(), 0);

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -1,15 +1,15 @@
-use stellar_contract_env_common::{CheckedEnv, RawValConvertible};
+use stellar_contract_env_common::{CheckedEnv, RawValConvertible, EnvVal};
 
 use crate::{
     xdr::{ScObject, ScObjectType, ScVal, ScVec},
-    Host, IntoEnvVal, Object, RawVal, Tag,
+    Host, IntoEnvVal, IntoVal, Object, RawVal, Tag,
 };
 
 #[test]
 fn u64_roundtrip() {
     let host = Host::default();
     let u: u64 = 38473_u64; // This will be treated as a ScVal::Object::U64
-    let v = u.into_env_val(&host);
+    let v: EnvVal<_, RawVal> = u.into_env_val(&host);
     let obj: Object = v.val.try_into().unwrap();
     assert!(obj.is_obj_type(ScObjectType::U64));
     assert_eq!(obj.get_handle(), 0);
@@ -17,7 +17,7 @@ fn u64_roundtrip() {
     assert_eq!(u, j);
 
     let u2: u64 = u64::MAX; // This will be treated as a ScVal::Object::U64
-    let v2 = u2.into_env_val(&host);
+    let v2: EnvVal<_, RawVal> = u2.into_env_val(&host);
     let obj: Object = v2.val.try_into().unwrap();
     assert!(obj.is_obj_type(ScObjectType::U64));
     assert_eq!(obj.get_handle(), 1);


### PR DESCRIPTION
### What

Have types implement Into/TryFrom EnvVal<_, TaggedVal<T>> where T is the tag object that is 1-1 with the type.

### Why

For all types we've been implementing conversions to and from EnvVal<_, RawVal>, but for many types we could implement to and from the specific tag object tagged val, and then macro an implementation from there to RawVal.

This potentially allows types and code to not need to dance between Object and RawVal so much.

This also potentially makes it harder to use into_env_val and try_from_env_val and their related traits, because there will now be multiple Val impls for each.

### Known limitations

This is just an experiment. This might cause a code size increase, but unclear since it should be mostly pass through.