### PR TITLE
Re-export the exact version of im_rc used in the host.

### DIFF
--- a/stellar-contract-env-host/src/lib.rs
+++ b/stellar-contract-env-host/src/lib.rs
@@ -14,4 +14,5 @@ mod test;
 #[cfg(feature = "testutils")]
 pub use host::FrameGuard;
 pub use host::{Host, HostError};
+pub use im_rc;
 pub use stellar_contract_env_common::*;


### PR DESCRIPTION
Theoretically we can try to make downstream clients such as stellar-core use "the same" `im_rc` version through matching `Cargo.toml` file entries; but it is less error-prone and friendlier to multi-versioning if we just re-export the version used by the host from the host itself.