### PR TITLE
Use toolchain action to install Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,8 +48,12 @@ jobs:
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3
-    - run: rustup update stable && rustup default stable
-    - run: rustup target add ${{ matrix.sys.target }}
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+      with:
+        toolchain: stable
+        default: true
+        components: rustfmt, clippy
+        target: ${{ matrix.sys.target }}
     - run: cargo install --locked --version 0.5.14 cargo-hack
     - run: cargo hack --feature-powerset check --profile ${{ matrix.profile }} --target ${{ matrix.sys.target }}
     - if: matrix.sys.test


### PR DESCRIPTION
### What

Use toolchain action to install Rust.

### Why

Rustup started to fail to update the version of Rust on some windows GitHub Action runners. https://github.com/actions/runner/issues/1993

Installing with the toolchain action seems to work though, so maybe there is something subtle we were doing wrong with how we were using rustup that only just now became a problem.

### Known limitations

[TODO or N/A]
