### PR TITLE
Impl std::error::Error for HostError and add some helpers

### DIFF
--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -257,7 +257,7 @@ impl Host {
         self.err(DebugError::general().msg(msg))
     }
 
-    pub(crate) fn err_conversion_rawval_to<T>(&self, rv: RawVal) -> HostError {
+    pub(crate) fn err_conversion_raw_val_to<T>(&self, rv: RawVal) -> HostError {
         self.err(
             DebugError::new(ConversionError)
                 .msg("error converting {} into {}")

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -257,6 +257,15 @@ impl Host {
         self.err(DebugError::general().msg(msg))
     }
 
+    pub(crate) fn err_conversion_rawval_to<T>(&self, rv: RawVal) -> HostError {
+        self.err(
+            DebugError::new(ConversionError)
+                .msg("error converting {} into {}")
+                .arg(rv)
+                .arg(std::any::type_name::<T>()),
+        )
+    }
+
     /// Helper for the next-simplest status-and-extended-debug-message error path.
     pub(crate) fn err_status_msg<T>(&self, status: T, msg: &'static str) -> HostError
     where
@@ -766,6 +775,22 @@ impl Host {
         }
     }
 
+    fn usize_from_rawval_u32_input(
+        &self,
+        name: &'static str,
+        r: RawVal,
+    ) -> Result<usize, HostError> {
+        match u32::try_from(r) {
+            Ok(v) => Ok(v as usize),
+            Err(cvt) => Err(self.err(
+                DebugError::new(ScHostFnErrorCode::InputArgsWrongType)
+                    .msg("unexpected RawVal {} for input '{}', need U32")
+                    .arg(r)
+                    .arg(name),
+            )),
+        }
+    }
+
     fn to_u256(&self, a: Object) -> Result<Uint256, HostError> {
         self.visit_obj(a, |bin: &Vec<u8>| {
             bin.try_into()
@@ -1156,9 +1181,7 @@ impl CheckedEnv for Host {
     }
 
     fn vec_put(&self, v: Object, i: RawVal, x: RawVal) -> Result<Object, HostError> {
-        let i: usize = u32::try_from(i).map_err(|_| {
-            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "i must be u32")
-        })? as usize;
+        let i: usize = self.usize_from_rawval_u32_input("i", i)?;
         let x = self.associate_raw_val(x);
         let vnew = self.visit_obj(v, move |hv: &HostVec| {
             if i >= hv.len() {
@@ -1173,9 +1196,7 @@ impl CheckedEnv for Host {
     }
 
     fn vec_get(&self, v: Object, i: RawVal) -> Result<RawVal, HostError> {
-        let i: usize = u32::try_from(i).map_err(|_| {
-            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "i must be u32")
-        })? as usize;
+        let i: usize = self.usize_from_rawval_u32_input("i", i)?;
         self.visit_obj(v, move |hv: &HostVec| match hv.get(i) {
             None => {
                 Err(self
@@ -1186,9 +1207,7 @@ impl CheckedEnv for Host {
     }
 
     fn vec_del(&self, v: Object, i: RawVal) -> Result<Object, HostError> {
-        let i: usize = u32::try_from(i).map_err(|_| {
-            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "i must be u32")
-        })? as usize;
+        let i: usize = self.usize_from_rawval_u32_input("i", i)?;
         let vnew = self.visit_obj(v, move |hv: &HostVec| {
             if i >= hv.len() {
                 return Err(self

--- a/stellar-contract-env-host/src/host/error.rs
+++ b/stellar-contract-env-host/src/host/error.rs
@@ -12,6 +12,8 @@ pub struct HostError {
     pub(crate) backtrace: backtrace::Backtrace,
 }
 
+impl std::error::Error for HostError {}
+
 impl Debug for HostError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // We do a little trimming here, skipping the first two frames (which


### PR DESCRIPTION
This adds an `impl Error for HostError` (which was accidentally lost when removing the use of `thiserror`) as well as a couple helper functions that factor out error-generating paths in host function.