### PR TITLE
Add BigInt fns to convert to bytes / array of digits

### DIFF
--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -275,6 +275,11 @@ macro_rules! call_macro_with_all_host_functions {
                 {"L", fn bigint_sqrt(x:Object) -> Object}
                 /// Determines the fewest bits necessary to express `x`, not including the sign.
                 {"M", fn bigint_bits(x:Object) -> u64}
+                /// Outputs the BigInt's magnitude in big-endian byte order into a binary array. The sign is dropped.
+                {"N", fn bigint_to_bytes_be(x:Object) -> Object}
+                /// Outputs the BigInt's magnitude in the requested base in big-endian digit order into a binary array.
+                /// The sign is dropped. Radix must be in the range 2...256.
+                {"N", fn bigint_to_radix_be(x:Object, radix:RawVal) -> Object}
             }
 
             mod binary "b" {

--- a/stellar-contract-env-common/src/env.rs
+++ b/stellar-contract-env-common/src/env.rs
@@ -279,7 +279,7 @@ macro_rules! call_macro_with_all_host_functions {
                 {"N", fn bigint_to_bytes_be(x:Object) -> Object}
                 /// Outputs the BigInt's magnitude in the requested base in big-endian digit order into a binary array.
                 /// The sign is dropped. Radix must be in the range 2...256.
-                {"N", fn bigint_to_radix_be(x:Object, radix:RawVal) -> Object}
+                {"O", fn bigint_to_radix_be(x:Object, radix:RawVal) -> Object}
             }
 
             mod binary "b" {

--- a/stellar-contract-env-host/src/test/bigint.rs
+++ b/stellar-contract-env-host/src/test/bigint.rs
@@ -201,6 +201,15 @@ fn bigint_tests() -> Result<(), HostError> {
         assert_eq!(host.bigint_bits(obj_b)?, 19);
         assert_eq!(host.bigint_bits(obj_0)?, 0);
     }
+    // convert to array
+    {
+        let bin = host.bigint_to_radix_be(obj_a, 10_u32.into())?;
+        let digits = host.test_bin_obj(&[2, 3, 7, 4, 3, 4, 0])?;
+        assert_eq!(host.obj_cmp(bin.into(), digits.into())?, 0);
 
+        let bin2 = host.bigint_to_radix_be(obj_b, 10_u32.into())?;
+        let digits2 = host.test_bin_obj(&[4, 3, 8, 7, 3, 0])?;
+        assert_eq!(host.obj_cmp(bin2.into(), digits2.into())?, 0);
+    }
     Ok(())
 }


### PR DESCRIPTION
### What
Resolves https://github.com/stellar/rs-stellar-contract-sdk/issues/219 
SDK side change will follow this. 

Add two `BigInt` host functions for debugging. 
- `bigint_to_bytes_be` to dump the digits as bytes
- `bigint_to_radix_be` to dump the digits as numbers in any base < 256

Along the change some hostfn impls gets shuffled into their correct (declared) order.  

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
