### PR TITLE
Split conversion-related code out of host into a new file.

### DIFF
--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -1043,9 +1043,7 @@ impl CheckedEnv for Host {
 
     fn map_len(&self, m: Object) -> Result<RawVal, HostError> {
         let len = self.visit_obj(m, |hm: &HostMap| Ok(hm.len()))?;
-        Ok(u32::try_from(len)
-            .map_err(|_| ScHostValErrorCode::U32OutOfRange)?
-            .into())
+        self.usize_to_rawval_u32(len)
     }
 
     fn map_has(&self, m: Object, k: RawVal) -> Result<RawVal, HostError> {

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -629,14 +629,7 @@ impl Host {
         id_preimage: Vec<u8>,
     ) -> Result<Object, HostError> {
         let id_obj = self.compute_hash_sha256(self.add_host_object(id_preimage)?.into())?;
-
-        let new_contract_id = self.visit_obj(id_obj, |bin: &Vec<u8>| {
-            let arr: [u8; 32] = bin
-                .as_slice()
-                .try_into()
-                .map_err(|_| self.err_status(ScHostObjErrorCode::ContractHashWrongLength))?;
-            Ok(xdr::Hash(arr))
-        })?;
+        let new_contract_id = self.hash_from_rawval_input("id_obj", id_obj)?;
 
         let storage_key = LedgerKey::ContractData(LedgerKeyContractData {
             contract_id: new_contract_id.clone(),
@@ -693,15 +686,7 @@ impl Host {
 
     fn call_n(&self, contract: Object, func: Symbol, args: &[RawVal]) -> Result<RawVal, HostError> {
         // Get contract ID
-        let id = self.visit_obj(contract, |bin: &Vec<u8>| {
-            let arr: [u8; 32] = bin.as_slice().try_into().map_err(|_| {
-                self.err_status_msg(
-                    ScHostObjErrorCode::ContractHashWrongLength,
-                    "invalid contract hash",
-                )
-            })?;
-            Ok(xdr::Hash(arr))
-        })?;
+        let id = self.hash_from_rawval_input("contract", contract)?;
 
         #[cfg(feature = "testutils")]
         {

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -475,18 +475,8 @@ impl Host {
 
     #[cfg(feature = "vm")]
     fn decode_vmslice(&self, pos: RawVal, len: RawVal) -> Result<VmSlice, HostError> {
-        let pos: u32 = u32::try_from(pos).map_err(|_| {
-            self.err_status_msg(
-                ScHostFnErrorCode::InputArgsWrongType,
-                "guest binary pos must be u32",
-            )
-        })?;
-        let len: u32 = u32::try_from(len).map_err(|_| {
-            self.err_status_msg(
-                ScHostFnErrorCode::InputArgsWrongType,
-                "guest binary len must be u32",
-            )
-        })?;
+        let pos: u32 = self.u32_from_rawval_input("pos", pos)?;
+        let len: u32 = self.u32_from_rawval_input("len", len)?;
         self.with_current_frame(|frame| match frame {
             Frame::ContractVM(vm) => {
                 let vm = vm.clone();
@@ -1165,12 +1155,7 @@ impl CheckedEnv for Host {
         let capacity: usize = if c.is_void() {
             0
         } else {
-            u32::try_from(c).map_err(|_| {
-                self.err_status_msg(
-                    ScHostFnErrorCode::InputArgsWrongType,
-                    "c must be either `ScStatic::Void` or an `u32`",
-                )
-            })? as usize
+            self.usize_from_rawval_u32_input("c", c)?
         };
         // TODO: optimize the vector based on capacity
         Ok(self.add_host_object(HostVec::new())?.into())
@@ -1291,12 +1276,8 @@ impl CheckedEnv for Host {
     }
 
     fn vec_slice(&self, v: Object, start: RawVal, end: RawVal) -> Result<Object, HostError> {
-        let start: usize = u32::try_from(start).map_err(|_| {
-            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "start must be u32")
-        })? as usize;
-        let end: usize = u32::try_from(end).map_err(|_| {
-            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "end must be u32")
-        })? as usize;
+        let start = self.usize_from_rawval_u32_input("start", start)?;
+        let end = self.usize_from_rawval_u32_input("end", end)?;
         if start > end {
             return Err(self.err_status_msg(
                 ScHostFnErrorCode::InputArgsInvalid,

--- a/stellar-contract-env-host/src/host/conversion.rs
+++ b/stellar-contract-env-host/src/host/conversion.rs
@@ -1,0 +1,60 @@
+use crate::events::DebugError;
+use crate::xdr::{ScHostFnErrorCode, ScHostValErrorCode};
+use crate::{Host, HostError, Object, RawVal};
+use stellar_contract_env_common::xdr::Uint256;
+
+impl Host {
+    pub(crate) fn usize_to_rawval_u32(&self, u: usize) -> Result<RawVal, HostError> {
+        match u32::try_from(u) {
+            Ok(v) => Ok(v.into()),
+            Err(_) => Err(self.err_status(ScHostValErrorCode::U32OutOfRange)),
+        }
+    }
+
+    pub(crate) fn usize_from_rawval_u32_input(
+        &self,
+        name: &'static str,
+        r: RawVal,
+    ) -> Result<usize, HostError> {
+        self.u32_from_rawval_input(name, r).map(|u| u as usize)
+    }
+
+    pub(crate) fn u32_from_rawval_input(
+        &self,
+        name: &'static str,
+        r: RawVal,
+    ) -> Result<u32, HostError> {
+        match u32::try_from(r) {
+            Ok(v) => Ok(v),
+            Err(cvt) => Err(self.err(
+                DebugError::new(ScHostFnErrorCode::InputArgsWrongType)
+                    .msg("unexpected RawVal {} for input '{}', need U32")
+                    .arg(r)
+                    .arg(name),
+            )),
+        }
+    }
+
+    pub(crate) fn to_u256(&self, a: Object) -> Result<Uint256, HostError> {
+        self.visit_obj(a, |bin: &Vec<u8>| {
+            bin.try_into()
+                .map_err(|_| self.err_general("bad u256 length"))
+        })
+    }
+
+    pub(crate) fn u8_from_rawval_input(
+        &self,
+        name: &'static str,
+        r: RawVal,
+    ) -> Result<u8, HostError> {
+        match u8::try_from(r) {
+            Ok(v) => Ok(v),
+            Err(cvt) => Err(self.err(
+                DebugError::new(ScHostFnErrorCode::InputArgsWrongType)
+                    .msg("unexpected RawVal {} for input '{}', need U8")
+                    .arg(r)
+                    .arg(name),
+            )),
+        }
+    }
+}


### PR DESCRIPTION
### What

Split out arg conversion functions into a new file.  Clean up existing (repetitive) conversion code to use those functions. 
Relates to https://github.com/stellar/rs-stellar-contract-env/issues/154.

### Why

Clean up the host file, to make it smaller and more readable.

### Known limitations

This is a continuous effort. 
