### PR TITLE
Misc gardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +423,7 @@ dependencies = [
 name = "stellar-contract-env-host"
 version = "0.0.0"
 dependencies = [
+ "assert_matches",
  "ed25519-dalek",
  "hex",
  "im-rc",

--- a/stellar-contract-env-common/src/bitset.rs
+++ b/stellar-contract-env-common/src/bitset.rs
@@ -1,11 +1,12 @@
 use crate::{RawVal, Tag, TagBitSet, TaggedVal};
-
 use core::cmp::Ordering;
+use core::fmt::Debug;
 use core::hash::{Hash, Hasher};
 use core::marker::PhantomData;
 
 pub type BitSet = TaggedVal<TagBitSet>;
 
+#[derive(Debug)]
 pub enum BitSetError {
     TooManyBits(u64),
 }
@@ -37,6 +38,12 @@ impl Ord for BitSet {
     #[inline(always)]
     fn cmp(&self, other: &Self) -> Ordering {
         self.as_ref().get_body().cmp(&other.as_ref().get_body())
+    }
+}
+
+impl Debug for BitSet {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "BitSet({:#b})", self.as_ref().get_body())
     }
 }
 

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -1,6 +1,8 @@
 use stellar_xdr::ScObjectType;
 
-use crate::{BitSet, Object, Status, Symbol, Tag, TagType, TaggedVal, Val};
+use crate::{
+    raw_val::ConversionError, BitSet, Object, Status, Symbol, Tag, TagType, TaggedVal, Val,
+};
 
 use super::{
     raw_val::{RawVal, RawValConvertible},
@@ -131,7 +133,7 @@ impl<E: Env> From<EnvVal<E, RawVal>> for RawVal {
 }
 
 impl<E: Env, T: TagType> TryFrom<EnvVal<E, RawVal>> for TaggedVal<T> {
-    type Error = ();
+    type Error = ConversionError;
 
     fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
         ev.to_raw().try_into()
@@ -139,7 +141,7 @@ impl<E: Env, T: TagType> TryFrom<EnvVal<E, RawVal>> for TaggedVal<T> {
 }
 
 impl<E: Env, T: TagType> TryFrom<EnvVal<E, RawVal>> for EnvVal<E, TaggedVal<T>> {
-    type Error = ();
+    type Error = ConversionError;
 
     fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
         let tv: TaggedVal<T> = ev.to_raw().try_into()?;
@@ -178,7 +180,7 @@ impl<E: Env, T: TagType> IntoEnvVal<E, TaggedVal<T>> for TaggedVal<T> {
 }
 
 impl<E: Env> TryFrom<EnvVal<E, RawVal>> for i64 {
-    type Error = ();
+    type Error = ConversionError;
 
     fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
         if ev.val.is_u63() {
@@ -187,7 +189,7 @@ impl<E: Env> TryFrom<EnvVal<E, RawVal>> for i64 {
             let obj = unsafe { Object::unchecked_from_val(ev.val) };
             Ok(ev.env.obj_to_i64(obj))
         } else {
-            Err(())
+            Err(ConversionError)
         }
     }
 }
@@ -207,14 +209,14 @@ impl<E: Env> IntoEnvVal<E, RawVal> for i64 {
 }
 
 impl<E: Env> TryFrom<EnvVal<E, RawVal>> for u64 {
-    type Error = ();
+    type Error = ConversionError;
 
     fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
         if Object::val_is_obj_type(ev.val, ScObjectType::U64) {
             let obj = unsafe { Object::unchecked_from_val(ev.val) };
             Ok(ev.env.obj_to_u64(obj))
         } else {
-            Err(())
+            Err(ConversionError)
         }
     }
 }

--- a/stellar-contract-env-common/src/lib.rs
+++ b/stellar-contract-env-common/src/lib.rs
@@ -17,7 +17,7 @@ mod val;
 pub use stellar_xdr as xdr;
 
 // RawVal and RawObj are the 64-bit transparent type.
-pub use raw_val::{RawVal, RawValConvertible, Tag};
+pub use raw_val::{ConversionError, RawVal, RawValConvertible, Tag};
 
 pub use tagged_val::{
     TagBitSet, TagI32, TagObject, TagStatic, TagStatus, TagSymbol, TagType, TagU32, TaggedVal,

--- a/stellar-contract-env-common/src/object.rs
+++ b/stellar-contract-env-common/src/object.rs
@@ -1,7 +1,20 @@
 use super::{xdr::ScObjectType, RawVal, Tag};
 use crate::tagged_val::{TagObject, TaggedVal};
+use core::fmt::Debug;
 
 pub type Object = TaggedVal<TagObject>;
+
+impl Debug for Object {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let object_type_res: Result<ScObjectType, _> = (self.0.get_minor() as i32).try_into();
+        let object_type_name: &str = match &object_type_res {
+            Ok(ty) => ty.name(),
+            Err(_) => &"Unknown",
+        };
+        let index = self.0.get_major();
+        write!(f, "Object({}({}))", object_type_name, index)
+    }
+}
 
 impl Object {
     // NB: we don't provide a "get_type" to avoid casting a bad bit-pattern into

--- a/stellar-contract-env-common/src/option.rs
+++ b/stellar-contract-env-common/src/option.rs
@@ -9,7 +9,7 @@ impl<E: Env, T> TryFrom<EnvVal<E, RawVal>> for Option<T>
 where
     T: TryFrom<EnvVal<E, RawVal>>,
 {
-    type Error = ();
+    type Error = ConversionError;
 
     fn try_from(ev: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
         if !Object::val_is_obj_type(ev.val, ScObjectType::Vec) {
@@ -24,7 +24,7 @@ where
                 let val = env.vec_get(vec, 0u32.into());
                 T::try_from_val(&env, val).map_err(|_| ())?
             }),
-            _ => Err(()),
+            _ => Err(ConversionError),
         }
     }
 }

--- a/stellar-contract-env-common/src/status.rs
+++ b/stellar-contract-env-common/src/status.rs
@@ -1,10 +1,14 @@
 use crate::{RawVal, Tag, TagStatus, TaggedVal};
 use core::{
     cmp::Ordering,
+    fmt::Debug,
     hash::{Hash, Hasher},
     marker::PhantomData,
 };
-use stellar_xdr::ScStatusType;
+use stellar_xdr::{
+    ScHostContextErrorCode, ScHostFnErrorCode, ScHostObjErrorCode, ScHostStorageErrorCode,
+    ScHostValErrorCode, ScStatus, ScStatusType, ScVmErrorCode,
+};
 
 pub type Status = TaggedVal<TagStatus>;
 
@@ -49,6 +53,85 @@ impl Ord for Status {
     }
 }
 
