### PR TITLE
Add more host-function / host-object metering infrastructure

### DIFF
--- a/stellar-contract-env-host/benches/calibrate_host_ops.rs
+++ b/stellar-contract-env-host/benches/calibrate_host_ops.rs
@@ -5,16 +5,31 @@ mod common;
 use common::*;
 use stellar_contract_env_host::{
     budget::CostType,
-    xdr::{ScObject, ScVal, ScVec},
+    xdr::{ScMap, ScMapEntry, ScObject, ScVal, ScVec},
     Host,
 };
 
-struct VecAllocRun {
+struct VecAllocVariableSizeRun {
     val: ScVal,
 }
 
-impl HostCostMeasurement for VecAllocRun {
-    const COST_TYPE: CostType = CostType::HostVecAlloc;
+struct EmptyVecAllocVariableCountRun {
+    count: u64,
+    val: ScVal,
+}
+
+struct MapAllocVariableSizeRun {
+    val: ScVal,
+}
+
+struct EmptyMapAllocVariableCountRun {
+    count: u64,
+    val: ScVal,
+}
+
+/// Measures the costs of allocating vectors of varying sizes.
+impl HostCostMeasurement for VecAllocVariableSizeRun {
+    const COST_TYPE: CostType = CostType::HostVecAllocCell;
 
     fn new(_host: &Host, size_hint: u64) -> Self {
         let size = size_hint * 10000;
@@ -30,19 +45,89 @@ impl HostCostMeasurement for VecAllocRun {
     }
 
     fn run(&mut self, host: &Host) {
-        host.intern(&self.val).unwrap();
+        host.inject_val(&self.val).unwrap();
     }
+}
+
+/// Measures the costs of allocating large numbers of 0-sized vectors.
+impl HostCostMeasurement for EmptyVecAllocVariableCountRun {
+    const COST_TYPE: CostType = CostType::HostVecAllocVec;
+
+    fn new(_host: &Host, size_hint: u64) -> Self {
+        let size = size_hint * 1000;
+        let scvec: ScVec = ScVec(vec![].try_into().unwrap());
+        let val = ScVal::Object(Some(ScObject::Vec(scvec)));
+        Self { count: size, val }
+    }
+
+    fn run(&mut self, host: &Host) {
+        for _ in 0..self.count {
+            host.inject_val(&self.val).unwrap();
+        }
+    }
+}
+
+/// Measures the costs of allocating maps of varying sizes.
+impl HostCostMeasurement for MapAllocVariableSizeRun {
+    const COST_TYPE: CostType = CostType::HostMapAllocCell;
+
+    fn new(_host: &Host, size_hint: u64) -> Self {
+        let size = size_hint * 10000;
+        let scmap: ScMap = ScMap(
+            (0..size)
+                .map(|i| ScMapEntry {
+                    key: ScVal::U32(i as u32),
+                    val: ScVal::U32(i as u32),
+                })
+                .collect::<Vec<ScMapEntry>>()
+                .try_into()
+                .unwrap(),
+        );
+        let val = ScVal::Object(Some(ScObject::Map(scmap)));
+        Self { val }
+    }
+
+    fn run(&mut self, host: &Host) {
+        host.inject_val(&self.val).unwrap();
+    }
+}
+
+/// Measures the costs of allocating large numbers of 0-sized maps.
+impl HostCostMeasurement for EmptyMapAllocVariableCountRun {
+    const COST_TYPE: CostType = CostType::HostMapAllocMap;
+
+    fn new(_host: &Host, size_hint: u64) -> Self {
+        let size = size_hint * 1000;
+        let scmap: ScMap = ScMap(vec![].try_into().unwrap());
+        let val = ScVal::Object(Some(ScObject::Map(scmap)));
+        Self { count: size, val }
+    }
+
+    fn run(&mut self, host: &Host) {
+        for _ in 0..self.count {
+            host.inject_val(&self.val).unwrap();
+        }
+    }
+}
+
+fn measure_one<M: HostCostMeasurement>() -> std::io::Result<()> {
+    let mut measurements = measure_costs::<M>(0..20)?;
+    measurements.subtract_baseline();
+    measurements.report();
+
+    if std::env::var("FIT_MODELS").is_ok() {
+        measurements.fit_model_to_cpu();
+        measurements.fit_model_to_mem();
+    }
+    Ok(())
 }
 
 #[cfg(all(test, target_os = "linux"))]
 fn main() -> std::io::Result<()> {
     env_logger::init();
-    let mut measurements = measure_costs::<VecAllocRun>(0..20)?;
-    measurements.subtract_baseline();
-    measurements.report();
-    if std::env::var("FIT_MODELS").is_ok() {
-        measurements.fit_model_to_cpu();
-        measurements.fit_model_to_mem();
-    }
+    measure_one::<VecAllocVariableSizeRun>()?;
+    measure_one::<EmptyVecAllocVariableCountRun>()?;
+    measure_one::<MapAllocVariableSizeRun>()?;
+    measure_one::<EmptyMapAllocVariableCountRun>()?;
     Ok(())
 }

--- a/stellar-contract-env-host/benches/common/measure.rs
+++ b/stellar-contract-env-host/benches/common/measure.rs
@@ -163,6 +163,7 @@ pub fn measure_costs<HCM: HostCostMeasurement>(
     let mut alloc_group_token =
         AllocationGroupToken::register().expect("failed to register allocation group");
     let mut ret = Vec::new();
+    eprintln!("\nMeasuring costs for CostType::{:?}\n", HCM::COST_TYPE);
     for input_hint in step_range {
         let host = Host::default();
         host.get_budget_mut(|budget| budget.reset_unlimited());
@@ -186,6 +187,10 @@ pub fn measure_costs<HCM: HostCostMeasurement>(
             mem_bytes,
             time_nsecs,
         })
+    }
+    AllocationRegistry::disable_tracking();
+    unsafe {
+        AllocationRegistry::clear_global_tracker();
     }
     Ok(Measurements(ret))
 }

--- a/stellar-contract-env-host/src/budget.rs
+++ b/stellar-contract-env-host/src/budget.rs
@@ -4,19 +4,24 @@ use crate::HostError;
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CostType {
-    HostVecAlloc = 0,
-    HostMapAlloc = 1,
-    WasmInsnExec = 2,
-    WasmMemAlloc = 3,
+    HostVecAllocVec = 0,
+    HostVecAllocCell = 1,
+    HostMapAllocMap = 2,
+    HostMapAllocCell = 3,
+    WasmInsnExec = 4,
+    WasmMemAlloc = 5,
 }
 
 // TODO: add XDR support for iterating over all the elements of an enum
 impl CostType {
     fn variants() -> std::slice::Iter<'static, CostType> {
         static VARIANTS: &'static [CostType] = &[
-            CostType::HostMapAlloc,
-            CostType::HostVecAlloc,
+            CostType::HostMapAllocMap,
+            CostType::HostMapAllocCell,
+            CostType::HostVecAllocVec,
+            CostType::HostVecAllocCell,
             CostType::WasmInsnExec,
+            CostType::WasmMemAlloc,
         ];
         VARIANTS.iter()
     }


### PR DESCRIPTION
This extends the metering infrastructure with a general charging-point for host objects (further down the funnel of ways-objects-can-be-added) and adds support for multiple calibrations in a single bench. Also calibrates empty vs. cell costs separately and does map in addition to vec (map is currently quite a bit more expensive -- im has a small-vec optimization but _not_ a small-map optimization, so we'll have to add one ourselves).