### PR TITLE
Derive Eq,PartialEq for ConversionError

### DIFF
--- a/stellar-contract-env-common/src/raw_val.rs
+++ b/stellar-contract-env-common/src/raw_val.rs
@@ -60,7 +60,7 @@ impl AsMut<RawVal> for RawVal {
 // This is a 0-arg struct rather than an enum to ensure it completely compiles
 // away, the same way `()` would, while remaining a separate type to allow
 // conversion to a more-structured error code at a higher level.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ConversionError;
 
 pub trait RawValConvertible: Into<RawVal> + TryFrom<RawVal> {


### PR DESCRIPTION
### What

Derive `Eq`, `PartialEq` for `ConversionError`.

### Why

So that `Result`s that contain the `ConversionError` can be compared.

### Known limitations

[TODO or N/A]
