### PR TITLE
Export WASM file functions in VM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
  "im-rc",
  "num-bigint",
  "num-rational",
+ "parity-wasm",
  "static_assertions",
  "stellar-contract-env-common",
  "thiserror",

--- a/stellar-contract-env-host/Cargo.toml
+++ b/stellar-contract-env-host/Cargo.toml
@@ -13,6 +13,7 @@ num-bigint = "0.4"
 num-rational = "0.4"
 thiserror = "1.0.31"
 wasmi = { version = "0.11.0", optional = true }
+parity-wasm = { version = "0.42.0", optional = true }
 
 [features]
-vm = ["wasmi", "stellar-contract-env-common/vm"]
+vm = ["wasmi", "parity-wasm", "stellar-contract-env-common/vm"]

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -36,6 +36,9 @@ pub enum HostError {
     #[cfg(feature = "vm")]
     #[error("WASMI error")]
     WASMIError(#[from] wasmi::Error),
+    #[cfg(feature = "vm")]
+    #[error("ParityWasmElements error")]
+    ParityWasmElementsError(#[from] parity_wasm::elements::Error),
 }
 
 impl From<TryFromIntError> for HostError {


### PR DESCRIPTION
### What

Add functions for getting a list of WASM functions from the loaded WASM in the `Vm`.

### Why

So that tools like the CLI can inspect the functions.

@graydon and I discussed a couple approaches to doing this. The first was to fork wasmi and to expose these details that it already has. However, @graydon pointed out that the parity_wasm crate can already expose these details to us, and we could load the wasm via it first then continue to use wasmi from there. This does appear to work elegantly, assuming that the wasmi crate retains this parity_wasm entry point.

### Known limitations

N/A

cc @graydon Adding you as a reviewer, but will be merging aggressively. Feel free to leave feedback post-merge.