### PR TITLE
Use the toolchain file in GitHub CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
-    - run: find . -type f -name '*.rs' -print0 | xargs -I {} -0 rustfmt --check "{}"
+    - run: cargo fmt --all --check
 
   build-and-test:
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,6 +49,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update
+    - run: rustup target add ${{ matrix.sys.target }}
     - run: cargo install --locked --version 0.5.14 cargo-hack
     - run: cargo hack --feature-powerset check --profile ${{ matrix.profile }} --target ${{ matrix.sys.target }}
     - if: matrix.sys.test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,11 +49,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
-      with:
-        toolchain: stable
-        default: true
-        components: rustfmt, clippy
-        target: ${{ matrix.sys.target }}
     - run: cargo install --locked --version 0.5.14 cargo-hack
     - run: cargo hack --feature-powerset check --profile ${{ matrix.profile }} --target ${{ matrix.sys.target }}
     - if: matrix.sys.test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: rustup update stable && rustup default stable
+    - run: rustup update
     - run: find . -type f -name '*.rs' -print0 | xargs -I {} -0 rustfmt --check "{}"
 
   build-and-test:
@@ -48,7 +48,7 @@ jobs:
     runs-on: ${{ matrix.sys.os }}
     steps:
     - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
+    - run: rustup update
     - run: cargo install --locked --version 0.5.14 cargo-hack
     - run: cargo hack --feature-powerset check --profile ${{ matrix.profile }} --target ${{ matrix.sys.target }}
     - if: matrix.sys.test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 all: build test
 
+export RUSTFLAGS=-Dwarnings
+
 test:
 	cargo hack --feature-powerset test
 

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,9 @@ build:
 
 watch:
 	cargo watch --clear --watch-when-idle --shell '$(MAKE)'
+
+fmt:
+	cargo fmt --all
+
+clean:
+	cargo clean

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+targets = ["wasm32-unknown-unknown"]
+components = ["rustc", "cargo", "rustfmt", "clippy", "rust-src"]


### PR DESCRIPTION
### What

Use the toolchain file in GitHub Actions.

### Why

There's no reason to respecify values that are included already in the toolchain file since the action will load them from there.

### Known limitations

[TODO or N/A]
