### PR TITLE
Add an iterator for the CostType enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +486,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
+name = "rustversion"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0a5f7c728f5d284929a1cccb5bc19884422bfe6ef4d6c409da2c41838983fcf"
+
+[[package]]
 name = "serde"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +595,7 @@ dependencies = [
  "sha2 0.10.2",
  "static_assertions",
  "stellar-contract-env-common",
+ "strum",
  "tabwriter",
  "thiserror",
  "thousands",
@@ -620,6 +633,28 @@ source = "git+https://github.com/stellar/rs-stellar-xdr?rev=540ed24e#540ed24edc6
 dependencies = [
  "base64",
  "serde",
+]
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4faebde00e8ff94316c01800f9054fd2ba77d30d9e922541913051d1d978918b"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]

--- a/stellar-contract-env-host/Cargo.toml
+++ b/stellar-contract-env-host/Cargo.toml
@@ -20,6 +20,7 @@ hex = "0.4.3"
 num-traits = "0.2.15"
 num-integer = "0.1.45"
 arrayvec = "0.7.2"
+strum = { version = "0.24.1", features = ["derive"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/stellar-contract-env-host/src/budget.rs
+++ b/stellar-contract-env-host/src/budget.rs
@@ -1,4 +1,4 @@
-use strum::EnumIter;
+use strum::{EnumIter, IntoEnumIterator};
 
 use crate::HostError;
 
@@ -160,7 +160,7 @@ impl Default for BudgetDimension {
             limit: Default::default(),
             count: Default::default(),
         };
-        for _ct in CostType::variants() {
+        for _ct in CostType::iter() {
             // TODO: load cost model for i from the chain.
             bd.cost_models.push(CostModel::default());
         }

--- a/stellar-contract-env-host/src/budget.rs
+++ b/stellar-contract-env-host/src/budget.rs
@@ -15,21 +15,6 @@ pub enum CostType {
     HostEventDebug = 6,
 }
 
-// TODO: add XDR support for iterating over all the elements of an enum
-impl CostType {
-    fn variants() -> std::slice::Iter<'static, CostType> {
-        static VARIANTS: &'static [CostType] = &[
-            CostType::HostMapAllocMap,
-            CostType::HostMapAllocCell,
-            CostType::HostVecAllocVec,
-            CostType::HostVecAllocCell,
-            CostType::WasmInsnExec,
-            CostType::WasmMemAlloc,
-        ];
-        VARIANTS.iter()
-    }
-}
-
 /// We provide a general "cost model" object that evaluates a general
 /// expression:
 ///
@@ -231,7 +216,7 @@ impl Default for Budget {
             inputs: Default::default(),
         };
 
-        for _ct in CostType::variants() {
+        for _ct in CostType::iter() {
             b.inputs.push(0);
         }
 

--- a/stellar-contract-env-host/src/budget.rs
+++ b/stellar-contract-env-host/src/budget.rs
@@ -1,8 +1,10 @@
+use strum::EnumIter;
+
 use crate::HostError;
 
 // TODO: move this to an XDR enum
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, EnumIter)]
 pub enum CostType {
     HostVecAllocVec = 0,
     HostVecAllocCell = 1,


### PR DESCRIPTION
### What

Add an iterator for the CostType enum.

### Why

So that tooling can iterate over all cost types and output details about them, wihtout having to hardcode knowledge of a fixed set of cost types.

### Known limitations

[TODO or N/A]
