### PR TITLE
Fix map prev and next key to do strict comparison

### DIFF
--- a/stellar-contract-env-host/src/budget.rs
+++ b/stellar-contract-env-host/src/budget.rs
@@ -15,7 +15,7 @@ pub enum CostType {
 
 // TODO: add XDR support for iterating over all the elements of an enum
 impl CostType {
-    fn variants() -> std::slice::Iter<'static, CostType> {
+    pub fn variants() -> std::slice::Iter<'static, CostType> {
         static VARIANTS: &'static [CostType] = &[
             CostType::HostMapAllocMap,
             CostType::HostMapAllocCell,
@@ -23,6 +23,7 @@ impl CostType {
             CostType::HostVecAllocCell,
             CostType::WasmInsnExec,
             CostType::WasmMemAlloc,
+            CostType::HostEventDebug,
         ];
         VARIANTS.iter()
     }

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -1090,12 +1090,12 @@ impl CheckedEnv for Host {
     fn map_prev_key(&self, m: Object, k: RawVal) -> Result<RawVal, HostError> {
         let k = self.associate_raw_val(k);
         self.visit_obj(m, |hm: &HostMap| {
-            // OrdMap's `get_prev`/`get_next` return the previous/next key if the input key is not found. 
+            // OrdMap's `get_prev`/`get_next` return the previous/next key if the input key is not found.
             // Otherwise it returns the input key. Therefore, if `get_prev`/`get_next` returns the same
-            // key, we will clone the map, delete the input key, and call `get_prev`/`get_next` again. 
-            // Note on performance: OrdMap does "lazy cloning", which only happens if data is modified, 
+            // key, we will clone the map, delete the input key, and call `get_prev`/`get_next` again.
+            // Note on performance: OrdMap does "lazy cloning", which only happens if data is modified,
             // and we are only modifying one entry. The cloned object will be thrown away in the end
-            // so there is no cost associated with host object creation and allocation. 
+            // so there is no cost associated with host object creation and allocation.
             if let Some((pk, pv)) = hm.get_prev(&k) {
                 if *pk != k {
                     Ok(pk.to_raw())

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -3,7 +3,7 @@ use crate::{
         ScHostFnErrorCode, ScHostObjErrorCode, ScObject, ScObjectType, ScStatic, ScStatus, ScVal,
         ScVec,
     },
-    Host, HostError, IntoEnvVal, Object, RawVal, Tag,
+    Host, HostError, IntoEnvVal, Object, RawVal, Tag, Symbol
 };
 
 use stellar_contract_env_common::{
@@ -27,7 +27,6 @@ use crate::Vm;
 #[cfg(feature = "vm")]
 use crate::{
     xdr::{ContractDataEntry, Hash, LedgerEntry, LedgerEntryExt, ScStatusType},
-    Symbol,
 };
 use assert_matches::assert_matches;
 #[cfg(feature = "vm")]

--- a/stellar-contract-env-host/src/test.rs
+++ b/stellar-contract-env-host/src/test.rs
@@ -3,7 +3,7 @@ use crate::{
         ScHostFnErrorCode, ScHostObjErrorCode, ScObject, ScObjectType, ScStatic, ScStatus, ScVal,
         ScVec,
     },
-    Host, HostError, IntoEnvVal, Object, RawVal, Tag, Symbol
+    Host, HostError, IntoEnvVal, Object, RawVal, Symbol, Tag,
 };
 
 use stellar_contract_env_common::{
@@ -23,11 +23,9 @@ use im_rc::OrdMap;
 use stellar_contract_env_common::xdr::WriteXdr;
 
 #[cfg(feature = "vm")]
-use crate::Vm;
+use crate::xdr::{ContractDataEntry, Hash, LedgerEntry, LedgerEntryExt, ScStatusType};
 #[cfg(feature = "vm")]
-use crate::{
-    xdr::{ContractDataEntry, Hash, LedgerEntry, LedgerEntryExt, ScStatusType},
-};
+use crate::Vm;
 use assert_matches::assert_matches;
 #[cfg(feature = "vm")]
 use stellar_contract_env_common::Status;


### PR DESCRIPTION
### What

Resolves https://github.com/stellar/rs-stellar-contract-env/issues/180 


### Why

Previously the `map_prev_key` , `map_next_key` replicates the im_rc's behavior: if the given key exists, returns itself, which is not useful for implementing iterators. 

### Known limitations

[TODO or N/A]
