### PR TITLE
Generate meta xdr containing interface version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,7 +551,7 @@ version = "0.0.0"
 dependencies = [
  "static_assertions",
  "stellar-contract-env-macros",
- "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=0edf9326)",
+ "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=540ed24)",
  "wasmi",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,20 @@ name = "serde"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.137"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "sha2"
@@ -530,7 +544,8 @@ name = "stellar-contract-env-common"
 version = "0.0.0"
 dependencies = [
  "static_assertions",
- "stellar-xdr",
+ "stellar-contract-env-macros",
+ "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=0edf9326)",
  "wasmi",
 ]
 
@@ -569,6 +584,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "stellar-contract-env-macros"
+version = "0.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "stellar-xdr 0.0.0 (git+https://github.com/stellar/rs-stellar-xdr?rev=540ed24e)",
+ "syn",
+]
+
+[[package]]
 name = "stellar-contract-env-panic-handler-wasm32-unreachable"
 version = "0.0.0"
 
@@ -578,6 +603,15 @@ version = "0.0.0"
 source = "git+https://github.com/stellar/rs-stellar-xdr?rev=0edf9326#0edf932688f672be03b1a06ebaed0304bf964485"
 dependencies = [
  "base64",
+]
+
+[[package]]
+name = "stellar-xdr"
+version = "0.0.0"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=540ed24e#540ed24edc66b5301459ed3269129670160e51e0"
+dependencies = [
+ "base64",
+ "serde",
 ]
 
 [[package]]

--- a/stellar-contract-env-common/Cargo.toml
+++ b/stellar-contract-env-common/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+stellar-contract-env-macros = { path = "../stellar-contract-env-macros" }
 static_assertions = "1.1.0"
 stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "0edf9326", default-features = false, features = [ "next" ] }
 # stellar-xdr = { path = "../../rs-stellar-xdr", default-features = false, features = ["next"] }

--- a/stellar-contract-env-common/src/lib.rs
+++ b/stellar-contract-env-common/src/lib.rs
@@ -15,7 +15,7 @@ mod tuple;
 mod unimplemented_env;
 mod val;
 
-pub const META: [u8; 12] = meta::META;
+pub use meta::META;
 
 // Re-export the XDR definitions
 pub use stellar_xdr as xdr;

--- a/stellar-contract-env-common/src/lib.rs
+++ b/stellar-contract-env-common/src/lib.rs
@@ -13,9 +13,9 @@ mod tagged_val;
 mod tuple;
 mod unimplemented_env;
 mod val;
-mod version;
+mod meta;
 
-pub use version::INTERFACE_VERSION;
+pub const META: [u8; _] = meta::META;
 
 // Re-export the XDR definitions
 pub use stellar_xdr as xdr;

--- a/stellar-contract-env-common/src/lib.rs
+++ b/stellar-contract-env-common/src/lib.rs
@@ -4,6 +4,7 @@ mod bitset;
 mod checked_env;
 mod env;
 mod env_val;
+mod meta;
 mod object;
 mod raw_val;
 mod r#static;
@@ -13,7 +14,6 @@ mod tagged_val;
 mod tuple;
 mod unimplemented_env;
 mod val;
-mod meta;
 
 pub const META: [u8; 12] = meta::META;
 

--- a/stellar-contract-env-common/src/lib.rs
+++ b/stellar-contract-env-common/src/lib.rs
@@ -15,7 +15,7 @@ mod tuple;
 mod unimplemented_env;
 mod val;
 
-pub use meta::META;
+pub use meta::{META_INTERFACE_VERSION, META};
 
 // Re-export the XDR definitions
 pub use stellar_xdr as xdr;

--- a/stellar-contract-env-common/src/lib.rs
+++ b/stellar-contract-env-common/src/lib.rs
@@ -15,7 +15,7 @@ mod unimplemented_env;
 mod val;
 mod meta;
 
-pub const META: [u8; _] = meta::META;
+pub const META: [u8; 12] = meta::META;
 
 // Re-export the XDR definitions
 pub use stellar_xdr as xdr;

--- a/stellar-contract-env-common/src/lib.rs
+++ b/stellar-contract-env-common/src/lib.rs
@@ -15,7 +15,7 @@ mod tuple;
 mod unimplemented_env;
 mod val;
 
-pub use meta::{META_INTERFACE_VERSION, META};
+pub use meta::{META, META_INTERFACE_VERSION};
 
 // Re-export the XDR definitions
 pub use stellar_xdr as xdr;

--- a/stellar-contract-env-common/src/meta.rs
+++ b/stellar-contract-env-common/src/meta.rs
@@ -33,7 +33,7 @@
 /// _not_ compiled into a contract, since the same contract will be expected to
 /// run against multliple implementations over a long period of time.
 
