### PR TITLE
Export SymbolStr

### DIFF
--- a/stellar-contract-env-common/src/lib.rs
+++ b/stellar-contract-env-common/src/lib.rs
@@ -35,7 +35,7 @@ pub use unimplemented_env::UnimplementedEnv;
 pub use bitset::{BitSet, BitSetError};
 pub use object::Object;
 pub use status::{Status, OK, UNKNOWN_ERROR};
-pub use symbol::{Symbol, SymbolError, SymbolIter};
+pub use symbol::{Symbol, SymbolError, SymbolIter, SymbolStr};
 
 #[inline(always)]
 // Awkward: this is a free function rather than a trait call because


### PR DESCRIPTION
### What
Export SymbolStr.

### Why
So that the SDK code can get a string from a Symbol.