+// This trait just lets us write `enum_name_or_unknown` below in a generic
+// fashion. Ideally there'd be a trait for "codes that can have .name() called
+// on them and return a &'static str" in the XDR crate, but that's not available
+// yet: there's no trait and the method that does exist returns a non-static
+// &str. See https://github.com/stellar/xdrgen/issues/107 and
+// https://github.com/stellar/xdrgen/issues/108
+trait NamedCode {
+    fn fmt_code_name(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result;
+}
+
+impl NamedCode for ScHostContextErrorCode {
+    fn fmt_code_name(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl NamedCode for ScHostFnErrorCode {
+    fn fmt_code_name(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl NamedCode for ScHostObjErrorCode {
+    fn fmt_code_name(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl NamedCode for ScHostStorageErrorCode {
+    fn fmt_code_name(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl NamedCode for ScHostValErrorCode {
+    fn fmt_code_name(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl NamedCode for ScVmErrorCode {
+    fn fmt_code_name(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+fn fmt_named_code<C: NamedCode>(code: u32, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+where
+    C: TryFrom<i32>,
+{
+    match C::try_from(code as i32) {
+        Ok(c) => c.fmt_code_name(f),
+        Err(_) => write!(f, "UnknownCode"),
+    }
+}
+
+impl Debug for Status {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let st_res: Result<ScStatusType, _> = (self.0.get_minor() as i32).try_into();
+        let code = self.0.get_major();
+        let st = match st_res {
+            Ok(t) => t,
+            Err(_) => return write!(f, "Status(UnknownType)"),
+        };
+        write!(f, "Status({}(", st.name())?;
+        match st {
+            ScStatusType::HostContextError => fmt_named_code::<ScHostContextErrorCode>(code, f),
+            ScStatusType::Ok => write!(f, "{}", code),
+            ScStatusType::UnknownError => write!(f, "{}", code),
+            ScStatusType::HostValueError => fmt_named_code::<ScHostValErrorCode>(code, f),
+            ScStatusType::HostObjectError => fmt_named_code::<ScHostObjErrorCode>(code, f),
+            ScStatusType::HostFunctionError => fmt_named_code::<ScHostFnErrorCode>(code, f),
+            ScStatusType::HostStorageError => fmt_named_code::<ScHostStorageErrorCode>(code, f),
+            ScStatusType::VmError => fmt_named_code::<ScVmErrorCode>(code, f),
+        }?;
+        write!(f, "))")
+    }
+}
+
 impl Status {
     // NB: we don't provide a "get_type" to avoid casting a bad bit-pattern into
     // an ScStatusType. Instead we provide an "is_type" to check any specific
@@ -78,5 +161,23 @@ impl Status {
                 PhantomData,
             )
         }
+    }
+
+    // TODO: this should be a const fn, waiting on
+    // https://github.com/stellar/xdrgen/issues/106 for the discriminant
+    // function call to be const.
+    #[inline(always)]
+    pub fn from_status(sc: ScStatus) -> Status {
+        let code: i32 = match sc {
+            ScStatus::Ok => 0,
+            ScStatus::HostContextError(code) => code as i32,
+            ScStatus::HostValueError(code) => code as i32,
+            ScStatus::HostObjectError(code) => code as i32,
+            ScStatus::HostFunctionError(code) => code as i32,
+            ScStatus::HostStorageError(code) => code as i32,
+            ScStatus::VmError(code) => code as i32,
+            ScStatus::UnknownError(code) => code as i32,
+        };
+        Self::from_type_and_code(sc.discriminant(), code as u32)
     }
 }

--- a/stellar-contract-env-common/src/symbol.rs
+++ b/stellar-contract-env-common/src/symbol.rs
@@ -7,6 +7,7 @@ use core::{
     str,
 };
 
+#[derive(Debug)]
 pub enum SymbolError {
     TooLong(usize),
     BadChar(char),
@@ -53,7 +54,14 @@ impl Ord for Symbol {
 impl Debug for Symbol {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let s: SymbolStr = self.into();
-        f.debug_tuple("Symbol").field(&s).finish()
+        write!(f, "Symbol(")?;
+        for c in s.0.iter() {
+            if *c == 0 {
+                break;
+            }
+            write!(f, "{}", unsafe { char::from_u32_unchecked(*c as u32) })?;
+        }
+        write!(f, ")")
     }
 }
 

--- a/stellar-contract-env-common/src/tagged_val.rs
+++ b/stellar-contract-env-common/src/tagged_val.rs
@@ -102,7 +102,7 @@ macro_rules! impl_tagged_from {
             }
         }
         impl<E: Env> TryFrom<EnvVal<E, TaggedVal<$tagty>>> for $fromty {
-            type Error = ();
+            type Error = ConversionError;
             #[inline(always)]
             fn try_from(v: EnvVal<E, TaggedVal<$tagty>>) -> Result<Self, Self::Error> {
                 Self::try_from(v.to_raw())
@@ -131,13 +131,13 @@ impl<T: TagType> From<TaggedVal<T>> for RawVal {
 }
 
 impl<T: TagType> TryFrom<RawVal> for TaggedVal<T> {
-    type Error = ();
+    type Error = ConversionError;
 
     fn try_from(rv: RawVal) -> Result<Self, Self::Error> {
         if rv.has_tag(T::TAG) {
             Ok(Self(rv, PhantomData))
         } else {
-            Err(())
+            Err(ConversionError)
         }
     }
 }

--- a/stellar-contract-env-common/src/tagged_val.rs
+++ b/stellar-contract-env-common/src/tagged_val.rs
@@ -1,3 +1,4 @@
+use crate::raw_val::ConversionError;
 use crate::Env;
 use crate::EnvVal;
 use crate::IntoEnvVal;
@@ -7,25 +8,26 @@ use crate::IntoEnvVal;
 use crate::RawVal;
 use crate::RawValConvertible;
 use crate::Tag;
+use core::fmt::Debug;
 use core::marker::PhantomData;
 
-pub trait TagType: Copy + Clone {
+pub trait TagType: Copy + Clone + Debug {
     const TAG: Tag;
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct TagU32;
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct TagI32;
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct TagStatic;
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct TagObject;
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct TagSymbol;
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct TagBitSet;
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct TagStatus;
 
 impl TagType for TagU32 {
@@ -50,8 +52,28 @@ impl TagType for TagStatus {
     const TAG: Tag = Tag::Status;
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 pub struct TaggedVal<T: TagType>(pub(crate) RawVal, pub(crate) PhantomData<T>);
+
+// Debug impls for Symbol, Status and Object are in their respective files;
+// for others we delegate to the Debug impls for RawVal.
+impl Debug for TaggedVal<TagU32> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Debug for TaggedVal<TagI32> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Debug for TaggedVal<TagStatic> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl<T: TagType> AsRef<RawVal> for TaggedVal<T> {
     fn as_ref(&self) -> &RawVal {

--- a/stellar-contract-env-host/Cargo.toml
+++ b/stellar-contract-env-host/Cargo.toml
@@ -18,6 +18,9 @@ sha2 = "0.10.2"
 ed25519-dalek = "1.0.1"
 hex = "0.4.3"
 
+[dev-dependencies]
+assert_matches = "1.5.0"
+
 [features]
 vm = ["wasmi", "parity-wasm", "stellar-contract-env-common/vm"]
 testutils = []

--- a/stellar-contract-env-host/benches/calibrate_wasm_insns.rs
+++ b/stellar-contract-env-host/benches/calibrate_wasm_insns.rs
@@ -64,7 +64,7 @@ fn main() -> std::io::Result<()> {
         host.modify_budget(|budget| {
             budget.event_counts.wasm_insns = 0;
             budget.cost_factors.cpu_insn_per_wasm_insn = 1;
-            budget.cost_limits.cpu_insn_limit = 1000000000000;
+            budget.cost_limits.cpu_insns = 1000000000000;
         });
 
         let id: Hash = [0; 32].into();

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -30,8 +30,8 @@ use crate::SymbolStr;
 #[cfg(feature = "vm")]
 use crate::Vm;
 use crate::{
-    BitSet, BitSetError, EnvBase, IntoEnvVal, Object, RawVal, RawValConvertible, Status, Symbol,
-    SymbolError, Tag, Val, UNKNOWN_ERROR,
+    BitSet, BitSetError, ConversionError, EnvBase, IntoEnvVal, Object, RawVal, RawValConvertible,
+    Status, Symbol, SymbolError, Tag, Val, UNKNOWN_ERROR,
 };
 
 use thiserror::Error;
@@ -1001,7 +1001,7 @@ impl CheckedEnv for Host {
             if i >= hv.len() {
                 return Err(HostError::WithStatus(
                     String::from("index out of bound"),
-                    ScStatus::HostObjectError(ScHostObjErrorCode::ObjectNotExist),
+                    ScStatus::HostObjectError(ScHostObjErrorCode::VecIndexOutOfBound),
                 ));
             }
             let mut vnew = hv.clone();
@@ -1021,7 +1021,7 @@ impl CheckedEnv for Host {
         let res = self.visit_obj(v, move |hv: &HostVec| match hv.get(i) {
             None => Err(HostError::WithStatus(
                 String::from("index out of bound"),
-                ScStatus::HostObjectError(ScHostObjErrorCode::ObjectNotExist),
+                ScStatus::HostObjectError(ScHostObjErrorCode::VecIndexOutOfBound),
             )),
             Some(hval) => Ok(hval.to_raw()),
         });

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -156,6 +156,12 @@ impl From<&HostError> for ScStatus {
     }
 }
 
+impl From<ConversionError> for HostError {
+    fn from(_: ConversionError) -> Self {
+        HostError::General("conversion error")
+    }
+}
+
 /// Saves host state (storage and objects) for rolling back a (sub-)transaction
 /// on error. A helper type used by [`FrameGuard`].
 #[derive(Clone)]

--- a/stellar-contract-env-host/src/storage.rs
+++ b/stellar-contract-env-host/src/storage.rs
@@ -174,6 +174,9 @@ impl Storage {
 
 #[cfg(test)]
 mod test_footprint {
+
+    use assert_matches::assert_matches;
+
     use super::*;
     use crate::xdr::{LedgerKeyContractData, ScVal};
 
@@ -188,16 +191,16 @@ mod test_footprint {
         });
         fp.record_access(&key, AccessType::ReadOnly);
         assert_eq!(fp.0.contains_key(&key), true);
-        assert_eq!(*fp.0.get(&key).unwrap(), AccessType::ReadOnly);
+        assert_eq!(fp.0.get(&key), Some(&AccessType::ReadOnly));
         // record and change access
         fp.record_access(&key, AccessType::ReadWrite);
-        assert_eq!(*fp.0.get(&key).unwrap(), AccessType::ReadWrite);
+        assert_eq!(fp.0.get(&key), Some(&AccessType::ReadWrite));
         fp.record_access(&key, AccessType::ReadOnly);
-        assert_eq!(*fp.0.get(&key).unwrap(), AccessType::ReadWrite);
+        assert_eq!(fp.0.get(&key), Some(&AccessType::ReadWrite));
     }
 
     #[test]
-    fn footprint_enforce_access() {
+    fn footprint_enforce_access() -> Result<(), HostError> {
         let contract_id = [0; 32].into();
         let key = LedgerKey::ContractData(LedgerKeyContractData {
             contract_id,
@@ -205,14 +208,14 @@ mod test_footprint {
         });
         let om = OrdMap::unit(key.clone(), AccessType::ReadOnly);
         let mut fp = Footprint(om);
-        fp.enforce_access(&key, AccessType::ReadOnly).unwrap();
-        *fp.0.get_mut(&key).unwrap() = AccessType::ReadWrite;
-        fp.enforce_access(&key, AccessType::ReadOnly).unwrap();
-        fp.enforce_access(&key, AccessType::ReadWrite).unwrap();
+        fp.enforce_access(&key, AccessType::ReadOnly)?;
+        fp.0.insert(key.clone(), AccessType::ReadWrite);
+        fp.enforce_access(&key, AccessType::ReadOnly)?;
+        fp.enforce_access(&key, AccessType::ReadWrite)?;
+        Ok(())
     }
 
     #[test]
-    #[should_panic(expected = "access to unknown footprint entry")]
     fn footprint_enforce_access_not_exist() {
         let mut fp = Footprint::default();
         let contract_id = [0; 32].into();
@@ -220,11 +223,16 @@ mod test_footprint {
             contract_id,
             key: ScVal::I32(0),
         });
-        fp.enforce_access(&key, AccessType::ReadOnly).unwrap();
+        assert_matches!(
+            fp.enforce_access(&key, AccessType::ReadOnly),
+            Err(HostError::WithStatus(
+                _,
+                ScStatus::HostStorageError(ScHostStorageErrorCode::AccessToUnknownEntry)
+            ))
+        );
     }
 
     #[test]
-    #[should_panic(expected = "read-write access to read-only footprint entry")]
     fn footprint_attempt_to_write_readonly_entry() {
         let contract_id = [0; 32].into();
         let key = LedgerKey::ContractData(LedgerKeyContractData {
@@ -233,7 +241,13 @@ mod test_footprint {
         });
         let om = OrdMap::unit(key.clone(), AccessType::ReadOnly);
         let mut fp = Footprint(om);
-        fp.enforce_access(&key, AccessType::ReadWrite).unwrap();
+        assert_matches!(
+            fp.enforce_access(&key, AccessType::ReadWrite),
+            Err(HostError::WithStatus(
+                _,
+                ScStatus::HostStorageError(ScHostStorageErrorCode::ReadwriteAccessToReadonlyEntry)
+            ))
+        );
     }
 }
 

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -1,6 +1,9 @@
 use crate::{
-    xdr::{LedgerKey, LedgerKeyContractData, ScObject, ScObjectType, ScVal, ScVec},
-    Host, IntoEnvVal, Object, RawVal, Tag,
+    xdr::{
+        LedgerKey, LedgerKeyContractData, ScHostFnErrorCode, ScHostObjErrorCode, ScObject,
+        ScObjectType, ScStatus, ScVal, ScVec,
+    },
+    Host, HostError, IntoEnvVal, Object, RawVal, Tag,
 };
 use im_rc::OrdMap;
 use stellar_contract_env_common::{
@@ -17,78 +20,81 @@ use crate::Vm;
 #[cfg(feature = "vm")]
 use crate::{
     xdr::{
-        ContractDataEntry, Hash, LedgerEntry, LedgerEntryData, LedgerEntryExt, ScHostObjErrorCode,
-        ScStatic, ScStatusType,
+        ContractDataEntry, Hash, LedgerEntry, LedgerEntryData, LedgerEntryExt, ScStatic,
+        ScStatusType,
     },
     Symbol,
 };
-#[cfg(feature = "vm")]
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use assert_matches::assert_matches;
 #[cfg(feature = "vm")]
 use stellar_contract_env_common::Status;
 
 /// numbers test
 #[test]
-fn u64_roundtrip() {
+fn u64_roundtrip() -> Result<(), HostError> {
     let host = Host::default();
     let u: u64 = 38473_u64; // This will be treated as a ScVal::Object::U64
     let v = u.into_env_val(&host);
-    let obj: Object = v.val.try_into().unwrap();
+    let obj: Object = v.val.try_into()?;
     assert!(obj.is_obj_type(ScObjectType::U64));
     assert_eq!(obj.get_handle(), 0);
-    let j = u64::try_from(v).unwrap();
+    let j = u64::try_from(v)?;
     assert_eq!(u, j);
 
     let u2: u64 = u64::MAX; // This will be treated as a ScVal::Object::U64
     let v2 = u2.into_env_val(&host);
-    let obj: Object = v2.val.try_into().unwrap();
+    let obj: Object = v2.val.try_into()?;
     assert!(obj.is_obj_type(ScObjectType::U64));
     assert_eq!(obj.get_handle(), 1);
-    let k = u64::try_from(v2).unwrap();
+    let k = u64::try_from(v2)?;
     assert_eq!(u2, k);
+    Ok(())
 }
 
 #[test]
-fn i64_roundtrip() {
+fn i64_roundtrip() -> Result<(), HostError> {
     let host = Host::default();
     let i: i64 = 12345_i64; // Will be treated as ScVal::I64
     let v = i.into_env_val(&host);
-    let j = i64::try_from(v).unwrap();
+    let j = i64::try_from(v)?;
     assert_eq!(i, j);
 
     let i2: i64 = -13234_i64; // WIll be treated as ScVal::Object::I64
     let v2 = i2.into_env_val(&host);
-    let obj: Object = v2.val.try_into().unwrap();
+    let obj: Object = v2.val.try_into()?;
     assert!(obj.is_obj_type(ScObjectType::I64));
     assert_eq!(obj.get_handle(), 0);
-    let k = i64::try_from(v2).unwrap();
+    let k = i64::try_from(v2)?;
     assert_eq!(i2, k);
+    Ok(())
 }
 
 #[test]
-fn u32_as_seen_by_host() {
+fn u32_as_seen_by_host() -> Result<(), HostError> {
     let host = Host::default();
     let scval0 = ScVal::U32(12345);
-    let val0 = host.to_host_val(&scval0).unwrap();
+    let val0 = host.to_host_val(&scval0)?;
     assert!(val0.val.is::<u32>());
     assert!(val0.val.get_tag() == Tag::U32);
     let u = unsafe { <u32 as RawValConvertible>::unchecked_from_val(val0.val) };
     assert_eq!(u, 12345);
+    Ok(())
 }
 
 #[test]
-fn i32_as_seen_by_host() {
+fn i32_as_seen_by_host() -> Result<(), HostError> {
     let host = Host::default();
     let scval0 = ScVal::I32(-12345);
-    let val0 = host.to_host_val(&scval0).unwrap();
+    let val0 = host.to_host_val(&scval0)?;
     assert!(val0.val.is::<i32>());
     assert!(val0.val.get_tag() == Tag::I32);
     let i = unsafe { <i32 as RawValConvertible>::unchecked_from_val(val0.val) };
     assert_eq!(i, -12345);
+    Ok(())
 }
 
 #[test]
-fn map_put_has_and_get() {
+fn map_put_has_and_get() -> Result<(), HostError> {
     let host = Host::default();
     let scmap: ScMap = vec![
         ScMapEntry {
@@ -100,23 +106,23 @@ fn map_put_has_and_get() {
             val: ScVal::U32(4),
         },
     ]
-    .try_into()
-    .unwrap();
+    .try_into()?;
     let scobj = ScObject::Map(scmap);
-    let obj = host.to_host_obj(&scobj).unwrap();
+    let obj = host.to_host_obj(&scobj)?;
     let k: RawVal = 3_u32.into();
     let v: RawVal = 6_u32.into();
-    assert!(!bool::try_from(host.map_has(obj.to_object(), k).unwrap()).unwrap());
-    let obj1 = host.map_put(obj.to_object(), k, v).unwrap();
-    assert!(bool::try_from(host.map_has(obj1, k).unwrap()).unwrap());
-    let rv = host.map_get(obj1, k).unwrap();
+    assert!(!bool::try_from(host.map_has(obj.to_object(), k)?)?);
+    let obj1 = host.map_put(obj.to_object(), k, v)?;
+    assert!(bool::try_from(host.map_has(obj1, k)?)?);
+    let rv = host.map_get(obj1, k)?;
     let v = unsafe { <u32 as RawValConvertible>::unchecked_from_val(rv) };
     assert_eq!(v, 6);
+    Ok(())
 }
 
 /// Vec test
 #[test]
-fn vec_as_seen_by_host() -> Result<(), ()> {
+fn vec_as_seen_by_host() -> Result<(), HostError> {
     let host = Host::default();
     let scvec0: ScVec = ScVec(vec![ScVal::U32(1)].try_into()?);
     let scvec1: ScVec = ScVec(vec![ScVal::U32(1)].try_into()?);
@@ -124,12 +130,12 @@ fn vec_as_seen_by_host() -> Result<(), ()> {
     let scobj1: ScObject = ScObject::Vec(scvec1);
     let scval0 = ScVal::Object(Some(scobj0));
     let scval1 = ScVal::Object(Some(scobj1));
-    let val0 = host.to_host_val(&scval0).unwrap();
-    let val1 = host.to_host_val(&scval1).unwrap();
+    let val0 = host.to_host_val(&scval0)?;
+    let val1 = host.to_host_val(&scval1)?;
     assert!(val0.val.is::<Object>());
     assert!(val1.val.is::<Object>());
-    let obj0: Object = val0.val.try_into().unwrap();
-    let obj1: Object = val1.val.try_into().unwrap();
+    let obj0: Object = val0.val.try_into()?;
+    let obj1: Object = val1.val.try_into()?;
     assert_eq!(obj0.get_handle(), 0);
     assert_eq!(obj1.get_handle(), 1);
     assert!(obj0.is_obj_type(ScObjectType::Vec));
@@ -142,273 +148,317 @@ fn vec_as_seen_by_host() -> Result<(), ()> {
 }
 
 #[test]
-fn vec_front_and_back() -> Result<(), ()> {
+fn vec_front_and_back() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
-        .try_into()
-        .unwrap();
+    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)].try_into()?;
     let scobj = ScObject::Vec(scvec);
-    let obj = host.to_host_obj(&scobj).unwrap();
-    let front = unsafe {
-        <i32 as RawValConvertible>::unchecked_from_val(host.vec_front(obj.to_object()).unwrap())
-    };
-    let back = unsafe {
-        <i32 as RawValConvertible>::unchecked_from_val(host.vec_back(obj.to_object()).unwrap())
-    };
+    let obj = host.to_host_obj(&scobj)?;
+    let front =
+        unsafe { <i32 as RawValConvertible>::unchecked_from_val(host.vec_front(obj.to_object())?) };
+    let back =
+        unsafe { <i32 as RawValConvertible>::unchecked_from_val(host.vec_back(obj.to_object())?) };
     assert_eq!(front, 1);
     assert_eq!(back, 3);
     Ok(())
 }
 
 #[test]
-#[should_panic(expected = "value does not exist")]
-fn empty_vec_front() {
+fn empty_vec_front() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![].try_into().unwrap();
+    let scvec: ScVec = vec![].try_into()?;
     let scobj = ScObject::Vec(scvec);
-    let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_front(obj.to_object()).unwrap();
+    let obj = host.to_host_obj(&scobj)?;
+    assert_matches!(
+        host.vec_front(obj.to_object()),
+        Err(HostError::WithStatus(
+            _,
+            ScStatus::HostObjectError(ScHostObjErrorCode::VecIndexOutOfBound)
+        ))
+    );
+    Ok(())
 }
 
 #[test]
-#[should_panic(expected = "value does not exist")]
-fn empty_vec_back() {
+fn empty_vec_back() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![].try_into().unwrap();
+    let scvec: ScVec = vec![].try_into()?;
     let scobj = ScObject::Vec(scvec);
-    let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_back(obj.to_object()).unwrap();
+    let obj = host.to_host_obj(&scobj)?;
+    assert_matches!(
+        host.vec_back(obj.to_object()),
+        Err(HostError::WithStatus(
+            _,
+            ScStatus::HostObjectError(ScHostObjErrorCode::VecIndexOutOfBound)
+        ))
+    );
+    Ok(())
 }
 
 #[test]
-fn vec_put_and_get() {
+fn vec_put_and_get() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
-        .try_into()
-        .unwrap();
+    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)].try_into()?;
     let scobj = ScObject::Vec(scvec);
-    let obj = host.to_host_obj(&scobj).unwrap();
+    let obj = host.to_host_obj(&scobj)?;
     let i: RawVal = 1_u32.into();
-    let obj1 = host.vec_put(obj.to_object(), i, 9_u32.into()).unwrap();
-    let rv = host.vec_get(obj1, i).unwrap();
+    let obj1 = host.vec_put(obj.to_object(), i, 9_u32.into())?;
+    let rv = host.vec_get(obj1, i)?;
     let v = unsafe { <u32 as RawValConvertible>::unchecked_from_val(rv) };
     assert_eq!(v, 9);
+    Ok(())
 }
 
 #[test]
-fn vec_push_pop_and_len() {
+fn vec_push_pop_and_len() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![].try_into().unwrap();
+    let scvec: ScVec = vec![].try_into()?;
     let scobj = ScObject::Vec(scvec);
-    let obj = host.to_host_obj(&scobj).unwrap();
-    let l = unsafe {
-        <u32 as RawValConvertible>::unchecked_from_val(host.vec_len(obj.to_object()).unwrap())
-    };
+    let obj = host.to_host_obj(&scobj)?;
+    let l =
+        unsafe { <u32 as RawValConvertible>::unchecked_from_val(host.vec_len(obj.to_object())?) };
     assert_eq!(l, 0);
-    let obj1 = host.vec_push(obj.to_object(), 1u32.into()).unwrap();
-    let obj2 = host.vec_push(obj1, 2u32.into()).unwrap();
-    let l = unsafe { <u32 as RawValConvertible>::unchecked_from_val(host.vec_len(obj2).unwrap()) };
+    let obj1 = host.vec_push(obj.to_object(), 1u32.into())?;
+    let obj2 = host.vec_push(obj1, 2u32.into())?;
+    let l = unsafe { <u32 as RawValConvertible>::unchecked_from_val(host.vec_len(obj2)?) };
     assert_eq!(l, 2);
-    let obj3 = host.vec_pop(obj2).unwrap();
-    let l = unsafe { <u32 as RawValConvertible>::unchecked_from_val(host.vec_len(obj3).unwrap()) };
+    let obj3 = host.vec_pop(obj2)?;
+    let l = unsafe { <u32 as RawValConvertible>::unchecked_from_val(host.vec_len(obj3)?) };
     assert_eq!(l, 1);
-    let obj4 = host.vec_pop(obj3).unwrap();
-    let l = unsafe { <u32 as RawValConvertible>::unchecked_from_val(host.vec_len(obj4).unwrap()) };
+    let obj4 = host.vec_pop(obj3)?;
+    let l = unsafe { <u32 as RawValConvertible>::unchecked_from_val(host.vec_len(obj4)?) };
     assert_eq!(l, 0);
+    Ok(())
 }
 
 #[test]
-#[should_panic(expected = "value does not exist")]
-fn vec_pop_empty_vec() {
+fn vec_pop_empty_vec() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![].try_into().unwrap();
+    let scvec: ScVec = vec![].try_into()?;
     let scobj = ScObject::Vec(scvec);
-    let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_pop(obj.to_object()).unwrap();
+    let obj = host.to_host_obj(&scobj)?;
+    assert_matches!(
+        host.vec_pop(obj.to_object()),
+        Err(HostError::WithStatus(
+            _,
+            ScStatus::HostObjectError(ScHostObjErrorCode::VecIndexOutOfBound)
+        ))
+    );
+    Ok(())
 }
 
 #[test]
-#[should_panic(expected = "index out of bound")]
-fn vec_get_out_of_bound() {
+fn vec_get_out_of_bound() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
-        .try_into()
-        .unwrap();
+    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)].try_into()?;
     let scobj = ScObject::Vec(scvec);
-    let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_get(obj.to_object(), 3_u32.into()).unwrap();
+    let obj = host.to_host_obj(&scobj)?;
+    assert_matches!(
+        host.vec_get(obj.to_object(), 3_u32.into()),
+        Err(HostError::WithStatus(
+            _,
+            ScStatus::HostObjectError(ScHostObjErrorCode::VecIndexOutOfBound)
+        ))
+    );
+    Ok(())
 }
 
 #[test]
-#[should_panic(expected = "i must be u32")]
-fn vec_get_wrong_index_type() {
+fn vec_get_wrong_index_type() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![].try_into().unwrap();
+    let scvec: ScVec = vec![].try_into()?;
     let scobj = ScObject::Vec(scvec);
-    let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_get(obj.to_object(), (-1_i32).into()).unwrap();
+    let obj = host.to_host_obj(&scobj)?;
+    assert_matches!(
+        host.vec_get(obj.to_object(), (-1_i32).into()),
+        Err(HostError::WithStatus(
+            _,
+            ScStatus::HostFunctionError(ScHostFnErrorCode::InputArgsWrongType)
+        ))
+    );
+    Ok(())
 }
 
 #[test]
-fn vec_del_and_cmp() {
+fn vec_del_and_cmp() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
-        .try_into()
-        .unwrap();
-    let obj = host.to_host_obj(&ScObject::Vec(scvec)).unwrap();
-    let obj1 = host.vec_del(obj.to_object(), 1u32.into()).unwrap();
-    let scvec_ref: ScVec = vec![ScVal::U32(1), ScVal::U32(3)].try_into().unwrap();
-    let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref)).unwrap();
-    assert_eq!(host.obj_cmp(obj1.into(), obj_ref.into()).unwrap(), 0);
+    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)].try_into()?;
+    let obj = host.to_host_obj(&ScObject::Vec(scvec))?;
+    let obj1 = host.vec_del(obj.to_object(), 1u32.into())?;
+    let scvec_ref: ScVec = vec![ScVal::U32(1), ScVal::U32(3)].try_into()?;
+    let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref))?;
+    assert_eq!(host.obj_cmp(obj1.into(), obj_ref.into())?, 0);
+    Ok(())
 }
 
 #[test]
-#[should_panic(expected = "index out of bound")]
-fn vec_del_out_of_bound() {
+fn vec_del_out_of_bound() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
-        .try_into()
-        .unwrap();
+    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)].try_into()?;
     let scobj = ScObject::Vec(scvec);
-    let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_del(obj.to_object(), 3_u32.into()).unwrap();
+    let obj = host.to_host_obj(&scobj)?;
+    assert_matches!(
+        host.vec_del(obj.to_object(), 3_u32.into()),
+        Err(HostError::WithStatus(
+            _,
+            ScStatus::HostObjectError(ScHostObjErrorCode::VecIndexOutOfBound)
+        ))
+    );
+    Ok(())
 }
 
 #[test]
-#[should_panic(expected = "i must be u32")]
-fn vec_del_wrong_index_type() {
+fn vec_del_wrong_index_type() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![].try_into().unwrap();
+    let scvec: ScVec = vec![].try_into()?;
     let scobj = ScObject::Vec(scvec);
-    let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_del(obj.to_object(), (-1_i32).into()).unwrap();
+    let obj = host.to_host_obj(&scobj)?;
+    assert_matches!(
+        host.vec_del(obj.to_object(), (-1_i32).into()),
+        Err(HostError::WithStatus(
+            _,
+            ScStatus::HostFunctionError(ScHostFnErrorCode::InputArgsWrongType)
+        ))
+    );
+    Ok(())
 }
 
 #[test]
-fn vec_slice_and_cmp() {
+fn vec_slice_and_cmp() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
-        .try_into()
-        .unwrap();
-    let obj = host.to_host_obj(&ScObject::Vec(scvec)).unwrap();
-    let obj1 = host
-        .vec_slice(obj.to_object(), 1u32.into(), 2u32.into())
-        .unwrap();
-    let scvec_ref: ScVec = vec![ScVal::U32(2), ScVal::U32(3)].try_into().unwrap();
-    let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref)).unwrap();
-    assert_eq!(host.obj_cmp(obj1.into(), obj_ref.into()).unwrap(), 0);
+    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)].try_into()?;
+    let obj = host.to_host_obj(&ScObject::Vec(scvec))?;
+    let obj1 = host.vec_slice(obj.to_object(), 1u32.into(), 2u32.into())?;
+    let scvec_ref: ScVec = vec![ScVal::U32(2), ScVal::U32(3)].try_into()?;
+    let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref))?;
+    assert_eq!(host.obj_cmp(obj1.into(), obj_ref.into())?, 0);
 
-    let obj2 = host
-        .vec_slice(obj.to_object(), 0u32.into(), 3u32.into())
-        .unwrap();
+    let obj2 = host.vec_slice(obj.to_object(), 0u32.into(), 3u32.into())?;
     assert_ne!(obj2.as_ref().get_payload(), obj.as_raw().get_payload());
-    assert_eq!(host.obj_cmp(obj2.into(), obj.into()).unwrap(), 0);
+    assert_eq!(host.obj_cmp(obj2.into(), obj.into())?, 0);
+    Ok(())
 }
 
 #[test]
-#[should_panic(expected = "u32 overflow")]
-fn vec_slice_index_overflow() {
+fn vec_slice_index_overflow() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
-        .try_into()
-        .unwrap();
+    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)].try_into()?;
     let scobj = ScObject::Vec(scvec);
-    let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_slice(obj.to_object(), u32::MAX.into(), 1_u32.into())
-        .unwrap();
+    let obj = host.to_host_obj(&scobj)?;
+    assert_matches!(
+        host.vec_slice(obj.to_object(), u32::MAX.into(), 1_u32.into()),
+        Err(HostError::WithStatus(
+            _,
+            ScStatus::HostFunctionError(ScHostFnErrorCode::InputArgsInvalid)
+        ))
+    );
+    Ok(())
 }
 
 #[test]
-#[should_panic(expected = "index out of bound")]
-fn vec_slice_out_of_bound() {
+fn vec_slice_out_of_bound() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
-        .try_into()
-        .unwrap();
+    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)].try_into()?;
     let scobj = ScObject::Vec(scvec);
-    let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_slice(obj.to_object(), 0_u32.into(), 4_u32.into())
-        .unwrap();
+    let obj = host.to_host_obj(&scobj)?;
+    assert_matches!(
+        host.vec_slice(obj.to_object(), 0_u32.into(), 4_u32.into()),
+        Err(HostError::WithStatus(
+            _,
+            ScStatus::HostObjectError(ScHostObjErrorCode::VecIndexOutOfBound)
+        ))
+    );
+    Ok(())
 }
 
 #[test]
-#[should_panic(expected = "i must be u32")]
-fn vec_take_wrong_index_type() {
+fn vec_take_wrong_index_type() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![].try_into().unwrap();
+    let scvec: ScVec = vec![].try_into()?;
     let scobj = ScObject::Vec(scvec);
-    let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_slice(obj.to_object(), (-1_i32).into(), 1_u32.into())
-        .unwrap();
+    let obj = host.to_host_obj(&scobj)?;
+    assert_matches!(
+        host.vec_slice(obj.to_object(), (-1_i32).into(), 1_u32.into()),
+        Err(HostError::WithStatus(
+            _,
+            ScStatus::HostFunctionError(ScHostFnErrorCode::InputArgsWrongType)
+        ))
+    );
+    Ok(())
 }
 
 #[test]
-#[should_panic(expected = "l must be u32")]
-fn vec_take_wrong_len_type() {
+fn vec_take_wrong_len_type() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![].try_into().unwrap();
+    let scvec: ScVec = vec![].try_into()?;
     let scobj = ScObject::Vec(scvec);
-    let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_slice(obj.to_object(), 1_u32.into(), (-1_i32).into())
-        .unwrap();
+    let obj = host.to_host_obj(&scobj)?;
+    assert_matches!(
+        host.vec_slice(obj.to_object(), 1_u32.into(), (-1_i32).into()),
+        Err(HostError::WithStatus(
+            _,
+            ScStatus::HostFunctionError(ScHostFnErrorCode::InputArgsWrongType)
+        ))
+    );
+    Ok(())
 }
 
 #[test]
-fn vec_insert_and_cmp() {
+fn vec_insert_and_cmp() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![ScVal::U32(2)].try_into().unwrap();
-    let obj = host.to_host_obj(&ScObject::Vec(scvec)).unwrap();
-    let obj1 = host
-        .vec_insert(obj.to_object(), 0u32.into(), 1u32.into())
-        .unwrap();
-    let scvec_ref: ScVec = vec![ScVal::U32(1), ScVal::U32(2)].try_into().unwrap();
-    let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref)).unwrap();
-    assert_eq!(host.obj_cmp(obj1.into(), obj_ref.into()).unwrap(), 0);
+    let scvec: ScVec = vec![ScVal::U32(2)].try_into()?;
+    let obj = host.to_host_obj(&ScObject::Vec(scvec))?;
+    let obj1 = host.vec_insert(obj.to_object(), 0u32.into(), 1u32.into())?;
+    let scvec_ref: ScVec = vec![ScVal::U32(1), ScVal::U32(2)].try_into()?;
+    let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref))?;
+    assert_eq!(host.obj_cmp(obj1.into(), obj_ref.into())?, 0);
 
-    let obj2 = host.vec_insert(obj1, 2u32.into(), 3u32.into()).unwrap();
-    let scvec_ref: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
-        .try_into()
-        .unwrap();
-    let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref)).unwrap();
-    assert_eq!(host.obj_cmp(obj2.into(), obj_ref.into()).unwrap(), 0);
+    let obj2 = host.vec_insert(obj1, 2u32.into(), 3u32.into())?;
+    let scvec_ref: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)].try_into()?;
+    let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref))?;
+    assert_eq!(host.obj_cmp(obj2.into(), obj_ref.into())?, 0);
+    Ok(())
 }
 
 #[test]
