### PR TITLE
Remove Copy from SymbolIter

### DIFF
--- a/stellar-contract-env-common/src/symbol.rs
+++ b/stellar-contract-env-common/src/symbol.rs
@@ -212,7 +212,7 @@ impl IntoIterator for Symbol {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct SymbolIter(u64);
 
 impl Iterator for SymbolIter {


### PR DESCRIPTION
### What

Remove `Copy` from `SymbolIter`.

### Why

Making an iterator copyable creates some footguns because it's easy to copy it when we should otherwise be borrowing.

### Known limitations

[TODO or N/A]