-pub const INTERFACE_VERSION: u64 = 1;
+pub const META_INTERFACE_VERSION: u64 = 1;
 
 pub const META: [u8; 12] = stellar_contract_env_macros::contract_env_meta!(
     // Interface Version

--- a/stellar-contract-env-common/src/meta.rs
+++ b/stellar-contract-env-common/src/meta.rs
@@ -35,7 +35,7 @@
 
 pub const META_INTERFACE_VERSION: u64 = 1;
 
-pub const META: [u8; 12] = stellar_contract_env_macros::contract_env_meta!(
+pub const META: [u8; 12] = stellar_contract_env_macros::build_env_meta_xdr!(
     // Interface Version
     1
 );

--- a/stellar-contract-env-common/src/meta.rs
+++ b/stellar-contract-env-common/src/meta.rs
@@ -33,7 +33,7 @@
 /// _not_ compiled into a contract, since the same contract will be expected to
 /// run against multliple implementations over a long period of time.
 
-pub const META: [u8; 1] = stellar_contract_env_macros::contract_env_meta!(
+pub const META: [u8; 12] = stellar_contract_env_macros::contract_env_meta!(
     // Interface Version
     1
 );

--- a/stellar-contract-env-common/src/meta.rs
+++ b/stellar-contract-env-common/src/meta.rs
@@ -34,5 +34,5 @@
 // run against multliple implementations over a long period of time.
 
 stellar_contract_env_macros::generate_env_meta_consts!(
-    META_INTERFACE_VERSION: 1
+    interface_version: 1,
 );

--- a/stellar-contract-env-common/src/meta.rs
+++ b/stellar-contract-env-common/src/meta.rs
@@ -1,41 +1,38 @@
-/// There are two different notions of versioning in this system:
-///
-///   1. Interface versioning
-///   2. Implementation versioning
-///
-/// Interface versioning controls the willingness of a host to _try_ to run a
-/// _new_ transaction against some contract. For this, a contract embeds an
-/// interface version number _inside itself_ and the host inspects it before
-/// starting the contract. If the contract's interface version is outside the
-/// supported range for a host, the host will fail the transaction with a useful
-/// error rather than an inscrutable misbehaviour (link error, data corruption,
-/// etc.) during execution. During development of the system this number will
-/// increase frequently in order to notify users of the need to recompile their
-/// contracts against new-and-incompatible versions of the
-/// system-in-development. Once we declare a commitment to network-wide
-/// backwards compatibility for contracts, the supported interface version range
-/// will likely only ever expand to cover newer interfaces, and that range will
-/// be stored on-chain so that the transactions and contracts
-/// accepted-or-rejected are identical across all validators.
-///
-/// Implementation versioning is different, and has more to do with ensuring
-/// that all validators that _do_ decide to execute a transaction -- whether new
-/// _or old_ -- execute it on an observably-identical software version, such
-/// that an arbitrarily subtle dependency on implementation quirks does not
-/// cause any bit-level divergence in the transaction results. Implementation
-/// versioning is done in stellar-core itself, by maintaining multiple versions
-/// of the host crate: strictly identical versions for new transactions entering
-/// the network, and observably-identical ones for replay of historical
-/// transactions (with a policy to allow expiring old versions that differ only
-/// in ways no transactions in the public network history actually observe).
-/// Implementation versioning will also be done by storing a version on-chain
-/// that changes by consensus, but the host implementation version number is
-/// _not_ compiled into a contract, since the same contract will be expected to
-/// run against multliple implementations over a long period of time.
+// There are two different notions of versioning in this system:
+//
+//   1. Interface versioning
+//   2. Implementation versioning
+//
+// Interface versioning controls the willingness of a host to _try_ to run a
+// _new_ transaction against some contract. For this, a contract embeds an
+// interface version number _inside itself_ and the host inspects it before
+// starting the contract. If the contract's interface version is outside the
+// supported range for a host, the host will fail the transaction with a useful
+// error rather than an inscrutable misbehaviour (link error, data corruption,
+// etc.) during execution. During development of the system this number will
+// increase frequently in order to notify users of the need to recompile their
+// contracts against new-and-incompatible versions of the
+// system-in-development. Once we declare a commitment to network-wide
+// backwards compatibility for contracts, the supported interface version range
+// will likely only ever expand to cover newer interfaces, and that range will
+// be stored on-chain so that the transactions and contracts
+// accepted-or-rejected are identical across all validators.
+//
+// Implementation versioning is different, and has more to do with ensuring
+// that all validators that _do_ decide to execute a transaction -- whether new
+// _or old_ -- execute it on an observably-identical software version, such
+// that an arbitrarily subtle dependency on implementation quirks does not
+// cause any bit-level divergence in the transaction results. Implementation
+// versioning is done in stellar-core itself, by maintaining multiple versions
+// of the host crate: strictly identical versions for new transactions entering
+// the network, and observably-identical ones for replay of historical
+// transactions (with a policy to allow expiring old versions that differ only
+// in ways no transactions in the public network history actually observe).
+// Implementation versioning will also be done by storing a version on-chain
+// that changes by consensus, but the host implementation version number is
+// _not_ compiled into a contract, since the same contract will be expected to
+// run against multliple implementations over a long period of time.
 
-pub const META_INTERFACE_VERSION: u64 = 1;
-
-pub const META: [u8; 12] = stellar_contract_env_macros::build_env_meta_xdr!(
-    // Interface Version
-    1
+stellar_contract_env_macros::generate_env_meta_consts!(
+    META_INTERFACE_VERSION: 1
 );

--- a/stellar-contract-env-common/src/meta.rs
+++ b/stellar-contract-env-common/src/meta.rs
@@ -33,4 +33,7 @@
 /// _not_ compiled into a contract, since the same contract will be expected to
 /// run against multliple implementations over a long period of time.
 
-pub const INTERFACE_VERSION: u64 = 1;
+pub const META: [u8; 1] = stellar_contract_env_macros::contract_env_meta!(
+    // Interface Version
+    1
+);

--- a/stellar-contract-env-common/src/meta.rs
+++ b/stellar-contract-env-common/src/meta.rs
@@ -33,7 +33,7 @@
 /// _not_ compiled into a contract, since the same contract will be expected to
 /// run against multliple implementations over a long period of time.
 
-pub const META: [u8; 12] = stellar_contract_env_macros::contract_env_meta!(
+pub const META: &[u8] = stellar_contract_env_macros::contract_env_meta!(
     // Interface Version
     1
 );

--- a/stellar-contract-env-common/src/meta.rs
+++ b/stellar-contract-env-common/src/meta.rs
@@ -33,7 +33,9 @@
 /// _not_ compiled into a contract, since the same contract will be expected to
 /// run against multliple implementations over a long period of time.
 
-pub const META: &[u8] = stellar_contract_env_macros::contract_env_meta!(
+pub const INTERFACE_VERSION: u64 = 1;
+
+pub const META: [u8; 12] = stellar_contract_env_macros::contract_env_meta!(
     // Interface Version
     1
 );

--- a/stellar-contract-env-macros/Cargo.toml
+++ b/stellar-contract-env-macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "stellar-contract-env-macros"
+version = "0.0.0"
+authors = ["Stellar Development Foundation <info@stellar.org>"]
+license = "Apache-2.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "540ed24e", features = ["next", "std"] }
+syn = {version="1.0",features=["full"]}
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/stellar-contract-env-macros/src/lib.rs
+++ b/stellar-contract-env-macros/src/lib.rs
@@ -1,0 +1,22 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    parse_macro_input, LitInt,
+};
+
+use stellar_xdr::{ScEnvMetaEntry, WriteXdr};
+
+#[proc_macro]
+pub fn contract_env_meta(input: TokenStream) -> TokenStream {
+    let version = parse_macro_input!(input as LitInt);
+    let meta = ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(version.base10_parse().unwrap());
+    let meta_xdr = meta.to_xdr().unwrap();
+    let meta_xdr_lit = proc_macro2::Literal::byte_string(meta_xdr.as_slice());
+    let meta_xdr_len = meta_xdr.len();
+    quote! {
+        /*pub const META: [u8; #meta_xdr_len] =*/ *#meta_xdr_lit;
+    }
+    .into()
+}

--- a/stellar-contract-env-macros/src/lib.rs
+++ b/stellar-contract-env-macros/src/lib.rs
@@ -14,9 +14,11 @@ impl Parse for MetaInput {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         Ok(MetaInput {
             interface_version: {
-                assert_eq!(input.parse::<Ident>()?, "META_INTERFACE_VERSION");
+                assert_eq!(input.parse::<Ident>()?, "interface_version");
                 input.parse::<Token![:]>()?;
-                input.parse::<LitInt>()?.base10_parse()?
+                let v = input.parse::<LitInt>()?.base10_parse()?;
+                input.parse::<Token![,]>()?;
+                v
             },
         })
     }

--- a/stellar-contract-env-macros/src/lib.rs
+++ b/stellar-contract-env-macros/src/lib.rs
@@ -12,5 +12,5 @@ pub fn contract_env_meta(input: TokenStream) -> TokenStream {
     let meta = ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(version.base10_parse().unwrap());
     let meta_xdr = meta.to_xdr().unwrap();
     let meta_xdr_lit = proc_macro2::Literal::byte_string(meta_xdr.as_slice());
-    quote! { #meta_xdr_lit }.into()
+    quote! { *#meta_xdr_lit }.into()
 }

--- a/stellar-contract-env-macros/src/lib.rs
+++ b/stellar-contract-env-macros/src/lib.rs
@@ -10,13 +10,9 @@ use stellar_xdr::{ScEnvMetaEntry, WriteXdr};
 
 #[proc_macro]
 pub fn contract_env_meta(input: TokenStream) -> TokenStream {
-    let version = parse_macro_input!(input as Body);
+    let version = parse_macro_input!(input as LitInt);
     let meta = ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(version.base10_parse().unwrap());
     let meta_xdr = meta.to_xdr().unwrap();
     let meta_xdr_lit = proc_macro2::Literal::byte_string(meta_xdr.as_slice());
-    // let meta_xdr_len = meta_xdr.len();
-    quote! {
-        /*pub const META: [u8; #meta_xdr_len] =*/ *#meta_xdr_lit
-    }
-    .into()
+    quote! { *#meta_xdr_lit } .into()
 }

--- a/stellar-contract-env-macros/src/lib.rs
+++ b/stellar-contract-env-macros/src/lib.rs
@@ -7,7 +7,7 @@ use syn::{parse_macro_input, LitInt};
 use stellar_xdr::{ScEnvMetaEntry, WriteXdr};
 
 #[proc_macro]
-pub fn contract_env_meta(input: TokenStream) -> TokenStream {
+pub fn build_env_meta_xdr(input: TokenStream) -> TokenStream {
     let version = parse_macro_input!(input as LitInt);
     let meta = ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(version.base10_parse().unwrap());
     let meta_xdr = meta.to_xdr().unwrap();

--- a/stellar-contract-env-macros/src/lib.rs
+++ b/stellar-contract-env-macros/src/lib.rs
@@ -12,5 +12,5 @@ pub fn contract_env_meta(input: TokenStream) -> TokenStream {
     let meta = ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(version.base10_parse().unwrap());
     let meta_xdr = meta.to_xdr().unwrap();
     let meta_xdr_lit = proc_macro2::Literal::byte_string(meta_xdr.as_slice());
-    quote! { *#meta_xdr_lit }.into()
+    quote! { #meta_xdr_lit }.into()
 }

--- a/stellar-contract-env-macros/src/lib.rs
+++ b/stellar-contract-env-macros/src/lib.rs
@@ -10,13 +10,13 @@ use stellar_xdr::{ScEnvMetaEntry, WriteXdr};
 
 #[proc_macro]
 pub fn contract_env_meta(input: TokenStream) -> TokenStream {
-    let version = parse_macro_input!(input as LitInt);
+    let version = parse_macro_input!(input as Body);
     let meta = ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(version.base10_parse().unwrap());
     let meta_xdr = meta.to_xdr().unwrap();
     let meta_xdr_lit = proc_macro2::Literal::byte_string(meta_xdr.as_slice());
-    let meta_xdr_len = meta_xdr.len();
+    // let meta_xdr_len = meta_xdr.len();
     quote! {
-        /*pub const META: [u8; #meta_xdr_len] =*/ *#meta_xdr_lit;
+        /*pub const META: [u8; #meta_xdr_len] =*/ *#meta_xdr_lit
     }
     .into()
 }

--- a/stellar-contract-env-macros/src/lib.rs
+++ b/stellar-contract-env-macros/src/lib.rs
@@ -2,9 +2,7 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{
-    parse_macro_input, LitInt,
-};
+use syn::{parse_macro_input, LitInt};
 
 use stellar_xdr::{ScEnvMetaEntry, WriteXdr};
 
@@ -14,5 +12,5 @@ pub fn contract_env_meta(input: TokenStream) -> TokenStream {
     let meta = ScEnvMetaEntry::ScEnvMetaKindInterfaceVersion(version.base10_parse().unwrap());
     let meta_xdr = meta.to_xdr().unwrap();
     let meta_xdr_lit = proc_macro2::Literal::byte_string(meta_xdr.as_slice());
-    quote! { *#meta_xdr_lit } .into()
+    quote! { *#meta_xdr_lit }.into()
 }


### PR DESCRIPTION
### What

Generate meta containing the interface version.

### Why

So that the SDK can embed this information into WASM files.

Unfortunately generating the XDR in the SDK is somewhat problematic, because we need the literal value to be present at the time the macro runs, and the constant from another crate is not particularly useful unless we have the SDK macro crate depend on the env crate. If we do that, we run into the risk that the SDK macro crate will depend on a different version of the env crate as the SDK itself which would cause the WASM to lie about which env interface it was built with.

Given all that complexity risk, it seems simpler to build the meta within the env crate. After all this meta being built is the meta for the environment only.

The env meta XDR and the macro can be expanded to include other values if we need to add them.

Close https://github.com/stellar/rs-stellar-contract-sdk/issues/142

### Known limitations

[TODO or N/A]