-#[should_panic(expected = "index out of bound")]
-fn vec_insert_out_of_bound() {
+fn vec_insert_out_of_bound() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
-        .try_into()
-        .unwrap();
+    let scvec: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)].try_into()?;
     let scobj = ScObject::Vec(scvec);
-    let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_insert(obj.to_object(), 4_u32.into(), 9u32.into())
-        .unwrap();
+    let obj = host.to_host_obj(&scobj)?;
+    assert_matches!(
+        host.vec_insert(obj.to_object(), 4_u32.into(), 9u32.into()),
+        Err(HostError::WithStatus(
+            _,
+            ScStatus::HostObjectError(ScHostObjErrorCode::VecIndexOutOfBound)
+        ))
+    );
+    Ok(())
 }
 
 #[test]
-#[should_panic(expected = "i must be u32")]
-fn vec_insert_wrong_index_type() {
+fn vec_insert_wrong_index_type() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec: ScVec = vec![].try_into().unwrap();
+    let scvec: ScVec = vec![].try_into()?;
     let scobj = ScObject::Vec(scvec);
-    let obj = host.to_host_obj(&scobj).unwrap();
-    host.vec_insert(obj.to_object(), (-1_i32).into(), 9u32.into())
-        .unwrap();
+    let obj = host.to_host_obj(&scobj)?;
+    assert_matches!(
+        host.vec_insert(obj.to_object(), (-1_i32).into(), 9u32.into()),
+        Err(HostError::WithStatus(
+            _,
+            ScStatus::HostFunctionError(ScHostFnErrorCode::InputArgsWrongType)
+        ))
+    );
+    Ok(())
 }
 
 #[test]
