### PR TITLE
Add ScVal to/trom Object impls

### DIFF
--- a/stellar-contract-env-common/src/object.rs
+++ b/stellar-contract-env-common/src/object.rs
@@ -1,4 +1,4 @@
-use stellar_xdr::ScObject;
+use stellar_xdr::{ScObject, ScVal};
 
 use crate::{
     tagged_val::{TagObject, TaggedVal},
@@ -89,5 +89,53 @@ where
             val: env.convert(self)?,
             env: env.clone(),
         })
+    }
+}
+
+impl<E> TryFrom<EnvVal<E, Object>> for ScVal
+where
+    E: Env + TryConvert<Object, ScObject>,
+{
+    type Error = E::Error;
+    fn try_from(ev: EnvVal<E, Object>) -> Result<Self, Self::Error> {
+        (&ev).try_into()
+    }
+}
+
+impl<E> TryFrom<&EnvVal<E, Object>> for ScVal
+where
+    E: Env + TryConvert<Object, ScObject>,
+{
+    type Error = E::Error;
+    fn try_from(ev: &EnvVal<E, Object>) -> Result<Self, Self::Error> {
+        Ok(ScVal::Object(Some(ev.env.convert(ev.val)?)))
+    }
+}
+
+impl<'a, E> TryIntoEnvVal<E, Object> for &'a ScVal
+where
+    E: Env + TryConvert<&'a ScObject, Object>,
+{
+    type Error = E::Error;
+    fn try_into_env_val(self, env: &E) -> Result<EnvVal<E, Object>, Self::Error> {
+        if let ScVal::Object(Some(o)) = self {
+            o.try_into_env_val(env)
+        } else {
+            todo!()
+        }
+    }
+}
+
+impl<E> TryIntoEnvVal<E, Object> for ScVal
+where
+    E: Env + TryConvert<ScObject, Object>,
+{
+    type Error = E::Error;
+    fn try_into_env_val(self, env: &E) -> Result<EnvVal<E, Object>, Self::Error> {
+        if let ScVal::Object(Some(o)) = self {
+            o.try_into_env_val(env)
+        } else {
+            todo!()
+        }
     }
 }

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -157,6 +157,31 @@ impl TryConvert<ScObject, Object> for Host {
     }
 }
 
+impl TryConvert<Object, ScVal> for Host {
+    type Error = HostError;
+    fn convert(&self, ob: Object) -> Result<ScVal, Self::Error> {
+        Ok(ScVal::Object(Some(self.convert(ob)?)))
+    }
+}
+
+impl TryConvert<&ScVal, Object> for Host {
+    type Error = HostError;
+    fn convert(&self, v: &ScVal) -> Result<Object, Self::Error> {
+        if let ScVal::Object(Some(o)) = v {
+            self.convert(o)
+        } else {
+            Err(self.err_status(ScHostValErrorCode::UnexpectedValType))
+        }
+    }
+}
+
+impl TryConvert<ScVal, Object> for Host {
+    type Error = HostError;
+    fn convert(&self, v: ScVal) -> Result<Object, Self::Error> {
+        self.convert(&v)
+    }
+}
+
 impl Host {
     /// Constructs a new [`Host`] that will use the provided [`Storage`] for
     /// contract-data access functions such as

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -157,31 +157,6 @@ impl TryConvert<ScObject, Object> for Host {
     }
 }
 
-impl TryConvert<Object, ScVal> for Host {
-    type Error = HostError;
-    fn convert(&self, ob: Object) -> Result<ScVal, Self::Error> {
-        Ok(ScVal::Object(Some(self.convert(ob)?)))
-    }
-}
-
-impl TryConvert<&ScVal, Object> for Host {
-    type Error = HostError;
-    fn convert(&self, v: &ScVal) -> Result<Object, Self::Error> {
-        if let ScVal::Object(Some(o)) = v {
-            self.convert(o)
-        } else {
-            Err(self.err_status(ScHostValErrorCode::UnexpectedValType))
-        }
-    }
-}
-
-impl TryConvert<ScVal, Object> for Host {
-    type Error = HostError;
-    fn convert(&self, v: ScVal) -> Result<Object, Self::Error> {
-        self.convert(&v)
-    }
-}
-
 impl Host {
     /// Constructs a new [`Host`] that will use the provided [`Storage`] for
     /// contract-data access functions such as


### PR DESCRIPTION
### What
Add ScVal to/trom Object impls.

### Why
So that there are more seamless TryFrom conversions to and from ScVal backed by TryConvert, not just ScObject.
