### PR TITLE
Implement subtransactions

### DIFF
--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -63,15 +63,30 @@ impl From<BitSetError> for HostError {
     }
 }
 
-/// Holds contextual information about a single contract invocation (or possibly
-/// other actions that alter the excution context).
+/// Saves host state (storage and objects) for rolling back a (sub-)transaction
+/// on error. A helper type used by [`FrameGuard`].
+#[derive(Clone)]
+struct RollbackPoint {
+    storage: OrdMap<LedgerKey, Option<LedgerEntry>>,
+    objects: usize,
+}
+
+/// Holds contextual information about a single invocation, either
+/// a reference to a contract [`Vm`] or an enclosing [`HostFunction`]
+/// invocation.
 ///
 /// Frames are arranged into a stack in [`HostImpl::context`], and are pushed
-/// with [`Host::push_frame`].
+/// with [`Host::push_frame`], which returns a [`FrameGuard`] that will
+/// pop the frame on scope-exit.
+///
+/// Frames are also the units of (sub-)transactions: each frame captures
+/// the host state when it is pushed, and the [`FrameGuard`] will either
+/// commit or roll back that state when it pops the stack.
 #[derive(Clone)]
-pub(crate) struct Frame {
-    pub(crate) contract_id: Hash,
-    // Other activation-frame / execution-context values here.
+pub(crate) enum Frame {
+    #[cfg(feature = "vm")]
+    ContractVM(Rc<Vm>),
+    Hostfunction(HostFunction),
 }
 
 #[derive(Clone, Default)]
@@ -81,18 +96,32 @@ pub(crate) struct HostImpl {
     context: RefCell<Vec<Frame>>,
 }
 
+/// A guard struct that exists to call [`Host::pop_frame`] when it is dropped,
+/// providing whatever rollback it is holding as an argument. By default, this
+/// means that when a [`FrameGuard`] drops, it will roll the [`Host`] back to
+/// the state it had before its associated [`Frame`] was pushed.
+///
+/// Users may call [`FrameGuard::commit`] to cause the rollback point to be set
+/// to `None`, which will cause the [`FrameGuard`] to commit changes to the host
+/// that occurred during its lifetime, rather than rollling them back.
 pub(crate) struct FrameGuard {
+    rollback: Option<RollbackPoint>,
     host: Host,
+}
+
+impl FrameGuard {
+    pub(crate) fn commit(&mut self) {
+        if self.rollback.is_none() {
+            panic!("committing on already-committed FrameGuard")
+        }
+        self.rollback = None
+    }
 }
 
 impl Drop for FrameGuard {
     fn drop(&mut self) {
-        self.host
-            .0
-            .context
-            .borrow_mut()
-            .pop()
-            .expect("unmatched host frame push/pop");
+        let rollback = self.rollback.take();
+        self.host.pop_frame(rollback)
     }
 }
 
@@ -118,18 +147,59 @@ impl Host {
         }))
     }
 
