### PR TITLE
Make Symbol usage in match statements

### DIFF
--- a/stellar-contract-env-common/src/symbol.rs
+++ b/stellar-contract-env-common/src/symbol.rs
@@ -95,7 +95,7 @@ impl wasmi::FromValue for Symbol {
 
 impl Hash for Symbol {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        RawVal::from_payload(self.0).get_payload().hash(state);
+        self.0.hash(state);
     }
 }
 

--- a/stellar-contract-env-common/src/symbol.rs
+++ b/stellar-contract-env-common/src/symbol.rs
@@ -2,13 +2,7 @@ use crate::{
     require, ConversionError, Env, EnvVal, IntoEnvVal, RawVal, RawValConvertible, TagSymbol,
     TaggedVal,
 };
-use core::{
-    cmp::Ordering,
-    fmt::Debug,
-    hash::{Hash, Hasher},
-    marker::PhantomData,
-    str,
-};
+use core::{cmp::Ordering, fmt::Debug, hash::Hash, marker::PhantomData, str};
 
 #[derive(Debug)]
 pub enum SymbolError {
@@ -27,7 +21,7 @@ sa::const_assert!(CODE_MASK == 0x3f);
 sa::const_assert!(CODE_BITS * MAX_CHARS == BODY_BITS);
 
 #[repr(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Symbol(u64);
 
 impl RawValConvertible for Symbol {

--- a/stellar-contract-env-common/src/symbol.rs
+++ b/stellar-contract-env-common/src/symbol.rs
@@ -79,6 +79,15 @@ impl<E: Env> IntoEnvVal<E, TaggedVal<TagSymbol>> for Symbol {
     }
 }
 
+impl<E: Env> TryFrom<EnvVal<E, RawVal>> for Symbol {
+    type Error = ConversionError;
+
+    #[inline(always)]
+    fn try_from(v: EnvVal<E, RawVal>) -> Result<Self, Self::Error> {
+        Ok(Self(v.try_into()?))
+    }
+}
+
 impl<E: Env> IntoEnvVal<E, RawVal> for Symbol {
     fn into_env_val(self, env: &E) -> EnvVal<E, RawVal> {
         EnvVal {

--- a/stellar-contract-env-common/src/symbol.rs
+++ b/stellar-contract-env-common/src/symbol.rs
@@ -1,5 +1,5 @@
 use crate::{
-    require, ConversionError, Env, EnvVal, IntoEnvVal, RawVal, RawValConvertible, TagSymbol,
+    require, ConversionError, Env, EnvVal, IntoEnvVal, RawVal, RawValConvertible, Tag, TagSymbol,
     TaggedVal,
 };
 use core::{cmp::Ordering, fmt::Debug, hash::Hash, marker::PhantomData, str};
@@ -51,9 +51,11 @@ impl TryFrom<RawVal> for Symbol {
     type Error = ConversionError;
 
     fn try_from(v: RawVal) -> Result<Self, Self::Error> {
-        Ok(Symbol(
-            <TaggedVal<TagSymbol> as TryFrom<RawVal>>::try_from(v)?.get_payload(),
-        ))
+        if v.has_tag(Tag::Symbol) {
+            Ok(Self(v.get_payload()))
+        } else {
+            Err(ConversionError)
+        }
     }
 }
 

--- a/stellar-contract-env-common/src/symbol.rs
+++ b/stellar-contract-env-common/src/symbol.rs
@@ -79,6 +79,15 @@ impl<E: Env> IntoEnvVal<E, TaggedVal<TagSymbol>> for Symbol {
     }
 }
 
+impl<E: Env> IntoEnvVal<E, RawVal> for Symbol {
+    fn into_env_val(self, env: &E) -> EnvVal<E, RawVal> {
+        EnvVal {
+            env: env.clone(),
+            val: self.into(),
+        }
+    }
+}
+
 #[cfg(feature = "vm")]
 impl wasmi::FromValue for Symbol {
     fn from_value(val: wasmi::RuntimeValue) -> Option<Self> {

--- a/stellar-contract-env-common/src/symbol.rs
+++ b/stellar-contract-env-common/src/symbol.rs
@@ -27,8 +27,8 @@ sa::const_assert!(CODE_MASK == 0x3f);
 sa::const_assert!(CODE_BITS * MAX_CHARS == BODY_BITS);
 
 #[repr(transparent)]
-#[derive(Copy, Clone)]
-pub struct Symbol(u64); //TaggedVal<TagSymbol>;
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct Symbol(u64);
 
 impl RawValConvertible for Symbol {
     fn is_val_type(v: RawVal) -> bool {
@@ -92,20 +92,6 @@ impl wasmi::FromValue for Symbol {
         maybe.map(Symbol)
     }
 }
-
-impl Hash for Symbol {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.hash(state);
-    }
-}
-
-impl PartialEq for Symbol {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-impl Eq for Symbol {}
 
 impl PartialOrd for Symbol {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {

--- a/stellar-contract-env-common/src/tagged_val.rs
+++ b/stellar-contract-env-common/src/tagged_val.rs
@@ -115,7 +115,10 @@ impl<T: TagType> TaggedVal<T> {
     }
 
     #[inline(always)]
-    pub(crate) const unsafe fn from_major_minor_and_tag_type(major: u32, minor: u32) -> TaggedVal<T> {
+    pub(crate) const unsafe fn from_major_minor_and_tag_type(
+        major: u32,
+        minor: u32,
+    ) -> TaggedVal<T> {
         let rv = RawVal::from_major_minor_and_tag(major, minor, T::TAG);
         Self(rv, PhantomData)
     }

--- a/stellar-contract-env-common/src/tagged_val.rs
+++ b/stellar-contract-env-common/src/tagged_val.rs
@@ -88,6 +88,11 @@ impl<T: TagType> AsMut<RawVal> for TaggedVal<T> {
 }
 
 impl<T: TagType> TaggedVal<T> {
+    #[inline(always)]
+    pub const fn get_payload(self) -> u64 {
+        self.0.get_payload()
+    }
+
     pub fn as_raw(&self) -> &RawVal {
         self.0.as_ref()
     }
@@ -104,13 +109,13 @@ impl<T: TagType> TaggedVal<T> {
     }
 
     #[inline(always)]
-    pub(crate) unsafe fn from_body_and_tag_type(body: u64) -> TaggedVal<T> {
+    pub(crate) const unsafe fn from_body_and_tag_type(body: u64) -> TaggedVal<T> {
         let rv = RawVal::from_body_and_tag(body, T::TAG);
         Self(rv, PhantomData)
     }
 
     #[inline(always)]
-    pub(crate) unsafe fn from_major_minor_and_tag_type(major: u32, minor: u32) -> TaggedVal<T> {
+    pub(crate) const unsafe fn from_major_minor_and_tag_type(major: u32, minor: u32) -> TaggedVal<T> {
         let rv = RawVal::from_major_minor_and_tag(major, minor, T::TAG);
         Self(rv, PhantomData)
     }


### PR DESCRIPTION
### What

Make Symbol its own standalone type separate from TaggedVal<TagSymbol>.

### Why

Symbol can't be used in match patterns because the RawVal type is not `#[derive(Eq, PartialEq)]`, and types must derive those traits to be used in pattern matching. 

This has an unfortunate affect that mapping we need to do must occur within a set of `if` blocks, which Rust does not optimize as well.

For a small match block of only 3 conditions this causes a Symbol mapping to be an extra 37 bytes in compiled WASM. Given that we use Symbols as constants in enum encoding, it seems like a substantial benefit to make it its own type.

An alternative would be to simply derive the equality traits on RawVal.

### Known limitations

[TODO or N/A]
