### PR TITLE
Add IntoEnvVal<_, RawVal> impl for TaggedVal/Symbol

### DIFF
--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -147,6 +147,15 @@ impl<E: Env, T: TagType> TryFrom<EnvVal<E, RawVal>> for EnvVal<E, TaggedVal<T>> 
     }
 }
 
+impl<E: Env, T: TagType> IntoEnvVal<E, RawVal> for TaggedVal<T> {
+    fn into_env_val(self, env: &E) -> EnvVal<E, RawVal> {
+        EnvVal {
+            env: env.clone(),
+            val: self.to_raw(),
+        }
+    }
+}
+
 impl<E: Env, T: TagType> From<EnvVal<E, TaggedVal<T>>> for RawVal {
     fn from(ev: EnvVal<E, TaggedVal<T>>) -> Self {
         ev.val.0


### PR DESCRIPTION
### What

Add `IntoEnvVal<_, RawVal>` impl for `TaggedVal`/`Symbol`.

### Why

It's not possible to into a `RawVal` for a `Symbol`, because a `Symbol` is a `TaggedVal<TagSymbol>` and `TaggedVal` was missing the impl.

### Known limitations

`TaggedVal` is a type that has `IntoEnvVal` impls for multiple `Val` types. It might get annoying to specify the destination type, but if so we can probably remove the other impl that already exists, as it probably isn't meaningful to keep.