### PR TITLE
Make TaggedVal fns const

### DIFF
--- a/stellar-contract-env-common/src/tagged_val.rs
+++ b/stellar-contract-env-common/src/tagged_val.rs
@@ -88,11 +88,11 @@ impl<T: TagType> AsMut<RawVal> for TaggedVal<T> {
 }
 
 impl<T: TagType> TaggedVal<T> {
-    pub fn as_raw(&self) -> &RawVal {
-        self.0.as_ref()
+    pub const fn as_raw(&self) -> &RawVal {
+        &self.0
     }
 
-    pub fn to_raw(&self) -> RawVal {
+    pub const fn to_raw(&self) -> RawVal {
         self.0
     }
 
@@ -104,13 +104,13 @@ impl<T: TagType> TaggedVal<T> {
     }
 
     #[inline(always)]
-    pub(crate) unsafe fn from_body_and_tag_type(body: u64) -> TaggedVal<T> {
+    pub(crate) const unsafe fn from_body_and_tag_type(body: u64) -> TaggedVal<T> {
         let rv = RawVal::from_body_and_tag(body, T::TAG);
         Self(rv, PhantomData)
     }
 
     #[inline(always)]
-    pub(crate) unsafe fn from_major_minor_and_tag_type(major: u32, minor: u32) -> TaggedVal<T> {
+    pub(crate) const unsafe fn from_major_minor_and_tag_type(major: u32, minor: u32) -> TaggedVal<T> {
         let rv = RawVal::from_major_minor_and_tag(major, minor, T::TAG);
         Self(rv, PhantomData)
     }

--- a/stellar-contract-env-common/src/tagged_val.rs
+++ b/stellar-contract-env-common/src/tagged_val.rs
@@ -110,7 +110,10 @@ impl<T: TagType> TaggedVal<T> {
     }
 
     #[inline(always)]
-    pub(crate) const unsafe fn from_major_minor_and_tag_type(major: u32, minor: u32) -> TaggedVal<T> {
+    pub(crate) const unsafe fn from_major_minor_and_tag_type(
+        major: u32,
+        minor: u32,
+    ) -> TaggedVal<T> {
         let rv = RawVal::from_major_minor_and_tag(major, minor, T::TAG);
         Self(rv, PhantomData)
     }


### PR DESCRIPTION
### What

Make TaggedVal fns const.

### Why

So that they can be called from const contexts at compile time.

### Known limitations

[TODO or N/A]
