### PR TITLE
Implement contract memory access and debug formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "dyn-fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a0836c9bd73a9d3ca55b0effc5b1eedf96dd13ef994389bcac6d4d33c46188"
+
+[[package]]
 name = "ed25519"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +625,7 @@ dependencies = [
 name = "stellar-contract-env-guest"
 version = "0.0.0"
 dependencies = [
+ "static_assertions",
  "stellar-contract-env-common",
 ]
 
@@ -628,6 +635,7 @@ version = "0.0.0"
 dependencies = [
  "assert_matches",
  "backtrace",
+ "dyn-fmt",
  "ed25519-dalek",
  "env_logger",
  "hex",

--- a/stellar-contract-env-common/src/unimplemented_env.rs
+++ b/stellar-contract-env-common/src/unimplemented_env.rs
@@ -14,6 +14,34 @@ impl EnvBase for UnimplementedEnv {
     fn deep_clone(&self) -> Self {
         Self
     }
+
+    fn binary_copy_from_slice(&self, _b: Object, _b_pos: RawVal, _mem: &[u8]) -> Object {
+        unimplemented!()
+    }
+
+    fn binary_copy_to_slice(&self, _b: Object, _b_pos: RawVal, _mem: &mut [u8]) {
+        unimplemented!()
+    }
+
+    fn binary_new_from_slice(&self, _mem: &[u8]) -> Object {
+        unimplemented!()
+    }
+
+    fn log_static_fmt_val(&self, _fmt: &'static str, _v: RawVal) {
+        unimplemented!()
+    }
+
+    fn log_static_fmt_static_str(&self, _fmt: &'static str, _s: &'static str) {
+        unimplemented!()
+    }
+
+    fn log_static_fmt_val_static_str(&self, _fmt: &'static str, _v: RawVal, _s: &'static str) {
+        unimplemented!()
+    }
+
+    fn log_static_fmt_general(&self, _fmt: &'static str, _vals: &[RawVal], _strs: &[&'static str]) {
+        unimplemented!()
+    }
 }
 
 // This is a helper macro used only by generate_env_unimplemented below. It

--- a/stellar-contract-env-guest/Cargo.toml
+++ b/stellar-contract-env-guest/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 stellar-contract-env-common = { path = "../stellar-contract-env-common" }
+static_assertions = "1.1.0"

--- a/stellar-contract-env-host/Cargo.toml
+++ b/stellar-contract-env-host/Cargo.toml
@@ -19,6 +19,7 @@ hex = "0.4.3"
 num-traits = "0.2.15"
 num-integer = "0.1.45"
 tinyvec = {version = "1.6.0", features = ["alloc"] }
+dyn-fmt = "0.3.0"
 log = "0.4.17"
 backtrace = "0.3"
 

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -76,6 +76,15 @@ pub(crate) enum Frame {
     TestContract(Hash),
 }
 
+/// Temporary helper for denoting a slice of guest memory, as formed by
+/// various binary operations.
+#[cfg(feature = "vm")]
+struct VmSlice {
+    vm: Rc<Vm>,
+    pos: u32,
+    len: u32,
+}
+
 #[derive(Clone, Default)]
 pub(crate) struct HostImpl {
     objects: RefCell<Vec<HostObject>>,
@@ -451,6 +460,33 @@ impl Host {
     // Testing interface to create values directly for later use via Env functions.
     pub fn inject_val(&self, v: &ScVal) -> Result<RawVal, HostError> {
         self.to_host_val(v).map(|hv| hv.into())
+    }
+
+    pub fn get_events(&self) -> Events {
+        self.0.events.borrow().clone()
+    }
+
+    #[cfg(feature = "vm")]
+    fn decode_vmslice(&self, pos: RawVal, len: RawVal) -> Result<VmSlice, HostError> {
+        let pos: u32 = u32::try_from(pos).map_err(|_| {
+            self.err_status_msg(
+                ScHostFnErrorCode::InputArgsWrongType,
+                "guest binary pos must be u32",
+            )
+        })?;
+        let len: u32 = u32::try_from(len).map_err(|_| {
+            self.err_status_msg(
+                ScHostFnErrorCode::InputArgsWrongType,
+                "guest binary len must be u32",
+            )
+        })?;
+        self.with_current_frame(|frame| match frame {
+            Frame::ContractVM(vm) => {
+                let vm = vm.clone();
+                Ok(VmSlice { vm, pos, len })
+            }
+            _ => Err(self.err_general("attempt to access guest binary in non-VM frame")),
+        })
     }
 
     pub(crate) fn to_host_val(&self, v: &ScVal) -> Result<HostVal, HostError> {
@@ -884,6 +920,81 @@ impl EnvBase for Host {
             }
         }
         new_host
+    }
+
+    fn binary_copy_from_slice(&self, b: Object, b_pos: RawVal, mem: &[u8]) -> Object {
+        // This is only called from native contracts, either when testing or
+        // when the contract is otherwise linked into the same address space as
+        // us. We therefore access the memory we were passed directly.
+        //
+        // This is also why we _panic_ on errors in here, rather than attempting
+        // to return a recoverable error code: native contracts that call this
+        // function do so through APIs that _should_ never pass bad data.
+        //
+        // TODO: we may revisit this choice of panicing in the future, depending
+        // on how we choose to try to contain panics-caused-by-native-contracts.
+        let b_pos = u32::try_from(b_pos).expect("pos input is not u32");
+        let len = u32::try_from(mem.len()).expect("slice len exceeds u32");
+        let mut vnew = self
+            .visit_obj(b, |hv: &Vec<u8>| Ok(hv.clone()))
+            .expect("access to unknown host binary object");
+        let end_idx = b_pos.checked_add(len).expect("u32 overflow") as usize;
+        // TODO: we currently grow the destination vec if it's not big enough,
+        // make sure this is desirable behaviour.
+        if end_idx > vnew.len() {
+            vnew.resize(end_idx, 0);
+        }
+        let write_slice = &mut vnew[b_pos as usize..end_idx];
+        write_slice.copy_from_slice(mem);
+        self.add_host_object(vnew)
+            .expect("unable to add host object")
+            .into()
+    }
+
+    fn binary_copy_to_slice(&self, b: Object, b_pos: RawVal, mem: &mut [u8]) {
+        let b_pos = u32::try_from(b_pos).expect("pos input is not u32");
+        let len = u32::try_from(mem.len()).expect("slice len exceeds u32");
+        self.visit_obj(b, move |hv: &Vec<u8>| {
+            let end_idx = b_pos.checked_add(len).expect("u32 overflow") as usize;
+            if end_idx > hv.len() {
+                panic!("index out of bounds");
+            }
+            mem.copy_from_slice(&hv.as_slice()[b_pos as usize..end_idx]);
+            Ok(())
+        })
+        .expect("access to unknown host object");
+    }
+
+    fn binary_new_from_slice(&self, mem: &[u8]) -> Object {
+        self.add_host_object::<Vec<u8>>(mem.into())
+            .expect("unable to add host binary object")
+            .into()
+    }
+
+    fn log_static_fmt_val(&self, fmt: &'static str, v: RawVal) {
+        self.debug_event(DebugEvent::new().msg(fmt).arg(v))
+            .expect("unable to record debug event")
+    }
+
+    fn log_static_fmt_static_str(&self, fmt: &'static str, s: &'static str) {
+        self.debug_event(DebugEvent::new().msg(fmt).arg(s))
+            .expect("unable to record debug event")
+    }
+
+    fn log_static_fmt_val_static_str(&self, fmt: &'static str, v: RawVal, s: &'static str) {
+        self.debug_event(DebugEvent::new().msg(fmt).arg(v).arg(s))
+            .expect("unable to record debug event")
+    }
+
+    fn log_static_fmt_general(&self, fmt: &'static str, vals: &[RawVal], strs: &[&'static str]) {
+        let mut evt = DebugEvent::new().msg(fmt);
+        for v in vals {
+            evt = evt.arg(*v)
+        }
+        for s in strs {
+            evt = evt.arg(*s)
+        }
+        self.debug_event(evt).expect("unable to record debug event")
     }
 }
 
