### PR TITLE
Add testutils feature and use it to emulate a Frame

### DIFF
--- a/stellar-contract-env-host/Cargo.toml
+++ b/stellar-contract-env-host/Cargo.toml
@@ -20,6 +20,7 @@ hex = "0.4.3"
 
 [features]
 vm = ["wasmi", "parity-wasm", "stellar-contract-env-common/vm"]
+testutils = []
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 perf-event = "0.4.7"

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -220,9 +220,16 @@ impl Host {
     #[cfg(feature = "testutils")]
     pub fn push_test_frame(&self, id: Object) -> Result<FrameGuard, HostError> {
         let contract_id = self.visit_obj(id, |b: &Vec<u8>| {
-            Ok(Hash(b.clone().try_into().map_err(|_| HostError::General("not binary"))?))
+            Ok(Hash(
+                b.clone()
+                    .try_into()
+                    .map_err(|_| HostError::General("not binary"))?,
+            ))
         })?;
-        self.0.context.borrow_mut().push(Frame::TestContract(contract_id));
+        self.0
+            .context
+            .borrow_mut()
+            .push(Frame::TestContract(contract_id));
         Ok(FrameGuard {
             rollback: Some(self.capture_rollback_point()),
             host: self.clone(),

--- a/stellar-contract-env-host/src/lib.rs
+++ b/stellar-contract-env-host/src/lib.rs
@@ -11,5 +11,7 @@ pub mod storage;
 #[cfg(test)]
 mod test;
 
+#[cfg(feature = "testutils")]
+pub use host::FrameGuard;
 pub use host::{Host, HostError};
 pub use stellar_contract_env_common::*;


### PR DESCRIPTION
### What

Adds a new feature that facilitates testing.

### Why

Makes it possible to call contract data functions from native tests.

### Known limitations

It would be better if we didn't need to use this "testutils" feature and instead could do this through `cfg(test)`.