### PR TITLE
Add conversions from ScVal to (), bool, and u32

### DIFF
--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -522,3 +522,36 @@ impl<E: Env, V: Val> Ord for EnvVal<E, V> {
         }
     }
 }
+
+impl<E: Env> TryFrom<EnvVal<E, ScVal>> for () {
+    type Error = ();
+    fn try_from(ev: EnvVal<E, ScVal>) -> Result<Self, Self::Error> {
+        if let ScVal::Static(ScStatic::Void) = ev.val {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl<E: Env> TryFrom<EnvVal<E, ScVal>> for bool {
+    type Error = ();
+    fn try_from(ev: EnvVal<E, ScVal>) -> Result<Self, Self::Error> {
+        match ev.val {
+            ScVal::Static(ScStatic::True) => Ok(true),
+            ScVal::Static(ScStatic::False) => Ok(false),
+            _ => Err(()),
+        }
+    }
+}
+
+impl<E: Env> TryFrom<EnvVal<E, ScVal>> for u32 {
+    type Error = ();
+    fn try_from(ev: EnvVal<E, ScVal>) -> Result<Self, Self::Error> {
+        if let ScVal::U32(x) = ev.val {
+            Ok(x)
+        } else {
+            Err(())
+        }
+    }
+}

--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -523,6 +523,7 @@ impl<E: Env, V: Val> Ord for EnvVal<E, V> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<E: Env> TryFrom<EnvVal<E, ScVal>> for () {
     type Error = ();
     fn try_from(ev: EnvVal<E, ScVal>) -> Result<Self, Self::Error> {
@@ -534,6 +535,7 @@ impl<E: Env> TryFrom<EnvVal<E, ScVal>> for () {
     }
 }
 
+#[cfg(feature = "std")]
 impl<E: Env> TryFrom<EnvVal<E, ScVal>> for bool {
     type Error = ();
     fn try_from(ev: EnvVal<E, ScVal>) -> Result<Self, Self::Error> {
@@ -545,6 +547,7 @@ impl<E: Env> TryFrom<EnvVal<E, ScVal>> for bool {
     }
 }
 
+#[cfg(feature = "std")]
 impl<E: Env> TryFrom<EnvVal<E, ScVal>> for u32 {
     type Error = ();
     fn try_from(ev: EnvVal<E, ScVal>) -> Result<Self, Self::Error> {


### PR DESCRIPTION
### What

Add conversions from `ScVal` to `()`, `bool`, and `u32`.

### Why

Needed to make the `call_external` macro work correctly.

### Known limitations

This doesn't include all relevant types.