### PR TITLE
Expose `try_call` as a public host function

### DIFF
--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -162,6 +162,7 @@ macro_rules! call_macro_with_all_host_functions {
 
             mod call "c" {
                 {"_", fn call(contract:Object, func:Symbol, args:Object) -> RawVal}
+                {"0", fn try_call(contract:Object, func:Symbol, args:Object) -> RawVal}
             }
 
             mod bigint "g" {

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -772,7 +772,9 @@ fn invoke_cross_contract_with_err() {
     let scvec0: ScVec = vec![ScVal::I32(1)].try_into().unwrap();
     let args = host.to_host_obj(&ScObject::Vec(scvec0)).unwrap();
     // call
-    let sv = host.try_call(obj.to_object(), sym.into(), args.clone().into());
+    let sv = host
+        .try_call(obj.to_object(), sym.into(), args.clone().into())
+        .unwrap();
     let exp_st = Status::from_type_and_code(
         ScStatusType::HostObjectError,
         ScHostObjErrorCode::VecIndexOutOfBound as u32,
@@ -890,7 +892,9 @@ fn invoke_cross_contract_lvl2_nested_with_err() {
     let scvec0: ScVec = vec![ScVal::I32(1)].try_into().unwrap();
     let args = host.to_host_obj(&ScObject::Vec(scvec0)).unwrap();
     // try call
-    let sv = host.try_call(obj.to_object(), sym.into(), args.clone().into());
+    let sv = host
+        .try_call(obj.to_object(), sym.into(), args.clone().into())
+        .unwrap();
     let exp_st = Status::from_type_and_code(
         ScStatusType::HostObjectError,
         ScHostObjErrorCode::VecIndexOutOfBound as u32,


### PR DESCRIPTION
### What

- Expose `try_call` as a public host function through macro. 
- Some minor cleanup.

### Why

Previously it was added as a public crate function but not a host function.
We decided that it is ok for `try_call` to return a `Result` that is always `Ok`.

### Known limitations

[TODO or N/A]
