### PR TITLE
Export meta under mod name

### DIFF
--- a/stellar-contract-env-common/src/lib.rs
+++ b/stellar-contract-env-common/src/lib.rs
@@ -4,7 +4,7 @@ mod bitset;
 mod checked_env;
 mod env;
 mod env_val;
-mod meta;
+pub mod meta;
 mod object;
 mod raw_val;
 mod r#static;
@@ -14,8 +14,6 @@ mod tagged_val;
 mod tuple;
 mod unimplemented_env;
 mod val;
-
-pub use meta::{META, META_INTERFACE_VERSION};
 
 // Re-export the XDR definitions
 pub use stellar_xdr as xdr;

--- a/stellar-contract-env-macros/src/lib.rs
+++ b/stellar-contract-env-macros/src/lib.rs
@@ -54,8 +54,8 @@ impl ToTokens for MetaConstsOutput {
 
         // Output.
         tokens.extend(quote! {
-            pub const META_INTERFACE_VERSION: u64 = #interface_version;
-            pub const META: [u8; #meta_xdr_len] = *#meta_xdr_lit;
+            pub const INTERFACE_VERSION: u64 = #interface_version;
+            pub const XDR: [u8; #meta_xdr_len] = *#meta_xdr_lit;
         });
     }
 }


### PR DESCRIPTION
### What

Export meta under mod name.

### Why

To group related variables without cluttering the root namespace of the crate.

Follow up to https://github.com/stellar/rs-stellar-contract-env/pull/210

Close https://github.com/stellar/rs-stellar-contract-sdk/issues/142

### Known limitations

[TODO or N/A]
