### PR TITLE
Fix type of idx used in tuple hostfn access

### DIFF
--- a/stellar-contract-env-common/src/tuple.rs
+++ b/stellar-contract-env-common/src/tuple.rs
@@ -26,7 +26,8 @@ macro_rules! impl_for_tuple {
                 Ok((
                     $({
                         let idx: u32 = $idx;
-                        $typ::try_from_val(&env, env.vec_get(vec, idx.into())).map_err(|_| ())?
+                        let val = env.vec_get(vec, idx.into());
+                        $typ::try_from_val(&env, val).map_err(|_| ())?
                     }),*
                 ))
             }

--- a/stellar-contract-env-common/src/tuple.rs
+++ b/stellar-contract-env-common/src/tuple.rs
@@ -24,7 +24,10 @@ macro_rules! impl_for_tuple {
                     return Err(());
                 }
                 Ok((
-                    $($typ::try_from_val(&env, env.vec_get(vec, $idx.into())).map_err(|_| ())?),*
+                    $({
+                        let idx: u32 = $idx;
+                        $typ::try_from_val(&env, env.vec_get(vec, idx.into())).map_err(|_| ())?
+                    }),*
                 ))
             }
         }


### PR DESCRIPTION
### What

Set the type of the idx to u32.

### Why

The type was defaulting to some other type.

### Known limitations

[TODO or N/A]
