### PR TITLE
Use cargo-hack instead of cargo-all-features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
     - run: rustup target add ${{ matrix.sys.target }}
-    - run: cargo install --locked --version 1.7.0 cargo-all-features
-    - run: cargo check-all-features --profile ${{ matrix.profile }} --target ${{ matrix.sys.target }}
+    - run: cargo install --locked --version 0.5.14 cargo-hack
+    - run: cargo hack --feature-powerset check -- --profile ${{ matrix.profile }} --target ${{ matrix.sys.target }}
     - if: matrix.sys.test
-      run: cargo test-all-features --profile ${{ matrix.profile }} --target ${{ matrix.sys.target }}
+      run: cargo hack --feature-powerset test -- --profile ${{ matrix.profile }} --target ${{ matrix.sys.target }}

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 all: build test
 
 test:
-	cargo test-all-features
+	cargo hack --feature-powerset test
 
 build:
-	cargo check-all-features
+	cargo hack --feature-powerset check
 
 watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'


### PR DESCRIPTION
### What

Use `cargo-hack` instead of `cargo-all-features` to run cargo commands for all crate and feature combinations.

### Why

`cargo-hack`, while the name is a little scary, appears to be being maintained and its 'powerset' feature will reduce the set of features down to the meaningfully unique feature sets. `cargo-all-features` on the other hands blindly takes all available features and generates a much larger set of builds to run, which is resulting in 27 builds instead of the 10 builds actually needed. This is because we have duplicate features that overlap, like the wasmi, parity-wasm, and vm features. Also, `cargo-all-features` hasn't been updated to correctly handle namespaced features or weak-depenency features, and it errors when I tried to introduce them.

### Known limitations

[TODO or N/A]
