### PR TITLE
Remove some ledger fns

### DIFF
--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -106,19 +106,10 @@ macro_rules! call_macro_with_all_host_functions {
             }
 
             mod ledger "l" {
-                {"$_", fn get_current_ledger_num() -> RawVal }
-                {"$0", fn get_current_ledger_close_time() -> RawVal}
-
-                {"$1", fn pay(src:RawVal, dst:RawVal, asset:RawVal, amt:RawVal) -> RawVal}
-
-                {"$2", fn put_contract_data(k:RawVal, v: RawVal) -> RawVal}
-                {"$3", fn has_contract_data(k:RawVal) -> RawVal}
-                {"$4", fn get_contract_data(k:RawVal) -> RawVal}
-                {"$5", fn del_contract_data(k:RawVal) -> RawVal}
-
-                {"$6", fn account_balance(acct:RawVal) -> RawVal}
-                {"$7", fn account_trust_line(acct:RawVal, asset:RawVal) -> RawVal}
-                {"$8", fn trust_line_balance(tl:RawVal) -> RawVal}
+                {"$_", fn put_contract_data(k:RawVal, v: RawVal) -> RawVal}
+                {"$0", fn has_contract_data(k:RawVal) -> RawVal}
+                {"$1", fn get_contract_data(k:RawVal) -> RawVal}
+                {"$2", fn del_contract_data(k:RawVal) -> RawVal}
             }
 
             mod call "c" {

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -619,24 +619,6 @@ impl CheckedEnv for Host {
         Ok(self.add_host_object(vnew)?.into())
     }
 
-    fn get_current_ledger_num(&self) -> Result<RawVal, HostError> {
-        todo!()
-    }
-
-    fn get_current_ledger_close_time(&self) -> Result<RawVal, HostError> {
-        todo!()
-    }
-
-    fn pay(
-        &self,
-        src: RawVal,
-        dst: RawVal,
-        asset: RawVal,
-        amt: RawVal,
-    ) -> Result<RawVal, HostError> {
-        todo!()
-    }
-
     fn put_contract_data(&self, k: RawVal, v: RawVal) -> Result<RawVal, HostError> {
         let key = self.to_storage_key(k)?;
         let val = self.from_host_val(v)?;
@@ -660,18 +642,6 @@ impl CheckedEnv for Host {
         let key = self.to_storage_key(k)?;
         self.0.storage.borrow_mut().del(&key)?;
         Ok(().into())
-    }
-
-    fn account_balance(&self, acct: RawVal) -> Result<RawVal, HostError> {
-        todo!()
-    }
-
-    fn account_trust_line(&self, acct: RawVal, asset: RawVal) -> Result<RawVal, HostError> {
-        todo!()
-    }
-
-    fn trust_line_balance(&self, tl: RawVal) -> Result<RawVal, HostError> {
-        todo!()
     }
 
     fn call(&self, contract: Object, func: Symbol, args: Object) -> Result<RawVal, HostError> {


### PR DESCRIPTION
### What

Remove ledger env functions:
- `get_current_ledger_num()`
- `get_current_ledger_close_time()`
- `pay(...)`
- `account_balance(...)`
- `account_trust_line(...)`
- `trust_line_balance(...)`

### Why

They aren't defined in CAPs, and are left over from experimentation. Removing so they don't unintentionally inform our implementation or create confusion.

### Known limitations

[TODO or N/A]
