### PR TITLE
Contract data update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,7 +189,7 @@ version = "0.0.0"
 [[package]]
 name = "stellar-xdr"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=d1dc8ce0#d1dc8ce045378ad664fe5f06b087d008016b6f3c"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=2a8b24c2978303612c49afcf005c1d35c592c97c#2a8b24c2978303612c49afcf005c1d35c592c97c"
 dependencies = [
  "base64",
 ]

--- a/stellar-contract-env-common/Cargo.toml
+++ b/stellar-contract-env-common/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 static_assertions = "1.1.0"
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "d1dc8ce0", default-features = false }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "2a8b24c2978303612c49afcf005c1d35c592c97c", default-features = false, features = ["next"] }
 # stellar-xdr = { path = "../../rs-stellar-xdr", default-features = false }
 
 # wasmi is an optional dependency only to let us impl its type conversion

--- a/stellar-contract-env-common/src/raw_val.rs
+++ b/stellar-contract-env-common/src/raw_val.rs
@@ -1,3 +1,5 @@
+use stellar_xdr::ScStatic;
+
 use super::{Env, EnvVal, IntoEnvVal, Symbol};
 use core::fmt::Debug;
 
@@ -37,14 +39,6 @@ pub enum Tag {
 
     #[allow(dead_code)]
     Reserved = 7,
-}
-
-#[repr(u32)]
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Static {
-    Void = 0,
-    True = 1,
-    False = 2,
 }
 
 #[repr(transparent)]
