### PR TITLE
Register Test Contract

### DIFF
--- a/stellar-contract-env-host/src/lib.rs
+++ b/stellar-contract-env-host/src/lib.rs
@@ -12,7 +12,7 @@ pub mod storage;
 mod test;
 
 #[cfg(feature = "testutils")]
-pub use host::{ContractVTable, ContractVTableFn, ContractVTableFnTrait};
+pub use host::ContractVTable;
 pub use host::{Host, HostError};
 pub use im_rc;
 pub use stellar_contract_env_common::*;

--- a/stellar-contract-env-host/src/lib.rs
+++ b/stellar-contract-env-host/src/lib.rs
@@ -12,7 +12,7 @@ pub mod storage;
 mod test;
 
 #[cfg(feature = "testutils")]
-pub use host::FrameGuard;
+pub use host::{ContractVTable, ContractVTableFn, ContractVTableFnTrait};
 pub use host::{Host, HostError};
 pub use im_rc;
 pub use stellar_contract_env_common::*;

--- a/stellar-contract-env-host/src/lib.rs
+++ b/stellar-contract-env-host/src/lib.rs
@@ -12,7 +12,7 @@ pub mod storage;
 mod test;
 
 #[cfg(feature = "testutils")]
-pub use host::ContractVTable;
+pub use host::ContractFunctionSet;
 pub use host::{Host, HostError};
 pub use im_rc;
 pub use stellar_contract_env_common::*;

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -737,10 +737,9 @@ fn create_contract_test() -> Result<(), HostError> {
     });
 
     let hash = sha256_hash_id_preimage(id_pre_image);
-    let hash_obj: Object = host.add_host_object(hash.0.to_vec())?.into();
 
     //Push the contract id onto the stack to simulate a contract call
-    let _frame_guard = host.push_test_frame(hash_obj)?;
+    let _frame_guard = host.push_test_frame(hash);
 
     let key = ScVal::Static(ScStatic::LedgerKeyContractCodeWasm);
 


### PR DESCRIPTION
### What

Add machinery to register a test contract and call it.

### Why

Testing multiple contracts is basically impossible right now. This facilitates calling contracts by contract identifier.

### Known limitations

The interface isn't amazing.