### PR TITLE
Use a single variadic function for cross-contract call

### DIFF
--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -122,11 +122,7 @@ macro_rules! call_macro_with_all_host_functions {
             }
 
             mod call "c" {
-                {"$_", fn call0(contract:Object,func:Symbol) -> RawVal}
-                {"$0", fn call1(contract:Object,func:Symbol,a:RawVal) -> RawVal}
-                {"$1", fn call2(contract:Object,func:Symbol,a:RawVal,b:RawVal) -> RawVal}
-                {"$2", fn call3(contract:Object,func:Symbol,a:RawVal,b:RawVal,c:RawVal) -> RawVal}
-                {"$3", fn call4(contract:Object,func:Symbol,a:RawVal,b:RawVal,c:RawVal,d:RawVal) -> RawVal}
+                {"$_", fn call(contract:Object,func:Symbol,args:Object) -> RawVal}
             }
 
             mod bigint "b" {

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -716,60 +716,16 @@ impl CheckedEnv for Host {
         todo!()
     }
 
-    fn call0(&self, contract: Object, func: Symbol) -> Result<RawVal, HostError> {
+    fn call(&self, contract: Object, func: Symbol, args: Object) -> Result<RawVal, HostError> {
         #[cfg(not(feature = "vm"))]
         todo!();
         #[cfg(feature = "vm")]
-        self.call_n(contract, func, &[])
-    }
-
-    fn call1(&self, contract: Object, func: Symbol, a: RawVal) -> Result<RawVal, HostError> {
-        #[cfg(not(feature = "vm"))]
-        todo!();
-        #[cfg(feature = "vm")]
-        self.call_n(contract, func, &[a])
-    }
-
-    fn call2(
-        &self,
-        contract: Object,
-        func: Symbol,
-        a: RawVal,
-        b: RawVal,
-    ) -> Result<RawVal, HostError> {
-        #[cfg(not(feature = "vm"))]
-        todo!();
-        #[cfg(feature = "vm")]
-        self.call_n(contract, func, &[a, b])
-    }
-
-    fn call3(
-        &self,
-        contract: Object,
-        func: Symbol,
-        a: RawVal,
-        b: RawVal,
-        c: RawVal,
-    ) -> Result<RawVal, HostError> {
-        #[cfg(not(feature = "vm"))]
-        todo!();
-        #[cfg(feature = "vm")]
-        self.call_n(contract, func, &[a, b, c])
-    }
-
-    fn call4(
-        &self,
-        contract: Object,
-        func: Symbol,
-        a: RawVal,
-        b: RawVal,
-        c: RawVal,
-        d: RawVal,
-    ) -> Result<RawVal, HostError> {
-        #[cfg(not(feature = "vm"))]
-        todo!();
-        #[cfg(feature = "vm")]
-        self.call_n(contract, func, &[a, b, c, d])
+        {
+            let args: Vec<RawVal> = self.visit_obj(args, |hv: &HostVec| {
+                Ok(hv.iter().map(|a| a.to_raw()).collect())
+            })?;
+            self.call_n(contract, func, args.as_slice())
+        }
     }
 
     fn bigint_from_u64(&self, x: u64) -> Result<Object, HostError> {

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -441,16 +441,18 @@ fn contract_invoke_another_contract() -> Result<(), ()> {
     let mut footprint = Footprint::default();
     footprint.record_access(&storage_key, AccessType::ReadOnly);
 
+    // initialize storage and host
     let storage = Storage::with_enforcing_footprint_and_map(footprint, map);
     let host = Host::with_storage(storage);
-
-    let sym = Symbol::from_str("add");
+    // create a dummy contract obj as the caller
     let scobj = ScObject::Binary([0; 32].try_into()?);
     let obj = host.to_host_obj(&scobj).unwrap();
-    let res = host
-        .call2(obj.to_object(), sym.into(), 1i32.into(), 2i32.into())
-        .unwrap();
+    // prepare arguments
+    let sym = Symbol::from_str("add");
+    let scvec0: ScVec = vec![ScVal::I32(1), ScVal::I32(2)].try_into().unwrap();
+    let args = host.to_host_obj(&ScObject::Vec(scvec0)).unwrap();
 
+    let res = host.call(obj.to_object(), sym.into(), args.into()).unwrap();
     assert!(res.is::<i32>());
     assert!(res.get_tag() == Tag::I32);
     let i: i32 = res.try_into()?;


### PR DESCRIPTION
### What

Replace `call0...4` function with a single `call` function that takes a single `ScVec` object containing variable number of arguments. 

### Why

Variadic function is a useful case for cross-contract calling, brought up in the CAP-51 discussion and the CAP has been updated to include it. Having multiple `callx` functions seem redundant. 

### Known limitations

[TODO or N/A]