-fn vec_append() {
+fn vec_append() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec0: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)]
-        .try_into()
-        .unwrap();
-    let obj0 = host.to_host_obj(&ScObject::Vec(scvec0)).unwrap();
-    let scvec1: ScVec = vec![ScVal::U32(4), ScVal::U32(5), ScVal::U32(6)]
-        .try_into()
-        .unwrap();
-    let obj1 = host.to_host_obj(&ScObject::Vec(scvec1)).unwrap();
-    let obj2 = host.vec_append(*obj0.as_ref(), *obj1.as_ref()).unwrap();
+    let scvec0: ScVec = vec![ScVal::U32(1), ScVal::U32(2), ScVal::U32(3)].try_into()?;
+    let obj0 = host.to_host_obj(&ScObject::Vec(scvec0))?;
+    let scvec1: ScVec = vec![ScVal::U32(4), ScVal::U32(5), ScVal::U32(6)].try_into()?;
+    let obj1 = host.to_host_obj(&ScObject::Vec(scvec1))?;
+    let obj2 = host.vec_append(*obj0.as_ref(), *obj1.as_ref())?;
     let scvec_ref: ScVec = vec![
         ScVal::U32(1),
         ScVal::U32(2),
@@ -417,32 +467,31 @@ fn vec_append() {
         ScVal::U32(5),
         ScVal::U32(6),
     ]
-    .try_into()
-    .unwrap();
-    let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref)).unwrap();
-    assert_eq!(host.obj_cmp(obj2.into(), obj_ref.into()).unwrap(), 0);
+    .try_into()?;
+    let obj_ref = host.to_host_obj(&ScObject::Vec(scvec_ref))?;
+    assert_eq!(host.obj_cmp(obj2.into(), obj_ref.into())?, 0);
+    Ok(())
 }
 
 #[test]
