### PR TITLE
Rename call module from 'c' to 'd'

### DIFF
--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -160,7 +160,7 @@ macro_rules! call_macro_with_all_host_functions {
                 {"4", fn create_contract_using_parent_id(v: Object, salt: Object) -> Object}
             }
 
-            mod call "c" {
+            mod call "d" {
                 /// Calls a function in another contract with arguments contained in vector `args`.
                 /// If the call is successful, forwards the result of the called function. Traps otherwise.
                 {"_", fn call(contract:Object, func:Symbol, args:Object) -> RawVal}


### PR DESCRIPTION

### What

Rename call module from "c" to "d".

### Why

Because it collides with crypto, and "d" stands for dispatch.

### Known limitations

None