### PR TITLE
Pass `Object` type to bigint `shl`, `shr`, `pow` fn signatures

### DIFF
--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -171,29 +171,55 @@ macro_rules! call_macro_with_all_host_functions {
             }
 
             mod bigint "g" {
+                /// Constructs a BigInt from an u64.
                 {"_", fn bigint_from_u64(x:u64) -> Object}
+                /// Converts a BigInt to an u64. Traps if the value cannot fit into u64.
                 {"0", fn bigint_to_u64(x:Object) -> u64}
+                /// Constructs a BigInt from an i64.
                 {"1", fn bigint_from_i64(x:i64) -> Object}
+                /// Converts a BigInt to an i64. Traps if the value cannot fit into i64.
                 {"2", fn bigint_to_i64(x:Object) -> i64}
+                /// Performs the `+` operation.
                 {"3", fn bigint_add(x:Object, y:Object) -> Object}
+                /// Performs the `-` operation.
                 {"4", fn bigint_sub(x:Object, y:Object) -> Object}
+                /// Performs the `*` operation.
                 {"5", fn bigint_mul(x:Object, y:Object) -> Object}
+                /// Performs the `/` operation. Traps if `y` is zero.
                 {"6", fn bigint_div(x:Object, y:Object) -> Object}
+                /// Performs the `%` operation. Traps if `y` is zero.
                 {"7", fn bigint_rem(x:Object, y:Object) -> Object}
+                /// Performs the `&` operation.
                 {"8", fn bigint_and(x:Object, y:Object) -> Object}
+                /// Performs the `|` operation.
                 {"9", fn bigint_or(x:Object, y:Object) -> Object}
+                /// Performs the `^` operation.
                 {"A", fn bigint_xor(x:Object, y:Object) -> Object}
+                /// Performs the `<<` operation. Traps if `y` is negative or larger than the size of u64.
                 {"B", fn bigint_shl(x:Object, y:Object) -> Object}
+                /// Performs the `>>` operation. Traps if `y` is negative or larger than the size of u64.
                 {"C", fn bigint_shr(x:Object, y:Object) -> Object}
+                /// Returns an ordering between `x` and `y`: -1 (less), 0 (equal) or 1 (greater).
                 {"D", fn bigint_cmp(x:Object, y:Object) -> RawVal}
+                /// Returns true if `x` is equal to the additive identity.
                 {"E", fn bigint_is_zero(x:Object) -> RawVal}
+                /// Performs the unary `-` operation.
                 {"F", fn bigint_neg(x:Object) -> Object}
+                /// Performs the unary `!` operation.
                 {"G", fn bigint_not(x:Object) -> Object}
+                /// Calculates the Greatest Common Divisor (GCD) of `x` and `y`.
                 {"H", fn bigint_gcd(x:Object, y:Object) -> Object}
+                /// Calculates the Lowest Common Multiple (LCM) of `x` and `y`.
                 {"I", fn bigint_lcm(x:Object, y:Object) -> Object}
+                /// Calculates `x` to the power `y`. Traps if `y` is negative or larger than the size of u64.
                 {"J", fn bigint_pow(x:Object, y:Object) -> Object}
+                /// Calculates `(p ^ q) mod m`. Note that this rounds like `mod_floor`, not like the `%` operator, which makes a difference when given a negative `p` or `m`.
+                /// The result will be in the interval `[0, m)` for `m > 0`, or in the interval `(m, 0]` for `m < 0`.
+                /// Traps if the `q` is negative or the `m` is zero.
                 {"K", fn bigint_pow_mod(p:Object, q:Object, m:Object) -> Object}
+                /// Calculates the truncated principal square root of `x`. Traps if `x` is negative.
                 {"L", fn bigint_sqrt(x:Object) -> Object}
+                /// Determines the fewest bits necessary to express `x`, not including the sign.
                 {"M", fn bigint_bits(x:Object) -> u64}
             }
 

