### PR TITLE
Add host functions for CAP-52

### DIFF
--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -64,6 +64,9 @@ macro_rules! call_macro_with_all_host_functions {
 
             mod context "x" {
                 {"_", fn log_value(v:RawVal) -> RawVal }
+                /// Get the binary contractID of the contract which invoked the
+                /// running contract. Traps if the running contract was not
+                /// invoked by a contract.
                 {"0", fn get_invoking_contract() -> Object }
                 {"1", fn obj_cmp(a:RawVal, b:RawVal) -> i64 }
             }
@@ -185,10 +188,21 @@ macro_rules! call_macro_with_all_host_functions {
             }
 
             mod account "a" {
+                /// Get the low threshold for the account with ed25519 public
+                /// key a (a is binary). Traps if no such account exists.
                 {"_", fn account_get_low_threshold(a:Object) -> RawVal}
+                /// Get the medium threshold for the account with ed25519 public
+                /// key a (a is binary). Traps if no such account exists.
                 {"0", fn account_get_medium_threshold(a:Object) -> RawVal}
+                /// Get the high threshold for the account with ed25519 public
+                /// key a (a is binary). Traps if no such account exists.
                 {"1", fn account_get_high_threshold(a:Object) -> RawVal}
-                {"2", fn account_get_signer_weight(a:Object) -> RawVal}
+                /// Get the signer weight for the signer with ed25519 public key
+                /// s (s is binary) on the account with ed25519 public key a (a
+                /// is binary). Returns the master weight if the signer is the
+                /// master, and returns 0 if no such signer exists. Traps if no
+                /// such account exists.
+                {"2", fn account_get_signer_weight(a:Object, s:Object) -> RawVal}
             }
         }
     };

--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -183,6 +183,13 @@ macro_rules! call_macro_with_all_host_functions {
                 {"_", fn compute_hash_sha256(x:Object) -> Object}
                 {"0", fn verify_sig_ed25519(x:Object, k:Object, s:Object) -> RawVal}
             }
+
+            mod account "a" {
+                {"_", fn get_low_threshold(a:Object) -> RawVal}
+                {"0", fn get_medium_threshold(a:Object) -> RawVal}
+                {"1", fn get_high_threshold(a:Object) -> RawVal}
+                {"2", fn get_signer_weight(a:Object) -> RawVal}
+            }
         }
     };
 }

--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -64,7 +64,7 @@ macro_rules! call_macro_with_all_host_functions {
 
             mod context "x" {
                 {"_", fn log_value(v:RawVal) -> RawVal }
-                {"0", fn get_last_operation_result() -> RawVal }
+                {"0", fn get_invoking_contract() -> Object }
                 {"1", fn obj_cmp(a:RawVal, b:RawVal) -> i64 }
             }
 

--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -185,10 +185,10 @@ macro_rules! call_macro_with_all_host_functions {
             }
 
             mod account "a" {
-                {"_", fn get_low_threshold(a:Object) -> RawVal}
-                {"0", fn get_medium_threshold(a:Object) -> RawVal}
-                {"1", fn get_high_threshold(a:Object) -> RawVal}
-                {"2", fn get_signer_weight(a:Object) -> RawVal}
+                {"_", fn account_get_low_threshold(a:Object) -> RawVal}
+                {"0", fn account_get_medium_threshold(a:Object) -> RawVal}
+                {"1", fn account_get_high_threshold(a:Object) -> RawVal}
+                {"2", fn account_get_signer_weight(a:Object) -> RawVal}
             }
         }
     };

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -1051,7 +1051,7 @@ impl CheckedEnv for Host {
         todo!()
     }
 
-    fn account_get_signer_weight(&self, a: Object) -> Result<RawVal, Self::Error> {
+    fn account_get_signer_weight(&self, a: Object, s: Object) -> Result<RawVal, Self::Error> {
         todo!()
     }
 }

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -1015,19 +1015,19 @@ impl CheckedEnv for Host {
         todo!()
     }
 
-    fn get_low_threshold(&self, a: Object) -> Result<RawVal, Self::Error> {
+    fn account_get_low_threshold(&self, a: Object) -> Result<RawVal, Self::Error> {
         todo!()
     }
 
-    fn get_medium_threshold(&self, a: Object) -> Result<RawVal, Self::Error> {
+    fn account_get_medium_threshold(&self, a: Object) -> Result<RawVal, Self::Error> {
         todo!()
     }
 
-    fn get_high_threshold(&self, a: Object) -> Result<RawVal, Self::Error> {
+    fn account_get_high_threshold(&self, a: Object) -> Result<RawVal, Self::Error> {
         todo!()
     }
 
-    fn get_signer_weight(&self, a: Object) -> Result<RawVal, Self::Error> {
+    fn account_get_signer_weight(&self, a: Object) -> Result<RawVal, Self::Error> {
         todo!()
     }
 }

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -1014,4 +1014,20 @@ impl CheckedEnv for Host {
     fn verify_sig_ed25519(&self, x: Object, k: Object, s: Object) -> Result<RawVal, HostError> {
         todo!()
     }
+
+    fn get_low_threshold(&self, a: Object) -> Result<RawVal, Self::Error> {
+        todo!()
+    }
+
+    fn get_medium_threshold(&self, a: Object) -> Result<RawVal, Self::Error> {
+        todo!()
+    }
+
+    fn get_high_threshold(&self, a: Object) -> Result<RawVal, Self::Error> {
+        todo!()
+    }
+
+    fn get_signer_weight(&self, a: Object) -> Result<RawVal, Self::Error> {
+        todo!()
+    }
 }

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -561,10 +561,6 @@ impl CheckedEnv for Host {
         todo!()
     }
 
-    fn get_last_operation_result(&self) -> Result<RawVal, HostError> {
-        todo!()
-    }
-
     fn obj_cmp(&self, a: RawVal, b: RawVal) -> Result<i64, HostError> {
         let res = unsafe {
             self.unchecked_visit_val_obj(a, |ao| self.unchecked_visit_val_obj(b, |bo| ao.cmp(&bo)))
@@ -574,6 +570,10 @@ impl CheckedEnv for Host {
             Ordering::Equal => 0,
             Ordering::Greater => 1,
         })
+    }
+
+    fn get_invoking_contract(&self) -> Result<Object, HostError> {
+        todo!()
     }
 
     fn obj_from_u64(&self, u: u64) -> Result<Object, HostError> {


### PR DESCRIPTION
### What

Removes stale `get_last_operation_result` host function that no longer exists. Adds host functions specified in CAP-52 without implementations.

### Why

The CAP-52 host functions are need for the implementation of CAP-54.

### Known limitations

New host functions aren't actually implemented yet.