@@ -1407,7 +1518,7 @@ impl CheckedEnv for Host {
             Err(e) => {
                 let evt = DebugEvent::new()
                     .msg("try_call got error from callee contract")
-                    .arg(e.status.clone());
+                    .arg::<RawVal>(e.status.clone().into());
                 self.debug_event(evt)?;
                 Ok(e.status.into())
             }
@@ -1629,14 +1740,11 @@ impl CheckedEnv for Host {
         #[cfg(not(feature = "vm"))]
         unimplemented!();
         #[cfg(feature = "vm")]
-        if let [b_pos, lm_pos, len] = [b_pos, lm_pos, len]
-            .iter()
-            .map(|v| u32::try_from(*v))
-            .collect::<Result<Vec<u32>, ConversionError>>()?
-            .as_slice()
         {
+            let VmSlice { vm, pos, len } = self.decode_vmslice(lm_pos, len)?;
+            let b_pos = u32::try_from(b_pos)?;
             self.visit_obj(b, move |hv: &Vec<u8>| {
-                let end_idx = b_pos.checked_add(*len).ok_or_else(|| {
+                let end_idx = b_pos.checked_add(len).ok_or_else(|| {
                     self.err_status_msg(ScHostFnErrorCode::InputArgsInvalid, "u32 overflow")
                 })? as usize;
                 if end_idx > hv.len() {
@@ -1645,22 +1753,11 @@ impl CheckedEnv for Host {
                         "index out of bound",
                     ));
                 }
-                self.with_current_frame(|frame| match frame {
-                    Frame::ContractVM(vm) => vm.with_memory_access(self, |mem| {
-                        Ok(self
-                            .map_err(mem.set(*lm_pos, &hv.as_slice()[*b_pos as usize..end_idx]))?)
-                    }),
-                    Frame::HostFunction(_) => Err(self.err_general("linear memory not supported")),
-                    #[cfg(feature = "testutils")]
-                    Frame::TestContract(id) => Err(self.err_general("linear memory not supported")),
-                })
-            })?;
-            Ok(().into())
-        } else {
-            return Err(self.err_status_msg(
-                ScHostFnErrorCode::InputArgsWrongType,
-                "failed conversion to u32",
-            ));
+                vm.with_memory_access(self, |mem| {
+                    self.map_err(mem.set(pos, &hv.as_slice()[b_pos as usize..end_idx]))
+                })?;
+                Ok(().into())
+            })
         }
     }
 
