### PR TITLE
Impl TryIntoEnvVal for all EnvVal<>: TryInto

### DIFF
--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -105,26 +105,36 @@ pub trait IntoEnvVal<E: Env, V>: Sized {
     fn into_env_val(self, env: &E) -> EnvVal<E, V>;
 }
 
-pub trait IntoVal<E: Env, V>: IntoEnvVal<E, V> {
+pub trait IntoVal<E: Env, V> {
+    fn into_val(self, env: &E) -> V;
+}
+
+impl<E: Env, V, T> IntoVal<E, V> for T where
+T: IntoEnvVal<E, V> {
     fn into_val(self, env: &E) -> V {
         Self::into_env_val(self, env).val
     }
 }
-
-impl<E: Env, V, T> IntoVal<E, V> for T where T: IntoEnvVal<E, V> {}
 
 pub trait TryIntoEnvVal<E: Env, V>: Sized {
     type Error;
     fn try_into_env_val(self, env: &E) -> Result<EnvVal<E, V>, Self::Error>;
 }
 
-pub trait TryIntoVal<E: Env, V>: TryIntoEnvVal<E, V> {
+pub trait TryIntoVal<E: Env, V> {
+    type Error;
+    fn try_into_val(self, env: &E) -> Result<V, Self::Error>;
+}
+
+impl<E: Env, V, T> TryIntoVal<E, V> for T
+where
+    T: TryIntoEnvVal<E, V>,
+{
+    type Error = T::Error;
     fn try_into_val(self, env: &E) -> Result<V, Self::Error> {
         Ok(Self::try_into_env_val(self, env)?.val)
     }
 }
-
-impl<E: Env, V, T> TryIntoVal<E, V> for T where T: TryIntoEnvVal<E, V> {}
 
 pub trait TryFromVal<E: Env, V>: Sized + TryFrom<EnvVal<E, V>> {
     fn try_from_val(env: &E, v: V) -> Result<Self, Self::Error> {

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -127,15 +127,14 @@ impl<E: Env, F, T> TryIntoEnvVal<E, T> for F
 where
     EnvVal<E, F>: TryInto<T>,
 {
-    type Error = ConversionError;
+    type Error = <EnvVal<E, F> as TryInto<T>>::Error;
 
     fn try_into_env_val(self, env: &E) -> Result<EnvVal<E, T>, Self::Error> {
         let ab: T = EnvVal {
             env: env.clone(),
             val: self,
         }
-        .try_into()
-        .map_err(|_| ConversionError)?;
+        .try_into()?;
         Ok(EnvVal {
             env: env.clone(),
             val: ab,

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -130,14 +130,14 @@ where
     type Error = <EnvVal<E, F> as TryInto<T>>::Error;
 
     fn try_into_env_val(self, env: &E) -> Result<EnvVal<E, T>, Self::Error> {
-        let ab: T = EnvVal {
+        let ev: T = EnvVal {
             env: env.clone(),
             val: self,
         }
         .try_into()?;
         Ok(EnvVal {
             env: env.clone(),
-            val: ab,
+            val: ev,
         })
     }
 }

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -121,6 +121,26 @@ pub trait TryIntoEnvVal<E: Env, V>: Sized {
     fn try_into_env_val(self, env: &E) -> Result<EnvVal<E, V>, Self::Error>;
 }
 
+impl<E: Env, F, T> TryIntoEnvVal<E, T> for F
+where
+    EnvVal<E, F>: TryInto<T>,
+{
+    type Error = ConversionError;
+
+    fn try_into_env_val(self, env: &E) -> Result<EnvVal<E, T>, Self::Error> {
+        let ab: T = EnvVal {
+            env: env.clone(),
+            val: self,
+        }
+        .try_into()
+        .map_err(|_| ConversionError)?;
+        Ok(EnvVal {
+            env: env.clone(),
+            val: ab,
+        })
+    }
+}
+
 pub trait TryIntoVal<E: Env, V> {
     type Error;
     fn try_into_val(self, env: &E) -> Result<V, Self::Error>;


### PR DESCRIPTION
### What
Impl `TryIntoEnvVal` for all `EnvVal<>: TryInto`.
### Why
To surface the useful `.try_into_env_val()` and `.try_into_val()` functions for types that implement `TryFrom<EnvVal<>>` or `TryInto<> for EnvVal<>`.

This new blanket impl will be the first time for some types that multiple implementations are possible for this trait, and so there will be some places in the SDK that will have ambiguous uses of these functions that will require some type annotations. I've already run through them and there are only a half dozen that are easy to fill in.