### PR TITLE
Add ExpectFromVal for panic version of TryFromVal

### DIFF
--- a/stellar-contract-env-common/src/lib.rs
+++ b/stellar-contract-env-common/src/lib.rs
@@ -27,7 +27,7 @@ pub use val::Val;
 // RawVal and EnvObj couple raw types to environments.
 pub use checked_env::CheckedEnv;
 pub use env::{Env, EnvBase};
-pub use env_val::{EnvVal, IntoEnvVal, IntoVal, TryFromVal};
+pub use env_val::{EnvVal, ExpectFromVal, IntoEnvVal, IntoVal, TryFromVal};
 pub use unimplemented_env::UnimplementedEnv;
 
 // BitSet, Status and Symbol wrap RawVals.


### PR DESCRIPTION
### What

Add ExpectFromVal for panic version of TryFromVal.

### Why

@jonjove pointed out that the size of contracts have gone up since introducing `contractfn`. The macro adds in try_from_val's around all parameters, even parameters that don't need them, like Symbols, Bitsets, etc. The macro will use this new trait instead and types that never fails conversion can override the 

### Known limitations

[TODO or N/A]
