### PR TITLE
Support 1-ary tuple conversion to/from RawVals

### DIFF
--- a/stellar-contract-env-common/src/tuple.rs
+++ b/stellar-contract-env-common/src/tuple.rs
@@ -46,6 +46,7 @@ macro_rules! impl_for_tuple {
         }
     };
 }
+
 impl_for_tuple! {  1 T0 0 }
 impl_for_tuple! {  2 T0 0 T1 1 }
 impl_for_tuple! {  3 T0 0 T1 1 T2 2 }

--- a/stellar-contract-env-common/src/tuple.rs
+++ b/stellar-contract-env-common/src/tuple.rs
@@ -7,7 +7,7 @@ use crate::{
 
 macro_rules! impl_for_tuple {
     ( $count:literal $($typ:ident $idx:tt)+ ) => {
-        impl<E: Env, $($typ),*> TryFrom<EnvVal<E, RawVal>> for ($($typ),*)
+        impl<E: Env, $($typ),*> TryFrom<EnvVal<E, RawVal>> for ($($typ,)*)
         where
             $($typ: TryFrom<EnvVal<E, RawVal>>),*
         {
@@ -28,12 +28,12 @@ macro_rules! impl_for_tuple {
                         let idx: u32 = $idx;
                         let val = env.vec_get(vec, idx.into());
                         $typ::try_from_val(&env, val).map_err(|_| ConversionError)?
-                    }),*
+                    },)*
                 ))
             }
         }
 
-        impl<E: Env, $($typ),*> IntoEnvVal<E, RawVal> for ($($typ),*)
+        impl<E: Env, $($typ),*> IntoEnvVal<E, RawVal> for ($($typ,)*)
         where
             $($typ: IntoEnvVal<E, RawVal>),*
         {
@@ -46,6 +46,7 @@ macro_rules! impl_for_tuple {
         }
     };
 }
+impl_for_tuple! {  1 T0 0 }
 impl_for_tuple! {  2 T0 0 T1 1 }
 impl_for_tuple! {  3 T0 0 T1 1 T2 2 }
 impl_for_tuple! {  4 T0 0 T1 1 T2 2 T3 3 }


### PR DESCRIPTION
### What

Support 1-ary tuple conversion to/from RawVals.

### Why

There's no reason to support it and @jonjove has pointed out it would be convenient in some cases. When I originally wrote this I thought Rust didn't have 1-ary tuples, but @jonjove pointed out it does. I was merely using the wrong syntax for doing so.

Close #178 

### Known limitations

[TODO or N/A]