--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -183,15 +183,15 @@ macro_rules! call_macro_with_all_host_functions {
                 {"8", fn bigint_and(x:Object, y:Object) -> Object}
                 {"9", fn bigint_or(x:Object, y:Object) -> Object}
                 {"A", fn bigint_xor(x:Object, y:Object) -> Object}
-                {"B", fn bigint_shl(x:Object, y:u64) -> Object}
-                {"C", fn bigint_shr(x:Object, y:u64) -> Object}
+                {"B", fn bigint_shl(x:Object, y:Object) -> Object}
+                {"C", fn bigint_shr(x:Object, y:Object) -> Object}
                 {"D", fn bigint_cmp(x:Object, y:Object) -> RawVal}
                 {"E", fn bigint_is_zero(x:Object) -> RawVal}
                 {"F", fn bigint_neg(x:Object) -> Object}
                 {"G", fn bigint_not(x:Object) -> Object}
                 {"H", fn bigint_gcd(x:Object, y:Object) -> Object}
                 {"I", fn bigint_lcm(x:Object, y:Object) -> Object}
-                {"J", fn bigint_pow(x:Object, y:RawVal) -> Object}
+                {"J", fn bigint_pow(x:Object, y:Object) -> Object}
                 {"K", fn bigint_pow_mod(p:Object, q:Object, m:Object) -> Object}
                 {"L", fn bigint_sqrt(x:Object) -> Object}
                 {"M", fn bigint_bits(x:Object) -> u64}

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -1237,15 +1237,35 @@ fn bigint_tests() -> Result<(), HostError> {
     }
     // shl
     {
-        let obj_res = host.bigint_shl(obj_a, 5)?;
+        let obj_res = host.bigint_shl(obj_a, host.bigint_from_i64(5)?)?;
         let obj_ref = host.bigint_from_u64(a << 5)?;
         assert_eq!(host.obj_cmp(obj_res.into(), obj_ref.into())?, 0);
+        assert_matches!(
+            host.bigint_shl(obj_a, host.bigint_from_i64(-5)?),
+            Err(HostError::General("attempt to shift left with negative"))
+        );
+        // a 65-bit integer
+        let obj_c = host.bigint_shl(host.bigint_from_u64(u64::MAX)?, host.bigint_from_i64(1)?)?;
+        assert_matches!(
+            host.bigint_shl(obj_a, obj_c),
+            Err(HostError::General("left-shift overflow"))
+        );
     }
     // shr
     {
-        let obj_res = host.bigint_shr(obj_a, 5)?;
+        let obj_res = host.bigint_shr(obj_a, host.bigint_from_i64(5)?)?;
         let obj_ref = host.bigint_from_u64(a >> 5)?;
         assert_eq!(host.obj_cmp(obj_res.into(), obj_ref.into())?, 0);
+        assert_matches!(
+            host.bigint_shr(obj_a, host.bigint_from_i64(-5)?),
+            Err(HostError::General("attempt to shift right with negative"))
+        );
+        // a 65-bit integer
+        let obj_c = host.bigint_shl(host.bigint_from_u64(u64::MAX)?, host.bigint_from_i64(1)?)?;
+        assert_matches!(
+            host.bigint_shr(obj_a, obj_c),
+            Err(HostError::General("right-shift overflow"))
+        );
     }
     // cmp
     {
@@ -1312,12 +1332,22 @@ fn bigint_tests() -> Result<(), HostError> {
     }
     // pow
     {
-        let obj_res = host.bigint_pow(obj_b, 2_u32.into())?;
+        let obj_res = host.bigint_pow(obj_b, host.bigint_from_u64(2_u32.into())?)?;
         let obj_ref = host.bigint_from_i64(192484012900)?;
         assert_eq!(host.obj_cmp(obj_res.into(), obj_ref.into())?, 0);
-        let obj_res = host.bigint_pow(obj_b, 0_u32.into())?;
+        let obj_res = host.bigint_pow(obj_b, host.bigint_from_u64(0_u32.into())?)?;
         let obj_ref = host.bigint_from_i64(1)?;
         assert_eq!(host.obj_cmp(obj_res.into(), obj_ref.into())?, 0);
+        assert_matches!(
+            host.bigint_pow(obj_b, host.bigint_from_i64(-1)?),
+            Err(HostError::General("negative exponentiation not supported"))
+        );
+        // a 65-bit integer
+        let obj_c = host.bigint_shl(host.bigint_from_u64(u64::MAX)?, host.bigint_from_i64(1)?)?;
+        assert_matches!(
+            host.bigint_pow(obj_b, obj_c),
+            Err(HostError::General("pow overflow"))
+        );
     }
     // pow_mod
     {


### PR DESCRIPTION
### What

Pass in bigint objects to `bigint_shl/shr/pow` fn signatures, and provide sign and overflow checks within these functions. 

### Why

The `num_bigint` api of `shl`, `shr`, `pow` has internal checks for [sign](https://docs.rs/num-bigint/latest/src/num_bigint/biguint/shift.rs.html#13) and [overflow](https://docs.rs/num-bigint/latest/src/num_bigint/biguint/power.rs.html#25), which may panic if the inputs do not fit. Instead of restricting our hostfn api (e.g taking a `u32` as the exponent in `bigint_pow`), we should still pass those parameters as `BigInt` and check their validity from within the host functions. This makes the bigint hostfn apis more uniform and easier to maintain. 

### Known limitations

[TODO or N/A]