@@ -1674,36 +1771,24 @@ impl CheckedEnv for Host {
         #[cfg(not(feature = "vm"))]
         unimplemented!();
         #[cfg(feature = "vm")]
-        if let [b_pos, lm_pos, len] = [b_pos, lm_pos, len]
-            .iter()
-            .map(|v| u32::try_from(*v))
-            .collect::<Result<Vec<u32>, ConversionError>>()?
-            .as_slice()
         {
+            let VmSlice { vm, pos, len } = self.decode_vmslice(lm_pos, len)?;
+            let b_pos = u32::try_from(b_pos)?;
             let mut vnew = self.visit_obj(b, |hv: &Vec<u8>| Ok(hv.clone()))?;
-            let end_idx = b_pos.checked_add(*len).ok_or_else(|| {
+            let end_idx = b_pos.checked_add(len).ok_or_else(|| {
                 self.err_status_msg(ScHostFnErrorCode::InputArgsInvalid, "u32 overflow")
             })? as usize;
-            self.with_current_frame(|frame| match frame {
-                Frame::ContractVM(vm) => vm.with_memory_access(self, |mem| {
-                    // we would potentially let the vec grow
-                    if end_idx > vnew.len() {
-                        vnew.resize(end_idx, 0);
-                    }
-                    Ok(self.map_err(
-                        mem.get_into(*lm_pos, &mut vnew.as_mut_slice()[*b_pos as usize..end_idx]),
-                    )?)
-                }),
-                Frame::HostFunction(_) => Err(self.err_general("linear memory not supported")),
-                #[cfg(feature = "testutils")]
-                Frame::TestContract(id) => Err(self.err_general("linear memory not supported")),
+            // TODO: we currently grow the destination vec if it's not big enough,
+            // make sure this is desirable behaviour.
+            if end_idx > vnew.len() {
+                vnew.resize(end_idx, 0);
+            }
+            vm.with_memory_access(self, |mem| {
+                Ok(self.map_err(
+                    mem.get_into(pos, &mut vnew.as_mut_slice()[b_pos as usize..end_idx]),
+                )?)
             })?;
             Ok(self.add_host_object(vnew)?.into())
-        } else {
-            return Err(self.err_status_msg(
-                ScHostFnErrorCode::InputArgsWrongType,
-                "failed conversion to u32",
-            ));
         }
     }
 
@@ -1719,27 +1804,13 @@ impl CheckedEnv for Host {
         #[cfg(not(feature = "vm"))]
         unimplemented!();
         #[cfg(feature = "vm")]
-        if let [lm_pos, len] = [lm_pos, len]
-            .iter()
-            .map(|v| u32::try_from(*v))
-            .collect::<Result<Vec<u32>, ConversionError>>()?
-            .as_slice()
         {
-            return self.with_current_frame(|frame| match frame {
-                Frame::ContractVM(vm) => vm.with_memory_access(self, |mem| {
-                    let mut vnew: Vec<u8> = vec![0; *len as usize];
-                    self.map_err(mem.get_into(*lm_pos, vnew.as_mut_slice()))?;
-                    Ok(self.add_host_object(vnew)?.into())
-                }),
-                Frame::HostFunction(_) => Err(self.err_general("linear memory not supported")),
-                #[cfg(feature = "testutils")]
-                Frame::TestContract(id) => Err(self.err_general("linear memory not supported")),
-            });
-        } else {
-            return Err(self.err_status_msg(
-                ScHostFnErrorCode::InputArgsWrongType,
-                "failed conversion to u32",
-            ));
+            let VmSlice { vm, pos, len } = self.decode_vmslice(lm_pos, len)?;
+            let mut vnew: Vec<u8> = vec![0; len as usize];
+            vm.with_memory_access(self, |mem| {
+                self.map_err(mem.get_into(pos, vnew.as_mut_slice()))
+            })?;
+            Ok(self.add_host_object(vnew)?.into())
         }
     }
 

--- a/stellar-contract-env-host/src/weak_host.rs
+++ b/stellar-contract-env-host/src/weak_host.rs
@@ -49,6 +49,34 @@ impl EnvBase for WeakHost {
     fn deep_clone(&self) -> Self {
         self.get_host().deep_clone().get_weak()
     }
+
+    fn binary_copy_from_slice(&self, b: Object, b_pos: RawVal, mem: &[u8]) -> Object {
+        self.get_host().binary_copy_from_slice(b, b_pos, mem)
+    }
+
+    fn binary_copy_to_slice(&self, b: Object, b_pos: RawVal, mem: &mut [u8]) {
+        self.get_host().binary_copy_to_slice(b, b_pos, mem)
+    }
+
+    fn binary_new_from_slice(&self, mem: &[u8]) -> Object {
+        self.get_host().binary_new_from_slice(mem)
+    }
+
+    fn log_static_fmt_val(&self, fmt: &'static str, v: RawVal) {
+        self.get_host().log_static_fmt_val(fmt, v)
+    }
+
+    fn log_static_fmt_static_str(&self, fmt: &'static str, s: &'static str) {
+        self.get_host().log_static_fmt_static_str(fmt, s)
+    }
+
+    fn log_static_fmt_val_static_str(&self, fmt: &'static str, v: RawVal, s: &'static str) {
+        self.get_host().log_static_fmt_val_static_str(fmt, v, s)
+    }
+
+    fn log_static_fmt_general(&self, fmt: &'static str, vals: &[RawVal], strs: &[&'static str]) {
+        self.get_host().log_static_fmt_general(fmt, vals, strs)
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/stellar-contract-env-host/tests/integration.rs
+++ b/stellar-contract-env-host/tests/integration.rs
@@ -1,4 +1,6 @@
-use stellar_contract_env_host::{xdr::ScObjectType, Env, Host, Object, RawVal};
+use stellar_contract_env_host::{
+    events::HostEvent, xdr::ScObjectType, Env, EnvBase, Host, Object, RawVal,
+};
 
 #[test]
 fn vec_as_seen_by_user() -> Result<(), ()> {
@@ -25,4 +27,31 @@ fn vec_host_fn() {
     let host = Host::default();
     let m = host.map_new();
     assert!(Object::val_is_obj_type(m.into(), ScObjectType::Map));
+}
+
+#[test]
+fn debug_fmt() {
+    let host = Host::default();
+
+    // Call a "native formatting-style" debug helper.
+    host.log_static_fmt_val_static_str(
+        "can't convert {} to {}",
+        RawVal::from_i32(1),
+        std::any::type_name::<Vec<u8>>(),
+    );
+
+    // Fish out the last debug event and check that it is
+    // correct, and formats as expected.
+    let events = host.get_events();
+    match events.0.last() {
+        Some(HostEvent::Debug(de)) => {
+            assert_eq!(
+                format!("{}", de),
+                "can't convert I32(1) to alloc::vec::Vec<u8>"
+            )
+        }
+        _ => {
+            panic!("missing debug event")
+        }
+    }
 }


### PR DESCRIPTION
This addresses two sets of related problems we've been discussing recently:

  - How to get contract-memory slices into binaries when `Env=Host` (call this "native" or "test contract", however you like): #179
  - How to get richer debug logging from contracts _at least_ (perhaps only) when building `Env=Host` (multiple args, format strings, static string args): #229, #181, #205 

The common problem / issue here (and what took so long, I tried a lot of different unsatisfying approaches) is "what's the safest and least-terrible way of receiving pointers-into-contract-memory on the host when `Env=Host`". We know what to do when `Env=Guest` -- a contract pointer is a linear memory address, a u32 -- but when `Env=Host` it means we're sharing a process with the host and we might find it ugly, unsafe or even unsound to try to transmit pointers through the narrow vocabulary of `Env`, which only knows about `u64` and `RawVal`.

The answer I came up with eventually is "provide the pointer-passing interfaces in `EnvBase`, have them take lifetime-qualified Rust slices, and _decay those to `Env` calls_ only in the `Env=Guest` case, and even then optionally (eg. the logging interface decays them to no-ops because we want `Env=Guest` builds to be mimimum-sized)". Then make the pointer-receiving paths on `Env` fail when called from a non-VM frame (i.e. native/test -- "definitely not `Guest`"), as they do today.

I think this sorts out how to move forwards with such questions, and more concretely it gives a pattern (as well as a few initial functions) for debug logging functions that take multiple args from _either_ guest or host side, formatting them lazily on print-out. I _think_ these should handle the error-reporting cases people are stuck on (eg. the rich type-conversion errors and such).