### PR TITLE
Change binary_get to return RawVal instead of Object

### DIFF
--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -160,7 +160,7 @@ macro_rules! call_macro_with_all_host_functions {
                 // These functions below ($3-$F) mirror vector operations
                 {"3", fn binary_new() -> Object}
                 {"4", fn binary_put(v:Object, i:RawVal, x:RawVal) -> Object}
-                {"5", fn binary_get(x:Object, i:RawVal) -> Object}
+                {"5", fn binary_get(x:Object, i:RawVal) -> RawVal}
                 {"6", fn binary_del(v:Object, i:RawVal) -> Object}
                 {"7", fn binary_len(x:Object) -> RawVal}
                 {"8", fn binary_push(x:Object, v:RawVal) -> Object}

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -951,7 +951,7 @@ impl CheckedEnv for Host {
         todo!()
     }
 
-    fn binary_get(&self, x: Object, i: RawVal) -> Result<Object, HostError> {
+    fn binary_get(&self, x: Object, i: RawVal) -> Result<RawVal, HostError> {
         todo!()
     }
 


### PR DESCRIPTION
### What

`binary_get` now returns a `RawVal`.

### Why

`binary_get` always returns a number, so there is no reason to use an object.

### Known limitations

None.