### PR TITLE
Export custom sections from Vm

### DIFF
--- a/stellar-contract-env-host/src/vm.rs
+++ b/stellar-contract-env-host/src/vm.rs
@@ -244,4 +244,16 @@ impl Vm {
             vec![]
         }
     }
+
+    // Custom section returns the bytes within the named custom section of the
+    // loaded WASM file.
+    pub fn custom_section(&self, name: impl AsRef<str>) -> Option<&[u8]> {
+        self.elements_module.custom_sections().find_map(|s| {
+            if s.name() == name.as_ref() {
+                Some(s.payload())
+            } else {
+                None
+            }
+        })
+    }
 }


### PR DESCRIPTION
### What

Export custom sections from Vm.

### Why

So that tools like the CLI, and the macros used in generating cross contract clients, can extract the custom section containing the specification.

### Known limitations

[TODO or N/A]

cc @graydon 