@@ -136,7 +130,7 @@ impl From<RawVal> for wasmi::RuntimeValue {
 impl RawValConvertible for () {
     #[inline(always)]
     fn is_val_type(v: RawVal) -> bool {
-        v.has_tag(Tag::Static) && v.get_body() == Static::Void as u64
+        v.has_tag(Tag::Static) && v.get_body() == ScStatic::Void as u64
     }
     #[inline(always)]
     unsafe fn unchecked_from_val(_v: RawVal) -> Self {}
@@ -146,18 +140,18 @@ impl RawValConvertible for bool {
     #[inline(always)]
     fn is_val_type(v: RawVal) -> bool {
         v.has_tag(Tag::Static)
-            && (v.get_body() == Static::True as u64 || v.get_body() == Static::False as u64)
+            && (v.get_body() == ScStatic::True as u64 || v.get_body() == ScStatic::False as u64)
     }
     #[inline(always)]
     unsafe fn unchecked_from_val(v: RawVal) -> Self {
-        v.get_body() == Static::True as u64
+        v.get_body() == ScStatic::True as u64
     }
     #[inline(always)]
     fn try_convert(v: RawVal) -> Option<Self> {
         if v.has_tag(Tag::Static) {
-            if v.get_body() == Static::True as u64 {
+            if v.get_body() == ScStatic::True as u64 {
                 Some(true)
-            } else if v.get_body() == Static::False as u64 {
+            } else if v.get_body() == ScStatic::False as u64 {
                 Some(false)
             } else {
                 None
@@ -313,13 +307,18 @@ impl RawVal {
 
     #[inline(always)]
     pub const fn from_void() -> RawVal {
-        unsafe { RawVal::from_body_and_tag(Static::Void as u64, Tag::Static) }
+        unsafe { RawVal::from_body_and_tag(ScStatic::Void as u64, Tag::Static) }
     }
 
     #[inline(always)]
     pub const fn from_bool(b: bool) -> RawVal {
-        let body = if b { Static::True } else { Static::False };
+        let body = if b { ScStatic::True } else { ScStatic::False };
         unsafe { RawVal::from_body_and_tag(body as u64, Tag::Static) }
+    }
+
+    #[inline(always)]
+    pub const fn from_other_static(st: ScStatic) -> RawVal {
+        unsafe { RawVal::from_body_and_tag(st as u64, Tag::Static) }
     }
 
     #[inline(always)]

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -6,12 +6,13 @@ use core::cmp::Ordering;
 use core::fmt::Debug;
 use im_rc::{OrdMap, Vector};
 use std::num::TryFromIntError;
+use stellar_contract_env_common::xdr::Hash;
 
 use crate::storage::{Key, Storage};
 use crate::weak_host::WeakHost;
 
+use crate::xdr;
 use crate::xdr::{ScMap, ScMapEntry, ScObject, ScStatic, ScStatus, ScStatusType, ScVal, ScVec};
-use crate::{xdr, ContractId};
 use std::rc::Rc;
 
 use crate::host_object::{HostMap, HostObj, HostObject, HostObjectType, HostVal, HostVec};
@@ -66,7 +67,7 @@ impl From<BitSetError> for HostError {
 /// with [`Host::push_frame`].
 #[derive(Clone)]
 pub(crate) struct Frame {
-    pub(crate) contract_id: ContractId,
+    pub(crate) contract_id: Hash,
     // Other activation-frame / execution-context values here.
 }
 
@@ -136,9 +137,9 @@ impl Host {
             .expect("missing current host frame"))
     }
 
-    /// Returns [`ContractID`] from top of context stack, panicking if the stack
-    /// is empty.
-    fn get_current_contract_id(&self) -> ContractId {
+    /// Returns [`Hash`] contract ID from top of context stack, panicking if the
+    /// stack is empty.
+    fn get_current_contract_id(&self) -> Hash {
         self.with_current_frame(|frame| frame.contract_id.clone())
     }
 
@@ -367,7 +368,7 @@ impl Host {
                 .as_slice()
                 .try_into()
                 .map_err(|_| HostError::General("invalid contract hash"))?;
-            Ok(ContractId(xdr::Hash(arr)))
+            Ok(xdr::Hash(arr))
         })?;
         let key = ScVal::Static(ScStatic::LedgerKeyContractCodeWasm);
         let storage_key = Key {

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -253,6 +253,7 @@ impl Host {
             ScVal::Static(ScStatic::Void) => RawVal::from_void(),
             ScVal::Static(ScStatic::True) => RawVal::from_bool(true),
             ScVal::Static(ScStatic::False) => RawVal::from_bool(false),
+            ScVal::Static(other) => RawVal::from_other_static(*other),
             ScVal::Object(None) => return Err(HostError::General("missing expected ScvObject")),
             ScVal::Object(Some(ob)) => return Ok(self.to_host_obj(&*ob)?.into()),
             ScVal::Symbol(bytes) => {

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -189,7 +189,7 @@ impl Host {
 
     pub(crate) fn from_host_val(&self, val: RawVal) -> Result<ScVal, HostError> {
         if val.is_u63() {
-            Ok(ScVal::U63(unsafe { val.unchecked_as_u63() } as u64))
+            Ok(ScVal::U63(unsafe { val.unchecked_as_u63() }))
         } else {
             match val.get_tag() {
                 Tag::U32 => Ok(ScVal::U32(unsafe {
@@ -214,7 +214,7 @@ impl Host {
                 Tag::Object => unsafe {
                     let ob = <Object as RawValConvertible>::unchecked_from_val(val);
                     let scob = self.from_host_obj(ob)?;
-                    Ok(ScVal::Object(Some(Box::new(scob))))
+                    Ok(ScVal::Object(Some(scob)))
                 },
                 Tag::Symbol => {
                     let sym: Symbol =
@@ -241,9 +241,9 @@ impl Host {
 
     pub(crate) fn to_host_val(&self, v: &ScVal) -> Result<HostVal, HostError> {
         let ok = match v {
-            ScVal::U63(u) => {
-                if *u <= (i64::MAX as u64) {
-                    unsafe { RawVal::unchecked_from_u63(*u as i64) }
+            ScVal::U63(i) => {
+                if *i >= 0 {
+                    unsafe { RawVal::unchecked_from_u63(*i) }
                 } else {
                     return Err(HostError::General("ScvU63 > i64::MAX"));
                 }
@@ -282,7 +282,6 @@ impl Host {
             self.unchecked_visit_val_obj(ob.into(), |ob| match ob {
                 None => Err(HostError::General("object not found")),
                 Some(ho) => match ho {
-                    HostObject::Box(v) => Ok(ScObject::Box(Box::new(self.from_host_val(v.val)?))),
                     HostObject::Vec(vv) => {
                         let mut sv = Vec::new();
                         for e in vv.iter() {
@@ -301,17 +300,7 @@ impl Host {
                     }
                     HostObject::U64(u) => Ok(ScObject::U64(*u)),
                     HostObject::I64(i) => Ok(ScObject::I64(*i)),
-                    HostObject::Str(s) => Ok(ScObject::String(s.as_bytes().try_into()?)),
                     HostObject::Bin(b) => Ok(ScObject::Binary(b.clone().try_into()?)),
-                    HostObject::BigInt(_) => todo!(),
-                    HostObject::BigRat(_) => todo!(),
-                    HostObject::LedgerKey(_) => todo!(),
-                    HostObject::Operation(_) => todo!(),
-                    HostObject::OperationResult(_) => todo!(),
-                    HostObject::Transaction(_) => todo!(),
-                    HostObject::Asset(_) => todo!(),
-                    HostObject::Price(_) => todo!(),
-                    HostObject::AccountID(_) => todo!(),
                 },
             })
         }
@@ -319,10 +308,6 @@ impl Host {
 
     pub(crate) fn to_host_obj(&self, ob: &ScObject) -> Result<HostObj, HostError> {
         match ob {
-            ScObject::Box(b) => {
-                let hv = self.to_host_val(b)?;
-                self.add_host_object(hv)
-            }
             ScObject::Vec(v) => {
                 let mut vv = Vector::new();
                 for e in v.0.iter() {
@@ -341,35 +326,7 @@ impl Host {
             }
             ScObject::U64(u) => self.add_host_object(*u),
             ScObject::I64(i) => self.add_host_object(*i),
-            ScObject::String(s) => {
-                let ss = match String::from_utf8(s.clone().into()) {
-                    Ok(ss) => ss,
-                    Err(_) => return Err(HostError::General("non-UTF-8 in ScoString")),
-                };
-                self.add_host_object(ss)
-            }
             ScObject::Binary(b) => self.add_host_object::<Vec<u8>>(b.clone().into()),
-
-            ScObject::Bigint(_) => todo!(),
-            ScObject::Bigrat(_) => todo!(),
-
-            ScObject::Ledgerkey(None) => Err(HostError::General("missing ScoLedgerKey")),
-            ScObject::Ledgerkey(Some(lk)) => self.add_host_object(lk.clone()),
-
-            ScObject::Operation(None) => Err(HostError::General("missing ScoOperation")),
-            ScObject::Operation(Some(op)) => self.add_host_object(op.clone()),
-
-            ScObject::OperationResult(None) => {
-                Err(HostError::General("missing ScoOperationResult"))
-            }
-            ScObject::OperationResult(Some(o)) => self.add_host_object(o.clone()),
-
-            ScObject::Transaction(None) => Err(HostError::General("missing ScoTransaction")),
-            ScObject::Transaction(Some(t)) => self.add_host_object(t.clone()),
-
-            ScObject::Asset(a) => self.add_host_object(a.clone()),
-            ScObject::Price(p) => self.add_host_object(p.clone()),
-            ScObject::Accountid(a) => self.add_host_object(a.clone()),
         }
     }
 
@@ -412,7 +369,7 @@ impl Host {
                 .map_err(|_| HostError::General("invalid contract hash"))?;
             Ok(ContractId(xdr::Hash(arr)))
         })?;
-        let key = ScVal::Static(ScStatic::Void); // TODO: replace with "SCS_LEDGER_KEY_CONTRACT_CODE_WASM"
+        let key = ScVal::Static(ScStatic::LedgerKeyContractCodeWasm);
         let storage_key = Key {
             contract_id: id.clone(),
             key,
@@ -420,7 +377,7 @@ impl Host {
         // Retrieve the contract code and create vm
         let scval = self.0.storage.borrow_mut().get(&storage_key)?;
         let scobj = match scval {
-            ScVal::Object(Some(ob)) => *ob,
+            ScVal::Object(Some(ob)) => ob,
             _ => return Err(HostError::General("not an object")),
         };
         let code = match scobj {
@@ -453,7 +410,6 @@ impl EnvBase for Host {
         let new_weak = new_host.get_weak();
         for hobj in new_host.0.objects.borrow_mut().iter_mut() {
             match hobj {
-                HostObject::Box(v) => v.env = new_weak.clone(),
                 HostObject::Vec(vs) => {
                     vs.iter_mut().for_each(|v| v.env = new_weak.clone());
                 }

--- a/stellar-contract-env-host/src/host_object.rs
+++ b/stellar-contract-env-host/src/host_object.rs
@@ -1,14 +1,6 @@
-use super::{
-    weak_host::WeakHost,
-    xdr::{
-        AccountId, Asset, LedgerKey, Operation, OperationResult, Price, ScObjectType, Transaction,
-    },
-    EnvVal, Object, RawVal,
-};
+use super::{weak_host::WeakHost, xdr::ScObjectType, EnvVal, Object, RawVal};
 
 use im_rc::{OrdMap, Vector};
-use num_bigint::BigInt;
-use num_rational::BigRational;
 
 pub(crate) type HostObj = EnvVal<WeakHost, Object>;
 pub(crate) type HostVal = EnvVal<WeakHost, RawVal>;
@@ -17,22 +9,11 @@ pub(crate) type HostVec = Vector<HostVal>;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum HostObject {
-    Box(HostVal),
     Vec(HostVec),
     Map(HostMap),
     U64(u64),
     I64(i64),
-    Str(String),
     Bin(Vec<u8>),
-    BigInt(BigInt),
-    BigRat(BigRational),
-    LedgerKey(LedgerKey),
-    Operation(Operation),
-    OperationResult(OperationResult),
-    Transaction(Transaction),
-    Asset(Asset),
-    Price(Price),
-    AccountID(AccountId),
 }
 
 pub(crate) trait HostObjectType: Sized {
@@ -62,20 +43,8 @@ macro_rules! declare_host_object_type {
     };
 }
 
-declare_host_object_type!(HostVal, Box, Box);
 declare_host_object_type!(HostMap, Map, Map);
 declare_host_object_type!(HostVec, Vec, Vec);
 declare_host_object_type!(u64, U64, U64);
 declare_host_object_type!(i64, I64, I64);
-declare_host_object_type!(String, String, Str);
 declare_host_object_type!(Vec<u8>, Binary, Bin);
-declare_host_object_type!(BigInt, Bigint, BigInt);
-declare_host_object_type!(BigRational, Bigrat, BigRat);
-
-declare_host_object_type!(LedgerKey, Ledgerkey, LedgerKey);
-declare_host_object_type!(Operation, Operation, Operation);
-declare_host_object_type!(OperationResult, OperationResult, OperationResult);
-declare_host_object_type!(Transaction, Transaction, Transaction);
-declare_host_object_type!(Asset, Asset, Asset);
-declare_host_object_type!(Price, Price, Price);
-declare_host_object_type!(AccountId, Accountid, AccountID);

--- a/stellar-contract-env-host/src/lib.rs
+++ b/stellar-contract-env-host/src/lib.rs
@@ -12,7 +12,3 @@ mod test;
 
 pub use host::{Host, HostError};
 pub use stellar_contract_env_common::*;
-
-// TODO: this should become xdr::ContractId when that type arrives.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub struct ContractId(pub xdr::Hash);

--- a/stellar-contract-env-host/src/storage.rs
+++ b/stellar-contract-env-host/src/storage.rs
@@ -22,7 +22,7 @@ pub trait SnapshotSource {
 }
 
 #[derive(Clone, Default)]
-pub struct Footprint(OrdMap<Key, AccessType>);
+pub struct Footprint(pub OrdMap<Key, AccessType>);
 
 impl Footprint {
     pub fn record_access(&mut self, key: &Key, ty: AccessType) {

--- a/stellar-contract-env-host/src/storage.rs
+++ b/stellar-contract-env-host/src/storage.rs
@@ -1,12 +1,12 @@
 use std::rc::Rc;
 
-use crate::xdr::ScVal;
-use crate::{ContractId, HostError};
+use crate::xdr::{Hash, ScVal};
+use crate::HostError;
 use im_rc::OrdMap;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Key {
-    pub contract_id: ContractId,
+    pub contract_id: Hash,
     pub key: ScVal,
 }
 
@@ -172,7 +172,7 @@ mod test_footprint {
     fn footprint_record_access() {
         let mut fp = Footprint::default();
         // record when key not exist
-        let contract_id = ContractId([0; 32].into());
+        let contract_id = [0; 32].into();
         let key = ScVal::I32(0);
         let key = Key { contract_id, key };
         fp.record_access(&key, AccessType::ReadOnly);
@@ -187,7 +187,7 @@ mod test_footprint {
 
     #[test]
     fn footprint_enforce_access() {
-        let contract_id = ContractId([0; 32].into());
+        let contract_id = [0; 32].into();
         let key = ScVal::I32(0);
         let key = Key { contract_id, key };
         let om = OrdMap::unit(key.clone(), AccessType::ReadOnly);
@@ -202,7 +202,7 @@ mod test_footprint {
     #[should_panic(expected = "access to unknown footprint entry")]
     fn footprint_enforce_access_not_exist() {
         let mut fp = Footprint::default();
-        let contract_id = ContractId([0; 32].into());
+        let contract_id = [0; 32].into();
         let key = ScVal::I32(0);
         let key = Key { contract_id, key };
         fp.enforce_access(&key, AccessType::ReadOnly).unwrap();
@@ -211,7 +211,7 @@ mod test_footprint {
     #[test]
     #[should_panic(expected = "read-write access to read-only footprint entry")]
     fn footprint_attempt_to_write_readonly_entry() {
-        let contract_id = ContractId([0; 32].into());
+        let contract_id = [0; 32].into();
         let key = ScVal::I32(0);
         let key = Key { contract_id, key };
         let om = OrdMap::unit(key.clone(), AccessType::ReadOnly);

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -81,8 +81,8 @@ fn vec_as_seen_by_host() -> Result<(), ()> {
     let scvec1: ScVec = ScVec(vec![ScVal::U32(1)].try_into()?);
     let scobj0: ScObject = ScObject::Vec(scvec0);
     let scobj1: ScObject = ScObject::Vec(scvec1);
-    let scval0 = ScVal::Object(Some(Box::new(scobj0)));
-    let scval1 = ScVal::Object(Some(Box::new(scobj1)));
+    let scval0 = ScVal::Object(Some(scobj0));
+    let scval1 = ScVal::Object(Some(scobj1));
     let val0 = host.to_host_val(&scval0).unwrap();
     let val1 = host.to_host_val(&scval1).unwrap();
     assert!(val0.val.is::<Object>());
@@ -420,7 +420,7 @@ fn contract_invoke_another_contract() -> Result<(), ()> {
     use im_rc::OrdMap;
 
     let contract_id = ContractId([0; 32].into());
-    let key = ScVal::Static(ScStatic::Void); // TODO: replace with "SCS_LEDGER_KEY_CONTRACT_CODE_WASM"
+    let key = ScVal::Static(ScStatic::LedgerKeyContractCodeWasm);
     let storage_key = Key { contract_id, key };
     let code: [u8; 163] = [
         0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x07, 0x01, 0x60, 0x02, 0x7e, 0x7e,
@@ -436,7 +436,7 @@ fn contract_invoke_another_contract() -> Result<(), ()> {
         0x0b, 0x00, 0x0b, 0x20, 0x02, 0xad, 0x42, 0x04, 0x86, 0x42, 0x03, 0x84, 0x0b,
     ];
     let scob = ScObject::Binary(code.try_into()?);
-    let val = ScVal::Object(Some(Box::new(scob)));
+    let val = ScVal::Object(Some(scob));
     let map = OrdMap::unit(storage_key.clone(), Some(val));
     let mut footprint = Footprint::default();
     footprint.record_access(&storage_key, AccessType::ReadOnly);

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -7,9 +7,9 @@ use stellar_contract_env_common::{CheckedEnv, RawValConvertible};
 #[cfg(feature = "vm")]
 use crate::storage::{AccessType, Footprint, Key, Storage};
 #[cfg(feature = "vm")]
-use crate::{xdr::ScStatic, Symbol};
+use crate::Vm;
 #[cfg(feature = "vm")]
-use crate::{ContractId, Vm};
+use crate::{xdr::Hash, xdr::ScStatic, Symbol};
 #[cfg(feature = "vm")]
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
@@ -394,7 +394,7 @@ fn invoke_single_contract_function() -> Result<(), ()> {
         0x04, 0x88, 0xa7, 0x22, 0x03, 0x6a, 0x22, 0x02, 0x20, 0x03, 0x48, 0x73, 0x45, 0x0d, 0x01,
         0x0b, 0x00, 0x0b, 0x20, 0x02, 0xad, 0x42, 0x04, 0x86, 0x42, 0x03, 0x84, 0x0b,
     ];
-    let id = ContractId([0; 32].into());
+    let id: Hash = [0; 32].into();
     let vm = Vm::new(&host, id, &code).unwrap();
     let a = 4i32;
     let b = 7i32;
@@ -419,7 +419,7 @@ fn invoke_single_contract_function() -> Result<(), ()> {
 fn contract_invoke_another_contract() -> Result<(), ()> {
     use im_rc::OrdMap;
 
-    let contract_id = ContractId([0; 32].into());
+    let contract_id: Hash = [0; 32].into();
     let key = ScVal::Static(ScStatic::LedgerKeyContractCodeWasm);
     let storage_key = Key { contract_id, key };
     let code: [u8; 163] = [

--- a/stellar-contract-env-host/src/vm.rs
+++ b/stellar-contract-env-host/src/vm.rs
@@ -1,10 +1,10 @@
 mod dispatch;
 mod func_info;
 
-use crate::{host::Frame, ContractId, HostError};
+use crate::{host::Frame, HostError};
 
 use super::{
-    xdr::{ScVal, ScVec},
+    xdr::{Hash, ScVal, ScVec},
     Host, RawVal,
 };
 use func_info::HOST_FUNCTIONS;
@@ -112,7 +112,7 @@ impl ImportResolver for Host {
 #[derive(Clone)]
 pub struct Vm {
     #[allow(dead_code)]
-    contract_id: ContractId,
+    contract_id: Hash,
     elements_module: elements::Module,
     instance: ModuleRef, // this is a cloneable Rc<ModuleInstance>
 }
@@ -125,11 +125,7 @@ pub struct VmFunction {
 }
 
 impl Vm {
-    pub fn new(
-        host: &Host,
-        contract_id: ContractId,
-        module_wasm_code: &[u8],
-    ) -> Result<Self, HostError> {
+    pub fn new(host: &Host, contract_id: Hash, module_wasm_code: &[u8]) -> Result<Self, HostError> {
         let elements_module: elements::Module = elements::deserialize_buffer(module_wasm_code)?;
         let module: Module = Module::from_parity_wasm_module(elements_module.clone())?;
         module.deny_floating_point()?;


### PR DESCRIPTION
This updates definitions to match core (and subsequently XDR) definitions that landed with the contract-data branch. It does include removal of all the in-progress host object types, including bigint, which was removed upstream in core (and thus XDR). They will need to be re-added as they're finalized.