-fn vec_append_empty() {
+fn vec_append_empty() -> Result<(), HostError> {
     let host = Host::default();
-    let scvec0: ScVec = vec![].try_into().unwrap();
-    let obj0 = host.to_host_obj(&ScObject::Vec(scvec0)).unwrap();
-    let obj1 = host.vec_append(*obj0.as_ref(), *obj0.as_ref()).unwrap();
+    let scvec0: ScVec = vec![].try_into()?;
+    let obj0 = host.to_host_obj(&ScObject::Vec(scvec0))?;
+    let obj1 = host.vec_append(*obj0.as_ref(), *obj0.as_ref())?;
     assert_ne!(obj0.as_raw().get_payload(), obj1.as_ref().get_payload());
-    assert_eq!(host.obj_cmp(obj0.into(), obj1.into()).unwrap(), 0);
+    assert_eq!(host.obj_cmp(obj0.into(), obj1.into())?, 0);
+    Ok(())
 }
 
 /// crypto tests
 #[test]
-fn sha256_test() {
+fn sha256_test() -> Result<(), HostError> {
     let host = Host::default();
-    let obj0 = host
-        .to_host_obj(&ScObject::Binary(vec![1].try_into().unwrap()))
-        .unwrap();
-    let hash_obj = host.compute_hash_sha256(obj0.to_object()).unwrap();
+    let obj0 = host.to_host_obj(&ScObject::Binary(vec![1].try_into()?))?;
+    let hash_obj = host.compute_hash_sha256(obj0.to_object())?;
 
-    let v = host.from_host_val(hash_obj.to_raw()).unwrap();
+    let v = host.from_host_val(hash_obj.to_raw())?;
     let bin = match v {
         ScVal::Object(Some(scobj)) => match scobj {
             ScObject::Binary(bin) => bin,
@@ -460,10 +509,11 @@ fn sha256_test() {
         49, 195, 133, 165, 215, 204, 226, 60, 119, 133, 69, 154,
     ];
     assert_eq!(bin.as_vec().clone(), exp);
+    Ok(())
 }
 
 #[test]
-fn ed25519_verify_test() {
+fn ed25519_verify_test() -> Result<(), HostError> {
     let host = Host::default();
 
     // From https://datatracker.ietf.org/doc/html/rfc8032#section-7.1
@@ -477,15 +527,9 @@ fn ed25519_verify_test() {
     let msg_bytes: Vec<u8> = FromHex::from_hex(message).unwrap();
     let sig_bytes: Vec<u8> = FromHex::from_hex(signature).unwrap();
 
-    let obj_pub = host
-        .to_host_obj(&ScObject::Binary(pub_bytes.try_into().unwrap()))
-        .unwrap();
-    let obj_msg = host
-        .to_host_obj(&ScObject::Binary(msg_bytes.try_into().unwrap()))
-        .unwrap();
-    let obj_sig = host
-        .to_host_obj(&ScObject::Binary(sig_bytes.try_into().unwrap()))
-        .unwrap();
+    let obj_pub = host.to_host_obj(&ScObject::Binary(pub_bytes.try_into()?))?;
+    let obj_msg = host.to_host_obj(&ScObject::Binary(msg_bytes.try_into()?))?;
+    let obj_sig = host.to_host_obj(&ScObject::Binary(sig_bytes.try_into()?))?;
 
     let res = host.verify_sig_ed25519(
         obj_msg.to_object(),
@@ -498,9 +542,7 @@ fn ed25519_verify_test() {
     // Now verify with wrong message
     let message2: &[u8] = b"73";
     let msg_bytes2: Vec<u8> = FromHex::from_hex(message2).unwrap();
-    let obj_msg2 = host
-        .to_host_obj(&ScObject::Binary(msg_bytes2.try_into().unwrap()))
-        .unwrap();
+    let obj_msg2 = host.to_host_obj(&ScObject::Binary(msg_bytes2.try_into()?))?;
 
     let res_failed = host.verify_sig_ed25519(
         obj_msg2.to_object(),
@@ -512,11 +554,12 @@ fn ed25519_verify_test() {
         Ok(_) => panic!("verification test failed"),
         _ => (),
     };
+    Ok(())
 }
 
 /// create contract tests
 #[test]
-fn create_contract_test() {
+fn create_contract_test() -> Result<(), HostError> {
     use crate::storage::{AccessType, Footprint, Storage};
     use crate::xdr;
     use crate::xdr::{ScObject, ScStatic, ScVal};
@@ -575,29 +618,19 @@ fn create_contract_test() {
     let host = Host::with_storage(storage);
 
     // Create contract
-    let obj_code = host
-        .to_host_obj(&ScObject::Binary(code.try_into().unwrap()))
-        .unwrap();
-    let obj_pub = host
-        .to_host_obj(&ScObject::Binary(pub_bytes.try_into().unwrap()))
-        .unwrap();
-    let obj_salt = host
-        .to_host_obj(&ScObject::Binary(salt_bytes.try_into().unwrap()))
-        .unwrap();
-    let obj_sig = host
-        .to_host_obj(&ScObject::Binary(signature.to_bytes().try_into().unwrap()))
-        .unwrap();
+    let obj_code = host.to_host_obj(&ScObject::Binary(code.try_into()?))?;
+    let obj_pub = host.to_host_obj(&ScObject::Binary(pub_bytes.try_into()?))?;
+    let obj_salt = host.to_host_obj(&ScObject::Binary(salt_bytes.try_into()?))?;
+    let obj_sig = host.to_host_obj(&ScObject::Binary(signature.to_bytes().try_into()?))?;
 
-    let contract_id = host
-        .create_contract(
-            obj_code.to_object(),
-            obj_salt.to_object(),
-            obj_pub.to_object(),
-            obj_sig.to_object(),
-        )
-        .unwrap();
+    let contract_id = host.create_contract(
+        obj_code.to_object(),
+        obj_salt.to_object(),
+        obj_pub.to_object(),
+        obj_sig.to_object(),
+    )?;
 
-    let v = host.from_host_val(contract_id.to_raw()).unwrap();
+    let v = host.from_host_val(contract_id.to_raw())?;
     let bin = match v {
         ScVal::Object(Some(scobj)) => match scobj {
             ScObject::Binary(bin) => bin,
@@ -606,6 +639,7 @@ fn create_contract_test() {
         _ => panic!("Wrong type"),
     };
     assert_eq!(bin.as_slice(), hash_copy.0.as_slice());
+    Ok(())
 }
 
 /// VM test
@@ -625,7 +659,7 @@ fn create_contract_test() {
 */
 #[cfg(feature = "vm")]
 #[test]
-fn invoke_single_contract_function() -> Result<(), ()> {
+fn invoke_single_contract_function() -> Result<(), HostError> {
     let host = Host::default();
     let code: [u8; 163] = [
         0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x07, 0x01, 0x60, 0x02, 0x7e, 0x7e,
@@ -641,28 +675,26 @@ fn invoke_single_contract_function() -> Result<(), ()> {
         0x0b, 0x00, 0x0b, 0x20, 0x02, 0xad, 0x42, 0x04, 0x86, 0x42, 0x03, 0x84, 0x0b,
     ];
     let id: Hash = [0; 32].into();
-    let vm = Vm::new(&host, id, &code).unwrap();
+    let vm = Vm::new(&host, id, &code)?;
     let a = 4i32;
     let b = 7i32;
     let c = 0x7fffffff_i32;
     let scvec0: ScVec = ScVec(vec![ScVal::I32(a), ScVal::I32(b)].try_into()?);
-    let res = vm.invoke_function(&host, "add", &scvec0).unwrap();
+    let res = vm.invoke_function(&host, "add", &scvec0)?;
     match res {
         ScVal::I32(v) => assert_eq!(v, a + b),
         _ => panic!("Wrong result type"),
     }
     // overflow
     let scvec0: ScVec = ScVec(vec![ScVal::I32(a), ScVal::I32(c)].try_into()?);
-    let res = catch_unwind(AssertUnwindSafe(|| {
-        vm.invoke_function(&host, "add", &scvec0).unwrap();
-    }));
-    assert!(res.is_err());
+    let res = vm.invoke_function(&host, "add", &scvec0);
+    assert_matches!(res, Err(HostError::WASMI(wasmi::Error::Trap(_))));
     Ok(())
 }
 
 #[cfg(feature = "vm")]
 #[test]
-fn invoke_cross_contract() -> Result<(), ()> {
+fn invoke_cross_contract() -> Result<(), HostError> {
     use im_rc::OrdMap;
 
     let contract_id: Hash = [0; 32].into();
@@ -704,13 +736,13 @@ fn invoke_cross_contract() -> Result<(), ()> {
     let host = Host::with_storage(storage);
     // create a dummy contract obj as the caller
     let scobj = ScObject::Binary([0; 32].try_into()?);
-    let obj = host.to_host_obj(&scobj).unwrap();
+    let obj = host.to_host_obj(&scobj)?;
     // prepare arguments
     let sym = Symbol::from_str("add");
-    let scvec0: ScVec = vec![ScVal::I32(1), ScVal::I32(2)].try_into().unwrap();
-    let args = host.to_host_obj(&ScObject::Vec(scvec0)).unwrap();
+    let scvec0: ScVec = vec![ScVal::I32(1), ScVal::I32(2)].try_into()?;
+    let args = host.to_host_obj(&ScObject::Vec(scvec0))?;
 
-    let res = host.call(obj.to_object(), sym.into(), args.into()).unwrap();
+    let res = host.call(obj.to_object(), sym.into(), args.into())?;
     assert!(res.is::<i32>());
     assert!(res.get_tag() == Tag::I32);
     let i: i32 = res.try_into()?;
@@ -720,8 +752,7 @@ fn invoke_cross_contract() -> Result<(), ()> {
 
 #[cfg(feature = "vm")]
 #[test]
-#[should_panic(expected = "index out of bound")]
-fn invoke_cross_contract_with_err() {
+fn invoke_cross_contract_with_err() -> Result<(), HostError> {
     use im_rc::OrdMap;
 
     let contract_id: Hash = [0; 32].into();
@@ -745,7 +776,7 @@ fn invoke_cross_contract_with_err() {
         0x20, 0x00, 0x10, 0x01, 0x37, 0x03, 0x00, 0x20, 0x01, 0x29, 0x03, 0x00, 0x20, 0x01, 0x41,
         0x10, 0x6a, 0x24, 0x00, 0x0b,
     ];
-    let scob = ScObject::Binary(code.try_into().unwrap());
+    let scob = ScObject::Binary(code.try_into()?);
     let val = ScVal::Object(Some(scob));
     let le = LedgerEntry {
         last_modified_ledger_seq: 0,
@@ -765,28 +796,29 @@ fn invoke_cross_contract_with_err() {
     let storage = Storage::with_enforcing_footprint_and_map(footprint, map);
     let host = Host::with_storage(storage);
     // create a dummy contract obj as the caller
-    let scobj = ScObject::Binary([0; 32].try_into().unwrap());
-    let obj = host.to_host_obj(&scobj).unwrap();
+    let scobj = ScObject::Binary([0; 32].try_into()?);
+    let obj = host.to_host_obj(&scobj)?;
     // prepare arguments
     let sym = Symbol::from_str("vec_err");
-    let scvec0: ScVec = vec![ScVal::I32(1)].try_into().unwrap();
-    let args = host.to_host_obj(&ScObject::Vec(scvec0)).unwrap();
+    let scvec0: ScVec = vec![ScVal::I32(1)].try_into()?;
+    let args = host.to_host_obj(&ScObject::Vec(scvec0))?;
     // call
-    let sv = host
-        .try_call(obj.to_object(), sym.into(), args.clone().into())
-        .unwrap();
+    let sv = host.try_call(obj.to_object(), sym.into(), args.clone().into())?;
     let exp_st = Status::from_type_and_code(
         ScStatusType::HostObjectError,
         ScHostObjErrorCode::VecIndexOutOfBound as u32,
     );
     assert_eq!(sv.get_payload(), exp_st.to_raw().get_payload());
-    host.call(obj.to_object(), sym.into(), args.into()).unwrap();
+    assert_matches!(
+        host.call(obj.to_object(), sym.into(), args.into()),
+        Err(HostError::WASMI(wasmi::Error::Trap(wasmi::Trap::Host(_))))
+    );
+    Ok(())
 }
 
 #[cfg(feature = "vm")]
 #[test]
-#[should_panic(expected = "index out of bound")]
-fn invoke_cross_contract_lvl2_nested_with_err() {
+fn invoke_cross_contract_lvl2_nested_with_err() -> Result<(), HostError> {
     use im_rc::OrdMap;
     // 1st level, the calling contract
     let id0: Hash = [0; 32].into();
@@ -831,7 +863,7 @@ fn invoke_cross_contract_lvl2_nested_with_err() {
         0x10, 0x01, 0x00, 0x41, 0x80, 0x80, 0xc0, 0x00, 0x0b, 0x07, 0x76, 0x65, 0x63, 0x5f, 0x65,
         0x72, 0x72,
     ];
-    let scob0 = ScObject::Binary(code0.try_into().unwrap());
+    let scob0 = ScObject::Binary(code0.try_into()?);
     let val0 = ScVal::Object(Some(scob0));
     let le0 = LedgerEntry {
         last_modified_ledger_seq: 0,
@@ -863,7 +895,7 @@ fn invoke_cross_contract_lvl2_nested_with_err() {
         0x20, 0x00, 0x10, 0x01, 0x37, 0x03, 0x00, 0x20, 0x01, 0x29, 0x03, 0x00, 0x20, 0x01, 0x41,
         0x10, 0x6a, 0x24, 0x00, 0x0b,
     ];
-    let scob1 = ScObject::Binary(code1.try_into().unwrap());
+    let scob1 = ScObject::Binary(code1.try_into()?);
     let val1 = ScVal::Object(Some(scob1));
     let le1 = LedgerEntry {
         last_modified_ledger_seq: 0,
@@ -886,34 +918,35 @@ fn invoke_cross_contract_lvl2_nested_with_err() {
     let storage = Storage::with_enforcing_footprint_and_map(footprint, map);
     let host = Host::with_storage(storage);
     // prepare arguments
-    let scobj = ScObject::Binary([0; 32].try_into().unwrap());
-    let obj = host.to_host_obj(&scobj).unwrap();
+    let scobj = ScObject::Binary([0; 32].try_into()?);
+    let obj = host.to_host_obj(&scobj)?;
     let sym = Symbol::from_str("del_call");
-    let scvec0: ScVec = vec![ScVal::I32(1)].try_into().unwrap();
-    let args = host.to_host_obj(&ScObject::Vec(scvec0)).unwrap();
+    let scvec0: ScVec = vec![ScVal::I32(1)].try_into()?;
+    let args = host.to_host_obj(&ScObject::Vec(scvec0))?;
     // try call
-    let sv = host
-        .try_call(obj.to_object(), sym.into(), args.clone().into())
-        .unwrap();
-    let exp_st = Status::from_type_and_code(
-        ScStatusType::HostObjectError,
-        ScHostObjErrorCode::VecIndexOutOfBound as u32,
-    );
-    assert_eq!(sv.get_payload(), exp_st.to_raw().get_payload());
+    let sv = host.try_call(obj.to_object(), sym.into(), args.clone().into())?;
+    let exp_st = Status::from_status(ScStatus::HostObjectError(
+        ScHostObjErrorCode::VecIndexOutOfBound,
+    ));
+    assert_eq!(sv.get_payload(), exp_st.as_ref().get_payload());
     // call
-    host.call(obj.to_object(), sym.into(), args.into()).unwrap();
+    assert_matches!(
+        host.call(obj.to_object(), sym.into(), args.into()),
+        Err(HostError::WASMI(wasmi::Error::Trap(wasmi::Trap::Host(_))))
+    );
+    Ok(())
 }
 
 #[test]
-fn binary_new_and_push() {
+fn binary_new_and_push() -> Result<(), HostError> {
     let host = Host::default();
 
-    let mut obj = host.binary_new().unwrap();
+    let mut obj = host.binary_new()?;
     for _i in 0..32 {
-        obj = host.binary_push(obj, 1_u32.into()).unwrap();
+        obj = host.binary_push(obj, 1_u32.into())?;
     }
 
-    let scobj = host.from_host_obj(obj).unwrap();
+    let scobj = host.from_host_obj(obj)?;
     let b = match scobj {
         ScObject::Binary(b) => b,
         _ => unreachable!(),
@@ -921,4 +954,5 @@ fn binary_new_and_push() {
 
     let res = [1; 32];
     assert_eq!(&res, b.as_slice());
+    Ok(())
 }

--- a/stellar-contract-env-host/src/vm.rs
+++ b/stellar-contract-env-host/src/vm.rs
@@ -41,7 +41,7 @@ impl Externals for Host {
 
     fn charge_cpu(&mut self, insns: u64) -> Result<(), wasmi::TrapCode> {
         self.modify_budget(|budget: &mut Budget| {
-            budget.event_counts.wasm_insns += insns;
+            budget.increment_wasm_insns(insns);
             if budget.cpu_limit_exceeded() {
                 Err(wasmi::TrapCode::CpuLimitExceeded)
             } else {


### PR DESCRIPTION
A few separate fixes here, probably worth reading by @leighmcculloch and @jayz22 (and maybe @sisuresh since it touches some of your tests) but nothing substantially weird or bad:

  - Move from ()-as-an-error in common to a specific named `ConversionError` struct
  - Make the Debug impls much better in common, using enum names and so forth
  - Make the budget arithmetic more efficient to check on the fly and partially update (as events grow)
  - Fix a couple error codes
  - Mostly: remove a ton of unwrap and should_panic in test code

One notable aspect of the last point is moving to `assert_matches!(...)` macros and matching on the error enum cases rather than the string messages in the error codes. I think this is a better thing to lean on for testing, not least because it lets us do semantic-rename of cases easily in the future, and also tests exactly the site at which the error is generated, and tests the code that the user is going to see out at the ScStatus level (keeping in mind that the informative extra strings are not propagated to the guest).