### PR TITLE
Fix `binary_slice` to take start and end index

### DIFF
--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -273,9 +273,9 @@ macro_rules! call_macro_with_all_host_functions {
                 /// Clone the binary `b1`, then moves all the elements of binary `b2` into it.
                 /// Return the new binary. Traps if number of elements in the binary overflows a u32.
                 {"E", fn binary_append(b1:Object, b2:Object) -> Object}
-                /// Copy the elements from `i` until length `l` in the binary and create a new binary from it.
-                /// Return the new binary. Traps if the index is out of bound.
-                {"F", fn binary_slice(b:Object, i:RawVal, l:RawVal) -> Object}
+                /// Copies the elements from `start` index until `end` index, exclusive, in the binary and creates a new binary from it.
+                /// Returns the new binary. Traps if the index is out of bound.
+                {"F", fn binary_slice(b:Object, start:RawVal, end:RawVal) -> Object}
             }
 
             mod hash "h" {

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -1872,24 +1872,25 @@ impl CheckedEnv for Host {
         Ok(self.add_host_object(vnew)?.into())
     }
 
-    fn binary_slice(&self, b: Object, i: RawVal, l: RawVal) -> Result<Object, HostError> {
-        let i: usize = u32::try_from(i).map_err(|_| {
-            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "i must be u32")
+    fn binary_slice(&self, b: Object, start: RawVal, end: RawVal) -> Result<Object, HostError> {
+        let start: usize = u32::try_from(start).map_err(|_| {
+            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "start must be u32")
         })? as usize;
-        let l: usize = u32::try_from(l).map_err(|_| {
-            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "l must be u32")
+        let end: usize = u32::try_from(end).map_err(|_| {
+            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "end must be u32")
         })? as usize;
         let vnew = self.visit_obj(b, move |hv: &Vec<u8>| {
-            if i > u32::MAX as usize - l {
-                return Err(
-                    self.err_status_msg(ScHostFnErrorCode::InputArgsInvalid, "u32 overflow")
-                );
+            if start > hv.len() {
+                return Err(self.err_status_msg(
+                    ScHostObjErrorCode::VecIndexOutOfBound,
+                    "start out of bounds",
+                ));
             }
-            if (i + l) > hv.len() {
+            if end > hv.len() {
                 return Err(self
-                    .err_status_msg(ScHostObjErrorCode::VecIndexOutOfBound, "index out of bound"));
+                    .err_status_msg(ScHostObjErrorCode::VecIndexOutOfBound, "end out of bounds"));
             }
-            Ok(hv.as_slice()[i..(i + l)].to_vec())
+            Ok(hv.as_slice()[start..end].to_vec())
         })?;
         Ok(self.add_host_object(vnew)?.into())
     }

--- a/stellar-contract-env-host/src/test/binary.rs
+++ b/stellar-contract-env-host/src/test/binary.rs
@@ -72,7 +72,7 @@ fn binary_suite_of_tests() -> Result<(), HostError> {
     } else {
         return Err(host.err_general("Type error"));
     }
-    let obj1 = host.binary_slice(obj, 3_u32.into(), 5_u32.into())?; // [3,4,5,6,7]
+    let obj1 = host.binary_slice(obj, 3_u32.into(), 8_u32.into())?; // [3,4,5,6,7]
     if let ScObject::Binary(b) = host.from_host_obj(obj1)? {
         assert_eq!((3..8).collect::<Vec<u8>>().as_slice(), b.as_slice());
     } else {


### PR DESCRIPTION
### What

Just like `vec_slice`, the `binary_slice` should take start and end index instead of the start and length. 

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
