### PR TITLE
Overhaul the budget system with general cost models, add model fitting.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,30 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "autocfg"
@@ -140,6 +160,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,10 +194,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "im-rc"
@@ -191,6 +239,21 @@ name = "libm"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memory_units"
@@ -241,10 +304,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "optimization"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b23fac7398d2a9edcd3a2f4cb6e045c6cb668cfcd0071edf37217941b6a9a01"
+dependencies = [
+ "log",
+ "rand",
+ "rand_distr",
+ "rand_pcg",
+]
 
 [[package]]
 name = "parity-wasm"
@@ -270,6 +351,12 @@ checksum = "ce9bedf5da2c234fdf2391ede2b90fabf585355f33100689bc364a3ea558561a"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "ppv-lite86"
@@ -334,10 +421,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 
 [[package]]
+name = "rand_distr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96977acbdd3a6576fb1d27391900035bf3863d4a16422973a409b488cf29ffb2"
+dependencies = [
+ "rand",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
 ]
@@ -350,6 +455,23 @@ checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "serde"
@@ -425,12 +547,15 @@ version = "0.0.0"
 dependencies = [
  "assert_matches",
  "ed25519-dalek",
+ "env_logger",
  "hex",
  "im-rc",
+ "log",
  "num-bigint",
  "num-integer",
  "num-rational",
  "num-traits",
+ "optimization",
  "parity-wasm",
  "perf-event",
  "sha2 0.10.2",
@@ -438,6 +563,8 @@ dependencies = [
  "stellar-contract-env-common",
  "tabwriter",
  "thiserror",
+ "thousands",
+ "tracking-allocator",
  "wasmi",
 ]
 
@@ -492,6 +619,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +645,51 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
+name = "tracing"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a713421342a5a666b7577783721d3117f1b69a393df803ee17bb73b1e122a59"
+dependencies = [
+ "tracing-core",
+]
+
+[[package]]
+name = "tracking-allocator"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b61e0cb3385e17df7db29c565b40fd0350dfe8a076c7eea83d416e30cfd0581"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -577,6 +758,37 @@ dependencies = [
  "num-traits",
  "parity-wasm",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"

--- a/stellar-contract-env-host/Cargo.toml
+++ b/stellar-contract-env-host/Cargo.toml
@@ -22,6 +22,9 @@ num-integer = "0.1.45"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
+optimization = "0.2.0"
+env_logger = "0.9.0"
+log = "0.4.17"
 
 [features]
 vm = ["wasmi", "parity-wasm", "stellar-contract-env-common/vm"]
@@ -29,7 +32,9 @@ testutils = []
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 perf-event = "0.4.7"
+tracking-allocator = "0.4.0"
 tabwriter = "1.2.1"
+thousands = "0.2.0"
 
 [[bench]]
 required-features = ["vm"]
@@ -37,3 +42,9 @@ harness = false
 bench = true
 name = "calibrate_wasm_insns"
 path = "benches/calibrate_wasm_insns.rs"
+
+[[bench]]
+harness = false
+bench = true
+name = "calibrate_host_ops"
+path = "benches/calibrate_host_ops.rs"

--- a/stellar-contract-env-host/benches/calibrate_host_ops.rs
+++ b/stellar-contract-env-host/benches/calibrate_host_ops.rs
@@ -1,0 +1,48 @@
+// Run this with
+// $ cargo bench calibrate_host_ops -- --nocapture
+
+mod common;
+use common::*;
+use stellar_contract_env_host::{
+    budget::CostType,
+    xdr::{ScObject, ScVal, ScVec},
+    Host,
+};
+
+struct VecAllocRun {
+    val: ScVal,
+}
+
+impl HostCostMeasurement for VecAllocRun {
+    const COST_TYPE: CostType = CostType::HostVecAlloc;
+
+    fn new(_host: &Host, size_hint: u64) -> Self {
+        let size = size_hint * 10000;
+        let scvec: ScVec = ScVec(
+            (0..size)
+                .map(|i| ScVal::U32(i as u32))
+                .collect::<Vec<ScVal>>()
+                .try_into()
+                .unwrap(),
+        );
+        let val = ScVal::Object(Some(ScObject::Vec(scvec)));
+        Self { val }
+    }
+
+    fn run(&mut self, host: &Host) {
+        host.intern(&self.val).unwrap();
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+fn main() -> std::io::Result<()> {
+    env_logger::init();
+    let mut measurements = measure_costs::<VecAllocRun>(0..20)?;
+    measurements.subtract_baseline();
+    measurements.report();
+    if std::env::var("FIT_MODELS").is_ok() {
+        measurements.fit_model_to_cpu();
+        measurements.fit_model_to_mem();
+    }
+    Ok(())
+}

--- a/stellar-contract-env-host/benches/common.rs
+++ b/stellar-contract-env-host/benches/common.rs
@@ -1,0 +1,10 @@
+#![allow(dead_code)]
+
+#[path = "common/measure.rs"]
+mod measure;
+
+#[path = "common/modelfit.rs"]
+mod modelfit;
+
+pub use measure::*;
+pub use modelfit::*;

--- a/stellar-contract-env-host/benches/common/measure.rs
+++ b/stellar-contract-env-host/benches/common/measure.rs
@@ -1,0 +1,191 @@
+use std::{
+    alloc::System,
+    ops::Range,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    time::Instant,
+};
+use stellar_contract_env_host::{budget::CostType, Host};
+use tabwriter::{Alignment, TabWriter};
+use tracking_allocator::{AllocationGroupToken, AllocationRegistry, AllocationTracker, Allocator};
+
+use super::{fit_model, FPCostModel, FPPoint};
+
+#[global_allocator]
+static GLOBAL: Allocator<System> = Allocator::system();
+
+#[derive(Clone)]
+pub struct MemTracker(Arc<AtomicU64>);
+impl AllocationTracker for MemTracker {
+    fn allocated(
+        &self,
+        _addr: usize,
+        _object_size: usize,
+        wrapped_size: usize,
+        _group_id: tracking_allocator::AllocationGroupId,
+    ) {
+        self.0.fetch_add(wrapped_size as u64, Ordering::SeqCst);
+    }
+
+    fn deallocated(
+        &self,
+        _addr: usize,
+        _object_size: usize,
+        wrapped_size: usize,
+        _source_group_id: tracking_allocator::AllocationGroupId,
+        _current_group_id: tracking_allocator::AllocationGroupId,
+    ) {
+        self.0.fetch_sub(wrapped_size as u64, Ordering::SeqCst);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Measurement {
+    pub input: u64,
+    pub cpu_insns: u64,
+    pub mem_bytes: u64,
+    pub time_nsecs: u64,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Measurements(pub Vec<Measurement>);
+impl Measurements {
+    /// Subtracts the values of the first measurement from all subsequent
+    /// measurements, to eliminate constant factors; this should only be done if
+    /// you're sure you don't want to capture those constant factors in a later
+    /// cost model.
+    pub fn subtract_baseline(&mut self) {
+        match self.0.split_first_mut() {
+            None => (),
+            Some((first, rest)) => {
+                for e in rest {
+                    e.input = e.input.saturating_sub(first.input);
+                    e.cpu_insns = e.cpu_insns.saturating_sub(first.cpu_insns);
+                    e.mem_bytes = e.mem_bytes.saturating_sub(first.mem_bytes);
+                    e.time_nsecs = e.time_nsecs.saturating_sub(first.time_nsecs);
+                }
+                *first = Measurement::default();
+            }
+        }
+    }
+
+    pub fn report(&self) {
+        use std::io::Write;
+        use thousands::Separable;
+        let mut tw = TabWriter::new(vec![])
+            .padding(5)
+            .alignment(Alignment::Right);
+
+        write!(
+            &mut tw,
+            "input\tcpu insns\tmem bytes\ttime nsecs\tinsns/input\tbytes/input\tnsecs/input\n"
+        )
+        .unwrap();
+        for m in self.0.iter() {
+            write!(
+                &mut tw,
+                "{}\t{}\t{}\t{}ns\t{}\t{}\t{}ns\n",
+                m.input.separate_with_commas(),
+                m.cpu_insns.separate_with_commas(),
+                m.mem_bytes.separate_with_commas(),
+                m.time_nsecs.separate_with_commas(),
+                (m.cpu_insns / m.input.max(1)).separate_with_commas(),
+                (m.mem_bytes / m.input.max(1)).separate_with_commas(),
+                (m.time_nsecs / m.input.max(1)).separate_with_commas()
+            )
+            .unwrap();
+        }
+        tw.flush().unwrap();
+        eprintln!("{}", String::from_utf8(tw.into_inner().unwrap()).unwrap());
+    }
+
+    pub fn fit_model_to_cpu(&self) -> FPCostModel {
+        let data = self
+            .0
+            .iter()
+            .map(|m| FPPoint {
+                x: m.input as f64,
+                y: m.cpu_insns as f64,
+            })
+            .collect();
+        fit_model(&data)
+    }
+
+    pub fn fit_model_to_mem(&self) -> FPCostModel {
+        let data = self
+            .0
+            .iter()
+            .map(|m| FPPoint {
+                x: m.input as f64,
+                y: m.mem_bytes as f64,
+            })
+            .collect();
+        fit_model(&data)
+    }
+}
+
+/// HostCostMeasurement is an interface to measuring the memory and CPU
+/// costs of a CostType: usually a block of WASM bytecode or a host function.
+pub trait HostCostMeasurement {
+    /// The type of cost we're measuring.
+    const COST_TYPE: CostType;
+
+    /// Initialize a new instance of a HostMeasurement at a given input _hint_, for
+    /// the run; the HostMeasurement can choose a precise input for a given hint
+    /// and use it during `run`; the precise input will be extracted at the end
+    /// using `get_input`.
+    ///
+    /// All setup should happen in the `new` function here; `run` should be
+    /// reserved for the "actual event" you're trying to measure.
+    fn new(host: &Host, input_hint: u64) -> Self;
+
+    /// Run the HostMeasurement. This method is called under CPU-and-memory tracking
+    /// machinery, so anything that happens during it will be considered part of
+    /// the cost for running the HostMeasurement at the returned input.
+    fn run(&mut self, host: &Host);
+
+    /// Return the _actual_ input chosen, rather than the hint passed to `new`.
+    fn get_input(&self, host: &Host) -> u64 {
+        host.get_budget(|budget| budget.get_input(Self::COST_TYPE))
+    }
+}
+
+pub fn measure_costs<HCM: HostCostMeasurement>(
+    step_range: Range<u64>,
+) -> Result<Measurements, std::io::Error> {
+    let mut cpu_counter = perf_event::Builder::new().build()?;
+    let mem_tracker = MemTracker(Arc::new(AtomicU64::new(0)));
+    let _ = AllocationRegistry::set_global_tracker(mem_tracker.clone())
+        .expect("no other global tracker should be set yet");
+    AllocationRegistry::enable_tracking();
+    let mut alloc_group_token =
+        AllocationGroupToken::register().expect("failed to register allocation group");
+    let mut ret = Vec::new();
+    for input_hint in step_range {
+        let host = Host::default();
+        host.get_budget_mut(|budget| budget.reset_unlimited());
+        let mut m = HCM::new(&host, input_hint);
+        let start = Instant::now();
+        mem_tracker.0.store(0, Ordering::SeqCst);
+        let alloc_guard = alloc_group_token.enter();
+        cpu_counter.reset()?;
+        cpu_counter.enable()?;
+        m.run(&host);
+        cpu_counter.disable()?;
+        drop(alloc_guard);
+        let stop = Instant::now();
+        let input = m.get_input(&host);
+        let cpu_insns = cpu_counter.read()?;
+        let mem_bytes = mem_tracker.0.load(Ordering::SeqCst);
+        let time_nsecs = stop.duration_since(start).as_nanos() as u64;
+        ret.push(Measurement {
+            input,
+            cpu_insns,
+            mem_bytes,
+            time_nsecs,
+        })
+    }
+    Ok(Measurements(ret))
+}

--- a/stellar-contract-env-host/benches/common/modelfit.rs
+++ b/stellar-contract-env-host/benches/common/modelfit.rs
@@ -1,0 +1,79 @@
+use log::{info, trace};
+use optimization;
+use optimization::{Func, GradientDescent, Minimizer, NumericalDifferentiation};
+
+pub struct FPPoint {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, PartialOrd)]
+pub struct FPCostModel {
+    pub const_param: f64,
+    pub log_param: f64,
+    pub log_base_param: f64,
+    pub lin_param: f64,
+    pub quad_param: f64,
+}
+
+// We have to use a floating-point cost model in order to interface with the
+// numerical optimizer below -- using integral types causes it to get very
+// confused due to rounding/truncation.
+impl FPCostModel {
+    pub fn new(params: &[f64]) -> Self {
+        let mut fcm = FPCostModel::default();
+        fcm.const_param = params[0];
+        fcm.log_param = params[1];
+        fcm.log_base_param = params[2];
+        fcm.lin_param = params[3];
+        fcm.quad_param = params[4];
+        fcm
+    }
+    // This is the same as the 'evaluate' function in the integral cost model,
+    // just using f64 ops rather than saturating integer ops.
+    pub fn evaluate(&self, input: f64) -> f64 {
+        let mut res = self.const_param;
+        if input.is_finite() && input != 0.0 {
+            res += self.log_param * input.log(self.log_base_param);
+            res += self.lin_param * input;
+            res += self.quad_param * input * input;
+        }
+        res
+    }
+}
+
+// Fits a FloatCostModel to the provided data, using least-squares
+// gradient descent optimization.
+pub fn fit_model(data: &Vec<FPPoint>) -> FPCostModel {
+    // We construct an objective function for the optimizer here that treats its
+    // inputs as parametes to a FloatCostModel, and returns the sum (over all
+    // provided data points) of squares of differences between the data.y value
+    // and the cost model evaluated at the data.x value.
+    //
+    // In other words, the objective function maps parameters to a measure of
+    // goodness-of-fit between the input data and a cost model with the provided
+    // parameter values.
+    let function = NumericalDifferentiation::new(Func(|params: &[f64]| {
+        let cm = FPCostModel::new(params);
+        let mut sum_sq = 0.0;
+        for pt in data.iter() {
+            let eval = cm.evaluate(pt.x);
+            let diff = pt.y - eval;
+            trace!(
+                "evaluated f({}) = {}, data has {}, diff {}",
+                pt.x,
+                eval,
+                pt.y,
+                diff
+            );
+            sum_sq += diff * diff;
+        }
+        trace!("sum-of-squares of differences at {:?}: {}", cm, sum_sq);
+        sum_sq
+    }));
+    let minimizer = GradientDescent::new().max_iterations(Some(1_000_000));
+    let solution = minimizer.minimize(&function, vec![0.0, 0.0, 0.0, 0.0, 0.0]);
+    let ret = FPCostModel::new(&solution.position[..]);
+    info!("found solution at f({:?}) = {:?}", ret, solution.value);
+    ret
+}

--- a/stellar-contract-env-host/src/budget.rs
+++ b/stellar-contract-env-host/src/budget.rs
@@ -1,73 +1,241 @@
-#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ResourceCosts {
-    pub mem_bytes: u64,
-    pub cpu_insns: u64,
+use crate::HostError;
+
+// TODO: move this to an XDR enum
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum CostType {
+    HostVecAlloc = 0,
+    HostMapAlloc = 1,
+    WasmInsnExec = 2,
+    WasmMemAlloc = 3,
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct CostFactors {
-    pub cpu_insn_per_wasm_insn: u64,
+// TODO: add XDR support for iterating over all the elements of an enum
+impl CostType {
+    fn variants() -> std::slice::Iter<'static, CostType> {
+        static VARIANTS: &'static [CostType] = &[
+            CostType::HostMapAlloc,
+            CostType::HostVecAlloc,
+            CostType::WasmInsnExec,
+        ];
+        VARIANTS.iter()
+    }
 }
 
-#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct EventCounts {
-    pub wasm_insns: u64,
-    pub wasm_linear_memory_bytes: u64,
+/// We provide a general "cost model" object that evaluates a general
+/// expression:
+///
+///    f(x) = a + b*log_i(x) + c*x + d*(x^2)
+///
+/// Where a, b, c, d, and i are all "fixed" parameters at construction time
+/// (extracted from an on-chain cost schedule, so technically not _totally_
+/// fixed) and x is some abstract input variable -- say, event counts or object
+/// sizes -- provided at runtime.
+///
+/// The log base i is also rounded-up to its nearest power of 2, since we
+/// implement that term using bit count instructions.
+///
+/// The same CostModel type (applied to different parameters and variables) is
+/// used for calculating memory as well as CPU time. We _hope_ this expression
+/// is capable of modeling any of the costs we want to measure at runtime.
+///
+/// The parameters for a CostModel are calibrated empirically. See this crate's
+/// benchmarks for more details.
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct CostModel {
+    pub const_param: u64,
+    pub log_param: u64,
+    pub log_base_param: u64,
+    pub lin_param: u64,
+    pub quad_param: u64,
 }
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+impl CostModel {
+    pub fn evaluate(&self, input: u64) -> u64 {
+        let mut res = self.const_param;
+        if self.log_param != 0 {
+            res = res.saturating_add(
+                self.log_param
+                    .saturating_mul(ceil_log_base(input, self.log_base_param)),
+            );
+        }
+        if self.lin_param != 0 {
+            res = res.saturating_add(self.lin_param.saturating_mul(input));
+        }
+        if self.quad_param != 0 {
+            res = res.saturating_add(self.quad_param.saturating_mul(input.saturating_mul(input)));
+        }
+        res
+    }
+}
+
+// Returns the next power of 2 >= the input, avoiding overflow and returning 2
+// for any input <= 2 (as we want to use this for logarithm input bases below).
+fn next_2(x: u64) -> u64 {
+    match x.checked_next_power_of_two() {
+        None => 0x1000_0000_0000_0000,
+        Some(0) => 2,
+        Some(1) => 2,
+        Some(n) => n,
+    }
+}
+
+// Returns the ceil(log_base(next_2(x_in), next_2(base_in))); in other words
+// rounds-up the input numbers to their nearest powers-of-two x and base
+// respectively and then returns the least k such that base^k >= x.
+//
+// This is used below when calculating the cost to charge for a logarithmic
+// term in the cost model.
+fn ceil_log_base(x_in: u64, base_in: u64) -> u64 {
+    let x = next_2(x_in);
+    let base = next_2(base_in);
+    let x_bits = x.trailing_zeros();
+    let base_bits = base.trailing_zeros();
+    let mut res = x_bits / base_bits;
+    if x_bits % base_bits != 0 {
+        res += 1;
+    }
+    assert!(base.pow(res) >= x);
+    assert!(base.pow(res) >= x_in);
+    res as u64
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BudgetDimension {
+    /// A set of cost models that map input values (eg. event counts, object
+    /// sizes) from some CostType to whatever concrete resource type is being
+    /// tracked by this dimension (eg. cpu or memory). CostType enum values are
+    /// used as indexes into this vector, to make runtime lookups as cheap as
+    /// possible.
+    cost_models: Vec<CostModel>,
+
+    /// The limit against-which the count is compared to decide if we're
+    /// over budget.
+    limit: u64,
+
+    /// Tracks the sum of _output_ values from the cost model, for purposes
+    /// of comparing to limit.
+    count: u64,
+}
+
+impl BudgetDimension {
+    pub fn get_cost_model(&self, ty: CostType) -> &CostModel {
+        &self.cost_models[ty as usize]
+    }
+
+    pub fn get_cost_model_mut(&mut self, ty: CostType) -> &mut CostModel {
+        &mut self.cost_models[ty as usize]
+    }
+
+    pub fn get_count(&self) -> u64 {
+        self.count
+    }
+
+    pub fn get_limit(&self) -> u64 {
+        self.limit
+    }
+
+    pub fn reset(&mut self, limit: u64) {
+        self.limit = limit;
+        self.count = 0;
+    }
+
+    pub fn is_over_budget(&self) -> bool {
+        self.count > self.limit
+    }
+
+    pub fn charge(&mut self, ty: CostType, input: u64) -> Result<(), HostError> {
+        if self.limit == u64::MAX {
+            return Ok(());
+        }
+        let cm = self.get_cost_model(ty);
+        self.count = self.count.saturating_add(cm.evaluate(input));
+        if self.is_over_budget() {
+            // TODO: convert this to a proper error code type.
+            Err(HostError::General("budget limit exceeded"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Default for BudgetDimension {
+    fn default() -> Self {
+        let mut bd = Self {
+            cost_models: Default::default(),
+            limit: Default::default(),
+            count: Default::default(),
+        };
+        for _ct in CostType::variants() {
+            // TODO: load cost model for i from the chain.
+            bd.cost_models.push(CostModel::default());
+        }
+        bd
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Budget {
-    pub cost_limits: ResourceCosts,
-    pub cost_incurred: ResourceCosts,
-    pub cost_factors: CostFactors,
-    pub event_counts: EventCounts,
+    pub cpu_insns: BudgetDimension,
+    pub mem_bytes: BudgetDimension,
+    /// Tracks the sums of _input_ values to the cost models, for purposes of
+    /// calibration and reporting; not used for budget-limiting per se.
+    inputs: Vec<u64>,
+}
+
+impl Budget {
+    pub fn charge(&mut self, ty: CostType, input: u64) -> Result<(), HostError> {
+        let i = self.get_input_mut(ty);
+        *i = i.saturating_add(input);
+
+        self.cpu_insns.charge(ty, input)?;
+        self.mem_bytes.charge(ty, input)?;
+        Ok(())
+    }
+
+    pub fn get_input(&self, ty: CostType) -> u64 {
+        self.inputs[ty as usize]
+    }
+
+    pub fn get_input_mut(&mut self, ty: CostType) -> &mut u64 {
+        &mut self.inputs[ty as usize]
+    }
+
+    pub fn reset_unlimited(&mut self) {
+        self.cpu_insns.reset(u64::MAX);
+        self.mem_bytes.reset(u64::MAX);
+        self.reset_inputs()
+    }
+
+    pub fn reset_inputs(&mut self) {
+        for i in self.inputs.iter_mut() {
+            *i = 0;
+        }
+    }
 }
 
 impl Default for Budget {
     fn default() -> Self {
-        Self {
-            cost_limits: ResourceCosts::default_limits(),
-            cost_incurred: Default::default(),
-            cost_factors: Default::default(),
-            event_counts: Default::default(),
+        let mut b = Self {
+            cpu_insns: Default::default(),
+            mem_bytes: Default::default(),
+            inputs: Default::default(),
+        };
+
+        for _ct in CostType::variants() {
+            b.inputs.push(0);
         }
-    }
-}
 
-impl Budget {
-    pub fn increment_wasm_insns(&mut self, insns: u64) {
-        self.event_counts.wasm_insns += insns;
-        self.cost_incurred.cpu_insns = self
-            .cost_incurred
-            .cpu_insns
-            .saturating_add(insns.saturating_mul(self.cost_factors.cpu_insn_per_wasm_insn));
-    }
+        // For the time being we don't have "on chain" cost models
+        // so we just set some up here that we calibrated manually
+        // in the adjacent benchmarks.
 
-    pub fn cpu_limit_exceeded(&self) -> bool {
-        self.cost_incurred.cpu_insns > self.cost_limits.cpu_insns
-    }
-    pub fn mem_limit_exceeded(&self) -> bool {
-        self.event_counts.wasm_linear_memory_bytes > self.cost_limits.mem_bytes
-    }
-}
+        // WASM instructions cost linear CPU instructions: 73 each.
+        b.cpu_insns
+            .get_cost_model_mut(CostType::WasmInsnExec)
+            .lin_param = 73;
 
-impl Default for CostFactors {
-    fn default() -> Self {
-        Self {
-            // Note: This was empirically calibrated very crudely on an x64
-            // system based on the `calibrate_wasm_insns` benchmark, using:
-            //
-            //  $ cargo bench --features vm calibrate_wasm_insns -- --nocapture
-            //
-            // It should be explored in more detail and stored / retrieved on
-            // chain in a CONFIG_SETTING LE.
-            cpu_insn_per_wasm_insn: 73,
-        }
-    }
-}
-
-impl ResourceCosts {
-    fn default_limits() -> Self {
         // Some "reasonable defaults": 640k of RAM and 100usec.
         //
         // We don't run for a time unit thought, we run for an estimated
@@ -77,9 +245,8 @@ impl ResourceCosts {
         // 4bn instructions / sec. So about 4000 instructions per usec, or 400k
         // instructions in a 100usec time budget, or about 5479 wasm instructions
         // using the calibration above. Very roughly!
-        Self {
-            mem_bytes: 0xa_0000,
-            cpu_insns: 400_000,
-        }
+        b.mem_bytes.limit = 0xa_0000;
+        b.cpu_insns.limit = 400_000;
+        b
     }
 }

--- a/stellar-contract-env-host/src/lib.rs
+++ b/stellar-contract-env-host/src/lib.rs
@@ -1,4 +1,4 @@
-mod budget;
+pub mod budget;
 mod host;
 pub(crate) mod host_object;
 pub(crate) mod weak_host;


### PR DESCRIPTION
I'm out of time for this evening, but I promised @jayz22 a little material and this is as far as I got. It compiles and half-works, but doesn't work enough to merge just yet. You're welcome to try to brush it up into something mergeable, or just stare at it and get an idea for the direction I think we should be going / where I'm going to try to take it next week.

(this addresses #160)

What's here:
  - General cost models rather than just linear factors. A cost model is a parameterized function with a constant, linear, log, log-base, and quadratic term. These parameters will eventually be loaded from ledger `CONFIG_SETTING` entries, but for now they're all zero except the one I added for tracking CPU insns per WASM insn.
  - Uniform interface to multiple cost models in multiple different dimensions. All the data structures are just keyed by a single type code for each cost type (it's an explicit enum in this PR -- it should go into the XDR), and the interface for charging costs is just calling `budget.charge(CostType::Foo, n)?` where `n` is the input domain for the cost model. It'll look up the cost model for each dimension (cpu and memory), transform `n` to a cost under the cost model, charge the dimension, and return an error if the dimension is over budget.
  - Model fitting for offline calibration of the cost models. I added enough machinery to _almost_ convince myself that we can empirically measure the costs of host functions using calibration benchmarks and then feed those benchmarks into a stock gradient-descent optimizer to do least-squares curve fitting of the model to the data (code is in the PR here, but I did test it and it was able to recover at least a linear and a quadratic curve from sample data I ran it on). I _think_ this is a viable path for calibrating cost models, but I'll need to return to it later.

Comments welcome! It's very rough, but I think it's close to the shape we'll want going forward.