### PR TITLE
Use test frame when calling a test contract

### DIFF
--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -849,9 +849,12 @@ impl Host {
 
         #[cfg(feature = "testutils")]
         if let Some(cfs) = self.0.contracts.borrow().get(&id) {
-            return cfs
+            let mut fg = self.push_test_frame(id.clone());
+            let res = cfs
                 .call(&func, self, args)
-                .ok_or_else(|| HostError::General("function not found"));
+                .ok_or_else(|| HostError::General("function not found"))?;
+            fg.commit();
+            return Ok(res);
         }
 
         #[cfg(feature = "vm")]


### PR DESCRIPTION
### What

Use a test frame when calling a test contract, so that frame-dependent host functions work.

### Why

Fixes a bug introduced in #214.

### Known limitations

N/A