### PR TITLE
Remove u8 as a RawVal

### DIFF
--- a/stellar-contract-env-common/src/raw_val.rs
+++ b/stellar-contract-env-common/src/raw_val.rs
@@ -140,7 +140,6 @@ declare_tryfrom!(());
 declare_tryfrom!(bool);
 declare_tryfrom!(u32);
 declare_tryfrom!(i32);
-declare_tryfrom!(u8);
 
 #[cfg(feature = "vm")]
 impl wasmi::FromValue for RawVal {
@@ -211,17 +210,6 @@ impl RawValConvertible for i32 {
     #[inline(always)]
     unsafe fn unchecked_from_val(v: RawVal) -> Self {
         v.get_body() as i32
-    }
-}
-
-impl RawValConvertible for u8 {
-    #[inline(always)]
-    fn is_val_type(v: RawVal) -> bool {
-        v.has_tag(Tag::U32)
-    }
-    #[inline(always)]
-    unsafe fn unchecked_from_val(v: RawVal) -> Self {
-        v.get_body() as u8
     }
 }
 

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -1806,7 +1806,10 @@ impl CheckedEnv for Host {
             self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "u must be u32")
         })?;
         let u: u8 = u.try_into().map_err(|_| {
-            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "u must be no greater than 255")
+            self.err_status_msg(
+                ScHostFnErrorCode::InputArgsWrongType,
+                "u must be no greater than 255",
+            )
         })?;
         let vnew = self.visit_obj(b, move |hv: &Vec<u8>| {
             let mut vnew = hv.clone();
@@ -1859,7 +1862,10 @@ impl CheckedEnv for Host {
             self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "x must be u32")
         })?;
         let u: u8 = u.try_into().map_err(|_| {
-            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "x must be no greater than 255")
+            self.err_status_msg(
+                ScHostFnErrorCode::InputArgsWrongType,
+                "x must be no greater than 255",
+            )
         })?;
         let vnew = self.visit_obj(b, move |hv: &Vec<u8>| {
             let mut vnew = hv.clone();
@@ -1912,7 +1918,10 @@ impl CheckedEnv for Host {
             self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "x must be u32")
         })?;
         let u: u8 = u.try_into().map_err(|_| {
-            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "x must be no greater than 255")
+            self.err_status_msg(
+                ScHostFnErrorCode::InputArgsWrongType,
+                "x must be no greater than 255",
+            )
         })?;
         let vnew = self.visit_obj(b, move |hv: &Vec<u8>| {
             if i > hv.len() {

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -1802,6 +1802,9 @@ impl CheckedEnv for Host {
         let i: usize = u32::try_from(i).map_err(|_| {
             self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "i must be u32")
         })? as usize;
+        let u: u32 = u.try_into().map_err(|_| {
+            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "u must be u8")
+        })?;
         let u: u8 = u.try_into().map_err(|_| {
             self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "u must be u8")
         })?;
@@ -1852,6 +1855,9 @@ impl CheckedEnv for Host {
     }
 
     fn binary_push(&self, b: Object, u: RawVal) -> Result<Object, HostError> {
+        let u: u32 = u.try_into().map_err(|_| {
+            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "x must be u8")
+        })?;
         let u: u8 = u.try_into().map_err(|_| {
             self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "x must be u8")
         })?;
@@ -1902,6 +1908,9 @@ impl CheckedEnv for Host {
         let i: usize = u32::try_from(i).map_err(|_| {
             self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "i must be u32")
         })? as usize;
+        let u: u32 = u.try_into().map_err(|_| {
+            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "x must be u8")
+        })?;
         let u: u8 = u.try_into().map_err(|_| {
             self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "x must be u8")
         })?;

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -1803,10 +1803,10 @@ impl CheckedEnv for Host {
             self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "i must be u32")
         })? as usize;
         let u: u32 = u.try_into().map_err(|_| {
-            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "u must be u8")
+            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "u must be u32")
         })?;
         let u: u8 = u.try_into().map_err(|_| {
-            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "u must be u8")
+            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "u must be no greater than 255")
         })?;
         let vnew = self.visit_obj(b, move |hv: &Vec<u8>| {
             let mut vnew = hv.clone();
@@ -1856,10 +1856,10 @@ impl CheckedEnv for Host {
 
     fn binary_push(&self, b: Object, u: RawVal) -> Result<Object, HostError> {
         let u: u32 = u.try_into().map_err(|_| {
-            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "x must be u8")
+            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "x must be u32")
         })?;
         let u: u8 = u.try_into().map_err(|_| {
-            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "x must be u8")
+            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "x must be no greater than 255")
         })?;
         let vnew = self.visit_obj(b, move |hv: &Vec<u8>| {
             let mut vnew = hv.clone();
@@ -1909,10 +1909,10 @@ impl CheckedEnv for Host {
             self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "i must be u32")
         })? as usize;
         let u: u32 = u.try_into().map_err(|_| {
-            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "x must be u8")
+            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "x must be u32")
         })?;
         let u: u8 = u.try_into().map_err(|_| {
-            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "x must be u8")
+            self.err_status_msg(ScHostFnErrorCode::InputArgsWrongType, "x must be no greater than 255")
         })?;
         let vnew = self.visit_obj(b, move |hv: &Vec<u8>| {
             if i > hv.len() {

--- a/stellar-contract-env-host/src/test/binary.rs
+++ b/stellar-contract-env-host/src/test/binary.rs
@@ -39,7 +39,7 @@ fn binary_suite_of_tests() -> Result<(), HostError> {
     );
     assert_eq!(
         unsafe {
-            <u8 as RawValConvertible>::unchecked_from_val(host.binary_get(obj, 5_u32.into())?)
+            <u32 as RawValConvertible>::unchecked_from_val(host.binary_get(obj, 5_u32.into())?)
         },
         5
     );
@@ -47,7 +47,7 @@ fn binary_suite_of_tests() -> Result<(), HostError> {
     obj = host.binary_put(obj, 5_u32.into(), 99_u32.into())?;
     assert_eq!(
         unsafe {
-            <u8 as RawValConvertible>::unchecked_from_val(host.binary_get(obj, 5_u32.into())?)
+            <u32 as RawValConvertible>::unchecked_from_val(host.binary_get(obj, 5_u32.into())?)
         },
         99
     );


### PR DESCRIPTION
### What
Remove implementations that make `u8` convertible with `RawVal`.

### Why
`u8` is not a type supported by the contract system, and so any use of u8 is a constrained space u32. We should just do the conversions to u32 when we need a value that has a max of a u8, rather than introducing this convenience method, otherwise developers may store what they think is a u8 into a contract field, then increment it elsewhere past the valid value of a u8.

There are also some inconveniences of making this a RawVal, as it prevents us from implementing some types with alternative implementations for u8, like the Vec type in the SDK.

cc @jayz22 @graydon @jonjove @sisuresh 