-    pub fn try_recover_storage(self) -> Result<Storage, Self> {
+    pub(crate) fn visit_storage<F, U>(&self, f: F) -> Result<U, HostError>
+    where
+        F: FnOnce(&mut Storage) -> Result<U, HostError>,
+    {
+        f(&mut *self.0.storage.borrow_mut())
+    }
+
+    pub fn recover_storage(self) -> Result<Storage, Self> {
         Rc::try_unwrap(self.0)
             .map(|host_impl| host_impl.storage.into_inner())
             .map_err(|rc_host_impl| Host(rc_host_impl))
     }
 
-    /// Pushes a new [`Frame`] on the context stack, returning a [`FrameGuard`]
+    fn capture_rollback_point(&self) -> RollbackPoint {
+        RollbackPoint {
+            objects: self.0.objects.borrow().len(),
+            storage: self.0.storage.borrow().map.clone(),
+        }
+    }
+
+    fn pop_frame(&self, rollback: Option<RollbackPoint>) {
+        self.0
+            .context
+            .borrow_mut()
+            .pop()
+            .expect("unmatched host frame push/pop");
+        match rollback {
+            None => (),
+            Some(rp) => {
+                self.0.objects.borrow_mut().truncate(rp.objects);
+                self.0.storage.borrow_mut().map = rp.storage;
+            }
+        }
+    }
+
+    /// Pushes a new VM-related [`Frame`] on the context stack, returning a [`FrameGuard`]
     /// that will pop the stack when it is dropped. This should be called at
     /// least any time a new contract is invoked.
-    pub(crate) fn push_frame(&self, frame: Frame) -> FrameGuard {
-        self.0.context.borrow_mut().push(frame);
-        FrameGuard { host: self.clone() }
+    #[cfg(feature = "vm")]
+    pub(crate) fn push_vm_frame(&self, vm: Rc<Vm>) -> FrameGuard {
+        self.0.context.borrow_mut().push(Frame::ContractVM(vm));
+        FrameGuard {
+            rollback: Some(self.capture_rollback_point()),
+            host: self.clone(),
+        }
+    }
+
+    pub(crate) fn push_host_function_frame(&self, func: HostFunction) -> FrameGuard {
+        self.0.context.borrow_mut().push(Frame::Hostfunction(func));
+        FrameGuard {
+            rollback: Some(self.capture_rollback_point()),
+            host: self.clone(),
+        }
     }
 
     /// Applies a function to the top [`Frame`] of the context stack. Returns
@@ -137,17 +207,27 @@ impl Host {
     /// function call.
     fn with_current_frame<F, U>(&self, f: F) -> Result<U, HostError>
     where
-        F: FnOnce(&Frame) -> U,
+        F: FnOnce(&Frame) -> Result<U, HostError>,
     {
-        Ok(f(self.0.context.borrow().last().ok_or(
-            HostError::General("no contract currently running"),
-        )?))
+        f(self
+            .0
+            .context
+            .borrow()
+            .last()
+            .ok_or(HostError::General("no contract currently running"))?)
     }
 
-    /// Returns [`Hash`] contract ID from top of context stack, or a
-    /// [`HostError`] if the context stack is empty.
+    /// Returns [`Hash`] contract ID from the VM frame at the top of the context
+    /// stack, or a [`HostError`] if the context stack is empty or has a non-VM
+    /// frame at its top.
     fn get_current_contract_id(&self) -> Result<Hash, HostError> {
-        self.with_current_frame(|frame| frame.contract_id.clone())
+        self.with_current_frame(|frame| match frame {
+            #[cfg(feature = "vm")]
+            Frame::ContractVM(vm) => Ok(vm.contract_id.clone()),
+            Frame::Hostfunction(_) => Err(HostError::General(
+                "Host function context has no contract ID",
+            )),
+        })
     }
 
     unsafe fn unchecked_visit_val_obj<F, U>(&self, val: RawVal, f: F) -> U
@@ -406,7 +486,7 @@ impl Host {
             for scv in rest.iter() {
                 raw_args.push(self.to_host_val(&scv)?.val);
             }
-
+            let mut frame_guard = self.push_host_function_frame(hf);
             let raw_res = match hf {
                 HostFunction::Call => {
                     #[cfg(not(feature = "vm"))]
@@ -416,6 +496,7 @@ impl Host {
                 }
                 _ => Err(HostError::General("bad host function")),
             }?;
+            frame_guard.commit();
             Ok(self.from_host_val(raw_res)?)
         } else {
             return Err(HostError::General("unexpected args"));

--- a/stellar-contract-env-host/src/vm.rs
+++ b/stellar-contract-env-host/src/vm.rs
@@ -1,7 +1,9 @@
 mod dispatch;
 mod func_info;
 
-use crate::{host::Frame, HostError};
+use std::rc::Rc;
+
+use crate::HostError;
 
 use super::{
     xdr::{Hash, ScVal, ScVec},
@@ -109,10 +111,9 @@ impl ImportResolver for Host {
 //
 // Any lookups on any tables other than import functions will fail, and only
 // those import functions listed above will succeed.
-#[derive(Clone)]
 pub struct Vm {
     #[allow(dead_code)]
-    contract_id: Hash,
+    pub(crate) contract_id: Hash,
     elements_module: elements::Module,
     instance: ModuleRef, // this is a cloneable Rc<ModuleInstance>
 }
@@ -125,7 +126,11 @@ pub struct VmFunction {
 }
 
 impl Vm {
-    pub fn new(host: &Host, contract_id: Hash, module_wasm_code: &[u8]) -> Result<Self, HostError> {
+    pub fn new(
+        host: &Host,
+        contract_id: Hash,
+        module_wasm_code: &[u8],
+    ) -> Result<Rc<Self>, HostError> {
         let elements_module: elements::Module = elements::deserialize_buffer(module_wasm_code)?;
         let module: Module = Module::from_parity_wasm_module(elements_module.clone())?;
         module.deny_floating_point()?;
@@ -136,22 +141,20 @@ impl Vm {
             );
         }
         let instance = not_started_instance.assert_no_start();
-        Ok(Self {
+        Ok(Rc::new(Self {
             contract_id,
             elements_module,
             instance,
-        })
+        }))
     }
 
     pub(crate) fn invoke_function_raw(
-        &self,
+        self: &Rc<Self>,
         host: &Host,
         func: &str,
         args: &[RawVal],
     ) -> Result<RawVal, HostError> {
-        let _frame_guard = host.push_frame(Frame {
-            contract_id: self.contract_id.clone(),
-        });
+        let mut frame_guard = host.push_vm_frame(self.clone());
         let wasm_args: Vec<_> = args
             .iter()
             .map(|i| RuntimeValue::I64(i.get_payload() as i64))
@@ -170,6 +173,7 @@ impl Vm {
             .instance
             .invoke_export(func, wasm_args.as_slice(), &mut host)?;
         if let Some(RuntimeValue::I64(ret)) = wasm_ret {
+            frame_guard.commit();
             Ok(RawVal::from_payload(ret as u64))
         } else {
             Err(HostError::WASMIError(wasmi::Error::Trap(
@@ -181,8 +185,11 @@ impl Vm {
     /// Invoke a function in the VM's module, converting externally stable
     /// XDR ScVal arguments into Host-specific RawVals and converting the
     /// RawVal result back to an ScVal.
+    ///
+    /// This function has to take self by [`Rc`] because it stores self in
+    /// a new [`Frame`]
     pub fn invoke_function(
-        &self,
+        self: &Rc<Self>,
         host: &Host,
         func: &str,
         args: &ScVec,


### PR DESCRIPTION
This implements subtransactions in the host. Both host function calls and VM export invocations push a frame that rolls back on error and commits on success. We can tweak the logic and provide user-facing access to the guts if desired later, but this at least makes errors behave as people will expect with respect to the host: as no-ops.