### PR TITLE
Allow mutual nesting of HostError and wasmi::Error

### DIFF
--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -28,13 +28,10 @@ pub enum HostError {
     #[error("general host error: {0}")]
     General(&'static str),
     #[error("XDR error")]
-    XDRError(xdr::Error),
-}
-
-impl From<xdr::Error> for HostError {
-    fn from(x: xdr::Error) -> Self {
-        HostError::XDRError(x)
-    }
+    XDRError(#[from] xdr::Error),
+    #[cfg(feature = "vm")]
+    #[error("WASMI error")]
+    WASMIError(#[from] wasmi::Error),
 }
 
 impl From<TryFromIntError> for HostError {

--- a/stellar-contract-env-host/src/vm.rs
+++ b/stellar-contract-env-host/src/vm.rs
@@ -1,12 +1,9 @@
 mod dispatch;
 mod func_info;
 
-use std::error::Error;
-
-use crate::{host::Frame, ContractID};
+use crate::{host::Frame, ContractID, HostError};
 
 use super::{
-    host,
     xdr::{ScVal, ScVec},
     Host, RawVal,
 };
@@ -16,7 +13,7 @@ use wasmi::{
     RuntimeValue, ValueType,
 };
 
-impl wasmi::HostError for host::HostError {}
+impl wasmi::HostError for HostError {}
 
 impl Externals for Host {
     fn invoke_index(
@@ -123,7 +120,7 @@ impl Vm {
         host: &Host,
         contract_id: ContractID,
         module_wasm_code: &[u8],
-    ) -> Result<Self, Box<dyn Error>> {
+    ) -> Result<Self, HostError> {
         let module = Module::from_buffer(module_wasm_code)?;
         module.deny_floating_point()?;
         let not_started_instance = ModuleInstance::new(&module, host)?;
@@ -172,7 +169,7 @@ impl Vm {
         host: &mut Host,
         func: &str,
         args: &ScVec,
-    ) -> Result<ScVal, Box<dyn Error>> {
+    ) -> Result<ScVal, HostError> {
         let mut raw_args: Vec<RawVal> = Vec::new();
         for scv in args.0.iter() {
             raw_args.push(host.to_host_val(scv)?.val);


### PR DESCRIPTION
I'm not sure why I had things wired up to use `dyn Error` before but this seems harmless and is necessary (or something like it) for calling vm methods from host (eg. cross-contract invocation)