### PR TITLE
Add preliminary support for metering and cost budgets.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+
+[[package]]
 name = "libm"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,9 +57,9 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "memory_units"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
+checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "num-bigint"
@@ -102,6 +108,25 @@ name = "parity-wasm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
+
+[[package]]
+name = "perf-event"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5396562cd2eaa828445d6d34258ae21ee1eb9d40fe626ca7f51c8dccb4af9d66"
+dependencies = [
+ "libc",
+ "perf-event-open-sys",
+]
+
+[[package]]
+name = "perf-event-open-sys"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9bedf5da2c234fdf2391ede2b90fabf585355f33100689bc364a3ea558561a"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -176,8 +201,10 @@ dependencies = [
  "num-bigint",
  "num-rational",
  "parity-wasm",
+ "perf-event",
  "static_assertions",
  "stellar-contract-env-common",
+ "tabwriter",
  "thiserror",
  "wasmi",
 ]
@@ -203,6 +230,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tabwriter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36205cfc997faadcc4b0b87aaef3fbedafe20d38d4959a7ca6ff803564051111"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -232,6 +268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,23 +288,30 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "wasmi"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a3cb58f98e4d6c944af18c2c9002f22d0b928dfbb8b6c2b7d78a8573a5216bf"
+source = "git+https://github.com/stellar/wasmi?rev=4f35508c1a2475ed5d33955023f073639e7ff7df#4f35508c1a2475ed5d33955023f073639e7ff7df"
+dependencies = [
+ "parity-wasm",
+ "wasmi-validation",
+ "wasmi_core",
+]
+
+[[package]]
+name = "wasmi-validation"
+version = "0.4.1"
+source = "git+https://github.com/stellar/wasmi?rev=4f35508c1a2475ed5d33955023f073639e7ff7df#4f35508c1a2475ed5d33955023f073639e7ff7df"
+dependencies = [
+ "parity-wasm",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "0.1.0"
+source = "git+https://github.com/stellar/wasmi?rev=4f35508c1a2475ed5d33955023f073639e7ff7df#4f35508c1a2475ed5d33955023f073639e7ff7df"
 dependencies = [
  "downcast-rs",
  "libm",
  "memory_units",
  "num-rational",
  "num-traits",
- "parity-wasm",
- "wasmi-validation",
-]
-
-[[package]]
-name = "wasmi-validation"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165343ecd6c018fc09ebcae280752702c9a2ef3e6f8d02f1cfcbdb53ef6d7937"
-dependencies = [
  "parity-wasm",
 ]

--- a/stellar-contract-env-common/Cargo.toml
+++ b/stellar-contract-env-common/Cargo.toml
@@ -10,7 +10,7 @@ stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "2a8b24
 
 # wasmi is an optional dependency only to let us impl its type conversion
 # trait on RawVal locally in this crate; the VM itself is used in the host. 
-wasmi = { version = "0.11.0", optional = true }
+wasmi = { git = "https://github.com/stellar/wasmi", rev = "4f35508c1a2475ed5d33955023f073639e7ff7df", optional = true }
 
 [features]
 std = ["stellar-xdr/std"]

--- a/stellar-contract-env-common/src/raw_val.rs
+++ b/stellar-contract-env-common/src/raw_val.rs
@@ -113,8 +113,8 @@ declare_tryfrom!(u32);
 declare_tryfrom!(i32);
 
 #[cfg(feature = "vm")]
-impl wasmi::FromRuntimeValue for RawVal {
-    fn from_runtime_value(val: wasmi::RuntimeValue) -> Option<Self> {
+impl wasmi::FromValue for RawVal {
+    fn from_value(val: wasmi::RuntimeValue) -> Option<Self> {
         let maybe: Option<u64> = val.try_into();
         maybe.map(RawVal::from_payload)
     }

--- a/stellar-contract-env-common/src/tagged_val.rs
+++ b/stellar-contract-env-common/src/tagged_val.rs
@@ -153,8 +153,8 @@ impl<T: TagType> RawValConvertible for TaggedVal<T> {
 }
 
 #[cfg(feature = "vm")]
-impl<T: TagType> wasmi::FromRuntimeValue for TaggedVal<T> {
-    fn from_runtime_value(val: wasmi::RuntimeValue) -> Option<Self> {
+impl<T: TagType> wasmi::FromValue for TaggedVal<T> {
+    fn from_value(val: wasmi::RuntimeValue) -> Option<Self> {
         let maybe: Option<RawVal> = val.try_into();
         maybe.map(|x| Self(x, PhantomData))
     }

--- a/stellar-contract-env-host/Cargo.toml
+++ b/stellar-contract-env-host/Cargo.toml
@@ -12,8 +12,19 @@ im-rc = "15.0.0"
 num-bigint = "0.4"
 num-rational = "0.4"
 thiserror = "1.0.31"
-wasmi = { version = "0.11.0", optional = true }
+wasmi = { git = "https://github.com/stellar/wasmi", rev = "4f35508c1a2475ed5d33955023f073639e7ff7df", optional = true }
 parity-wasm = { version = "0.42.0", optional = true }
 
 [features]
 vm = ["wasmi", "parity-wasm", "stellar-contract-env-common/vm"]
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+perf-event = "0.4.7"
+tabwriter = "1.2.1"
+
+[[bench]]
+required-features = ["vm"]
+harness = false
+bench = true
+name = "calibrate_wasm_insns"
+path = "benches/calibrate_wasm_insns.rs"

--- a/stellar-contract-env-host/benches/calibrate_wasm_insns.rs
+++ b/stellar-contract-env-host/benches/calibrate_wasm_insns.rs
@@ -1,0 +1,101 @@
+// Run this with
+// $ cargo bench --features vm calibrate_wasm_insns -- --nocapture
+
+#[cfg(all(test, feature = "vm"))]
+fn wasm_module_with_4n_insns(n: usize) -> Vec<u8> {
+    use parity_wasm::builder;
+    use parity_wasm::elements::{
+        ExportEntry, Instruction,
+        Instruction::{GetLocal, I64Add, I64Const, I64Mul},
+        Instructions, Internal, ValueType,
+    };
+    let mut insns: Vec<Instruction> = Vec::new();
+    insns.push(I64Const(1));
+    for i in 0..n {
+        insns.push(GetLocal(0));
+        insns.push(I64Const(i as i64));
+        insns.push(I64Mul);
+        insns.push(I64Add);
+    }
+    insns.push(Instruction::Drop);
+    insns.push(I64Const(0));
+    insns.push(Instruction::End);
+    let module = builder::module()
+        .function()
+        .signature()
+        .with_params(vec![ValueType::I64])
+        .with_result(ValueType::I64)
+        .build()
+        .body()
+        .with_instructions(Instructions::new(insns))
+        .build()
+        .build()
+        .with_export(ExportEntry::new("test".into(), Internal::Function(0)))
+        .build();
+    module.to_bytes().unwrap()
+}
+
+#[cfg(all(test, feature = "vm", target_os = "linux"))]
+fn main() -> std::io::Result<()> {
+    use std::io::Write;
+    use std::time::Instant;
+    use stellar_contract_env_host::xdr::{Hash, ScVal, ScVec};
+    use stellar_contract_env_host::{Host, Vm};
+    use tabwriter::{Alignment, TabWriter};
+
+    let mut counter = perf_event::Builder::new().build()?;
+
+    let host = Host::default();
+    let scvec0: ScVec = ScVec(vec![ScVal::U63(5)].try_into().unwrap());
+
+    let mut baseline = 0;
+
+    let mut tw = TabWriter::new(vec![])
+        .padding(5)
+        .alignment(Alignment::Right);
+
+    write!(
+        &mut tw,
+        "CPU insns\tusec\tCPU / usec\tCPU - baseline\twasm insns\tCPU / wasm\n"
+    )
+    .unwrap();
+
+    for i in 0..20 {
+        host.modify_budget(|budget| {
+            budget.event_counts.wasm_insns = 0;
+            budget.cost_factors.cpu_insn_per_wasm_insn = 1;
+            budget.cost_limits.cpu_insn_limit = 1000000000000;
+        });
+
+        let id: Hash = [0; 32].into();
+        let code = wasm_module_with_4n_insns(i * 1000);
+        let vm = Vm::new(&host, id, &code).unwrap();
+        let start = Instant::now();
+        counter.reset()?;
+        counter.enable()?;
+        vm.invoke_function(&host, "test", &scvec0).unwrap();
+        counter.disable()?;
+        let stop = Instant::now();
+        let insns_total = counter.read()?;
+        let usec = stop.duration_since(start).as_micros() as u64;
+        if baseline == 0 {
+            baseline = insns_total;
+        }
+        let wasms_total = host.modify_budget(|b| b.event_counts.wasm_insns);
+        let wasm_per_insn = (insns_total - baseline) / wasms_total;
+        write!(
+            &mut tw,
+            "{}\t{}us\t{}\t{}\t{}\t{}\n",
+            insns_total,
+            usec,
+            insns_total / usec,
+            (insns_total - baseline),
+            wasms_total,
+            wasm_per_insn
+        )
+        .unwrap();
+    }
+    tw.flush().unwrap();
+    eprintln!("{}", String::from_utf8(tw.into_inner().unwrap()).unwrap());
+    Ok(())
+}

--- a/stellar-contract-env-host/src/budget.rs
+++ b/stellar-contract-env-host/src/budget.rs
@@ -1,0 +1,68 @@
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CostLimits {
+    pub mem_byte_limit: u64,
+    pub cpu_insn_limit: u64,
+}
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CostFactors {
+    pub cpu_insn_per_wasm_insn: u64,
+}
+
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct EventCounts {
+    pub wasm_insns: u64,
+    pub wasm_linear_memory_bytes: u64,
+}
+
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Budget {
+    pub cost_limits: CostLimits,
+    pub cost_factors: CostFactors,
+    pub event_counts: EventCounts,
+}
+
+impl Budget {
+    pub fn cpu_limit_exceeded(&self) -> bool {
+        self.event_counts
+            .wasm_insns
+            .saturating_mul(self.cost_factors.cpu_insn_per_wasm_insn)
+            > self.cost_limits.cpu_insn_limit
+    }
+    pub fn mem_limit_exceeded(&self) -> bool {
+        self.event_counts.wasm_linear_memory_bytes > self.cost_limits.mem_byte_limit
+    }
+}
+
+impl Default for CostFactors {
+    fn default() -> Self {
+        Self {
+            // Note: This was empirically calibrated very crudely on an x64
+            // system based on the `calibrate_wasm_insns` benchmark, using:
+            //
+            //  $ cargo bench --features vm calibrate_wasm_insns -- --nocapture
+            //
+            // It should be explored in more detail and stored / retrieved on
+            // chain in a CONFIG_SETTING LE.
+            cpu_insn_per_wasm_insn: 73,
+        }
+    }
+}
+
+impl Default for CostLimits {
+    fn default() -> Self {
+        // Some "reasonable defaults": 640k of RAM and 100usec.
+        //
+        // We don't run for a time unit thought, we run for an estimated
+        // (calibrated) number of CPU instructions.
+        //
+        // Assuming 2ghz chips at 2 instructions per cycle, we can guess about
+        // 4bn instructions / sec. So about 4000 instructions per usec, or 400k
+        // instructions in a 100usec time budget, or about 5479 wasm instructions
+        // using the calibration above. Very roughly!
+        Self {
+            mem_byte_limit: 0xa_0000,
+            cpu_insn_limit: 400_000,
+        }
+    }
+}

--- a/stellar-contract-env-host/src/lib.rs
+++ b/stellar-contract-env-host/src/lib.rs
@@ -1,3 +1,4 @@
+mod budget;
 mod host;
 pub(crate) mod host_object;
 pub(crate) mod weak_host;

--- a/stellar-contract-env-host/src/vm.rs
+++ b/stellar-contract-env-host/src/vm.rs
@@ -1,7 +1,7 @@
 mod dispatch;
 mod func_info;
 
-use crate::{budget::Budget, host::Frame, HostError};
+use crate::{budget::Budget, HostError};
 use std::rc::Rc;
 
 use super::{

--- a/stellar-contract-env-host/src/vm.rs
+++ b/stellar-contract-env-host/src/vm.rs
@@ -1,7 +1,7 @@
 mod dispatch;
 mod func_info;
 
-use crate::{host::Frame, HostError};
+use crate::{budget::Budget, host::Frame, HostError};
 
 use super::{
     xdr::{Hash, ScVal, ScVec},
@@ -23,15 +23,41 @@ impl Externals for Host {
         args: RuntimeArgs,
     ) -> Result<Option<wasmi::RuntimeValue>, wasmi::Trap> {
         if index > HOST_FUNCTIONS.len() {
-            return Err(wasmi::TrapKind::TableAccessOutOfBounds.into());
+            return Err(wasmi::TrapCode::TableAccessOutOfBounds.into());
         }
         let hf = &HOST_FUNCTIONS[index];
         if hf.arity != args.len() {
-            return Err(wasmi::TrapKind::UnexpectedSignature.into());
+            return Err(wasmi::TrapCode::UnexpectedSignature.into());
         }
 
         let rv = (hf.dispatch)(self, args)?;
         Ok(Some(rv))
+    }
+
+    fn max_insn_step(&self) -> u64 {
+        256
+    }
+
+    fn charge_cpu(&mut self, insns: u64) -> Result<(), wasmi::TrapCode> {
+        self.modify_budget(|budget: &mut Budget| {
+            budget.event_counts.wasm_insns += insns;
+            if budget.cpu_limit_exceeded() {
+                Err(wasmi::TrapCode::CpuLimitExceeded)
+            } else {
+                Ok(())
+            }
+        })
+    }
+
+    fn charge_mem(&mut self, bytes: u64) -> Result<(), wasmi::TrapCode> {
+        self.modify_budget(|budget: &mut Budget| {
+            budget.event_counts.wasm_linear_memory_bytes += bytes;
+            if budget.mem_limit_exceeded() {
+                Err(wasmi::TrapCode::MemLimitExceeded)
+            } else {
+                Ok(())
+            }
+        })
     }
 }
 
@@ -173,7 +199,7 @@ impl Vm {
             Ok(RawVal::from_payload(ret as u64))
         } else {
             Err(HostError::WASMIError(wasmi::Error::Trap(
-                wasmi::TrapKind::UnexpectedSignature.into(),
+                wasmi::TrapCode::UnexpectedSignature.into(),
             )))
         }
     }


### PR DESCRIPTION
This PR does 3 main things:

1. Adds a new `Budget` type to `Host` that can be queried or modified by host and vm code to record cost-incurring events, scale them by cost factors, and compare them to cost limits.
2. Bumps wasmi to a recent commit I pushed to https://github.com/stellar/wasmi which gives it some basic step-metering and memory-metering capability (calling back through the `Externals` interface it already uses to call back to host functions), wiring that up to the `Budget` type.
3. Adds a benchmark that calibrates (using synthetic wasm code of varying lengths) a basic CPU-instructions-per-wasm-instruction in terms of linux `perf` hardware performance counters. It's fairly crude but gets us a decently stable number. On my system it produces this:

![image](https://user-images.githubusercontent.com/14097/174249526-9c63c081-4590-4b58-83f6-908e5749531d.png)
