### PR TITLE
More struct wrapping

### DIFF
--- a/stellar-contract-env-common/src/bitset.rs
+++ b/stellar-contract-env-common/src/bitset.rs
@@ -95,6 +95,21 @@ impl RawValConvertible for BitSet {
     }
 }
 
+#[cfg(feature = "vm")]
+impl wasmi::FromValue for BitSet {
+    fn from_value(val: wasmi::RuntimeValue) -> Option<Self> {
+        let maybe: Option<TaggedVal<TagBitSet>> = val.try_into();
+        maybe.map(|x| Self(x))
+    }
+}
+
+#[cfg(feature = "vm")]
+impl From<BitSet> for wasmi::RuntimeValue {
+    fn from(v: BitSet) -> Self {
+        wasmi::RuntimeValue::I64(v.as_raw().get_payload() as i64)
+    }
+}
+
 impl BitSet {
     pub const fn as_raw(&self) -> &RawVal {
         &self.0 .0

--- a/stellar-contract-env-common/src/bitset.rs
+++ b/stellar-contract-env-common/src/bitset.rs
@@ -4,6 +4,7 @@ use core::fmt::Debug;
 use core::hash::{Hash, Hasher};
 use core::marker::PhantomData;
 
+#[derive(Copy, Clone)]
 pub struct BitSet(TaggedVal<TagBitSet>);
 
 #[derive(Debug)]

--- a/stellar-contract-env-common/src/bitset.rs
+++ b/stellar-contract-env-common/src/bitset.rs
@@ -1,4 +1,4 @@
-use crate::{ConversionError, RawVal, RawValConvertible, Tag, TagBitSet, TaggedVal};
+use crate::{ConversionError, Env, EnvVal, RawVal, RawValConvertible, Tag, TagBitSet, TaggedVal};
 use core::cmp::Ordering;
 use core::fmt::Debug;
 use core::hash::{Hash, Hasher};
@@ -66,6 +66,12 @@ impl AsRef<RawVal> for BitSet {
     }
 }
 
+impl AsMut<RawVal> for BitSet {
+    fn as_mut(&mut self) -> &mut RawVal {
+        self.0.as_mut()
+    }
+}
+
 impl From<TaggedVal<TagBitSet>> for BitSet {
     fn from(tv: TaggedVal<TagBitSet>) -> Self {
         BitSet(tv)
@@ -111,6 +117,12 @@ impl From<BitSet> for wasmi::RuntimeValue {
 }
 
 impl BitSet {
+    pub fn in_env<E: Env>(self, env: &E) -> EnvVal<E, BitSet> {
+        EnvVal {
+            env: env.clone(),
+            val: self,
+        }
+    }
     pub const fn as_raw(&self) -> &RawVal {
         &self.0 .0
     }

--- a/stellar-contract-env-common/src/raw_val.rs
+++ b/stellar-contract-env-common/src/raw_val.rs
@@ -142,6 +142,7 @@ declare_tryfrom!(u32);
 declare_tryfrom!(i32);
 declare_tryfrom!(BitSet);
 declare_tryfrom!(Status);
+declare_tryfrom!(Symbol);
 
 #[cfg(feature = "vm")]
 impl wasmi::FromValue for RawVal {

--- a/stellar-contract-env-common/src/raw_val.rs
+++ b/stellar-contract-env-common/src/raw_val.rs
@@ -141,6 +141,7 @@ declare_tryfrom!(bool);
 declare_tryfrom!(u32);
 declare_tryfrom!(i32);
 declare_tryfrom!(BitSet);
+declare_tryfrom!(Status);
 
 #[cfg(feature = "vm")]
 impl wasmi::FromValue for RawVal {

--- a/stellar-contract-env-common/src/static.rs
+++ b/stellar-contract-env-common/src/static.rs
@@ -1,15 +1,101 @@
 use stellar_xdr::ScStatic;
 
-use crate::{TagStatic, TaggedVal};
+use crate::{Env, EnvVal, RawVal, RawValConvertible, TagStatic, TaggedVal};
 
-pub type Static = TaggedVal<TagStatic>;
+#[derive(Copy, Clone)]
+pub struct Static(TaggedVal<TagStatic>);
+
 impl Static {
+    pub fn in_env<E: Env>(self, env: &E) -> EnvVal<E, Static> {
+        EnvVal {
+            env: env.clone(),
+            val: self,
+        }
+    }
+    pub const fn as_raw(&self) -> &RawVal {
+        &self.0 .0
+    }
+
+    pub const fn to_raw(&self) -> RawVal {
+        self.0 .0
+    }
+
+    pub const fn as_tagged(&self) -> &TaggedVal<TagStatic> {
+        &self.0
+    }
+
+    pub const fn to_tagged(&self) -> TaggedVal<TagStatic> {
+        self.0
+    }
+
     // NB: we don't provide a "get_type" to avoid casting a bad bit-pattern into
     // an ScStatic. Instead we provide an "is_type" to check any specific
     // bit-pattern.
 
     #[inline(always)]
     pub const fn is_type(&self, ty: ScStatic) -> bool {
-        self.0.has_minor(ty as u32)
+        self.as_raw().has_minor(ty as u32)
+    }
+}
+
+impl AsRef<TaggedVal<TagStatic>> for Static {
+    fn as_ref(&self) -> &TaggedVal<TagStatic> {
+        self.as_tagged()
+    }
+}
+
+impl AsRef<RawVal> for Static {
+    fn as_ref(&self) -> &RawVal {
+        self.as_raw()
+    }
+}
+
+impl AsMut<RawVal> for Static {
+    fn as_mut(&mut self) -> &mut RawVal {
+        self.0.as_mut()
+    }
+}
+
+impl From<TaggedVal<TagStatic>> for Static {
+    fn from(tv: TaggedVal<TagStatic>) -> Self {
+        Static(tv)
+    }
+}
+
+impl From<Static> for TaggedVal<TagStatic> {
+    fn from(b: Static) -> Self {
+        b.to_tagged()
+    }
+}
+
+impl From<Static> for RawVal {
+    fn from(b: Static) -> Self {
+        b.to_raw()
+    }
+}
+
+impl RawValConvertible for Static {
+    #[inline(always)]
+    fn is_val_type(v: RawVal) -> bool {
+        <TaggedVal<TagStatic> as RawValConvertible>::is_val_type(v)
+    }
+    #[inline(always)]
+    unsafe fn unchecked_from_val(v: RawVal) -> Self {
+        Static(<TaggedVal<TagStatic> as RawValConvertible>::unchecked_from_val(v))
+    }
+}
+
+#[cfg(feature = "vm")]
+impl wasmi::FromValue for Static {
+    fn from_value(val: wasmi::RuntimeValue) -> Option<Self> {
+        let maybe: Option<TaggedVal<TagStatic>> = val.try_into();
+        maybe.map(|x| Self(x))
+    }
+}
+
+#[cfg(feature = "vm")]
+impl From<Static> for wasmi::RuntimeValue {
+    fn from(v: Static) -> Self {
+        wasmi::RuntimeValue::I64(v.as_raw().get_payload() as i64)
     }
 }

--- a/stellar-contract-env-common/src/status.rs
+++ b/stellar-contract-env-common/src/status.rs
@@ -1,5 +1,6 @@
 use crate::{
-    BitSetError, ConversionError, RawVal, RawValConvertible, SymbolError, Tag, TagStatus, TaggedVal,
+    BitSetError, ConversionError, Env, EnvVal, RawVal, RawValConvertible, SymbolError, Tag,
+    TagStatus, TaggedVal,
 };
 use core::{
     cmp::Ordering,
@@ -256,6 +257,12 @@ impl AsRef<RawVal> for Status {
     }
 }
 
+impl AsMut<RawVal> for Status {
+    fn as_mut(&mut self) -> &mut RawVal {
+        self.0.as_mut()
+    }
+}
+
 impl From<TaggedVal<TagStatus>> for Status {
     fn from(tv: TaggedVal<TagStatus>) -> Self {
         Status(tv)
@@ -301,6 +308,13 @@ impl From<Status> for wasmi::RuntimeValue {
 }
 
 impl Status {
+    pub fn in_env<E: Env>(self, env: &E) -> EnvVal<E, Status> {
+        EnvVal {
+            env: env.clone(),
+            val: self,
+        }
+    }
+
     pub const fn as_raw(&self) -> &RawVal {
         &self.0 .0
     }

--- a/stellar-contract-env-common/src/status.rs
+++ b/stellar-contract-env-common/src/status.rs
@@ -285,6 +285,21 @@ impl RawValConvertible for Status {
     }
 }
 
+#[cfg(feature = "vm")]
+impl wasmi::FromValue for Status {
+    fn from_value(val: wasmi::RuntimeValue) -> Option<Self> {
+        let maybe: Option<TaggedVal<TagStatus>> = val.try_into();
+        maybe.map(|x| Self(x))
+    }
+}
+
+#[cfg(feature = "vm")]
+impl From<Status> for wasmi::RuntimeValue {
+    fn from(v: Status) -> Self {
+        wasmi::RuntimeValue::I64(v.as_raw().get_payload() as i64)
+    }
+}
+
 impl Status {
     pub const fn as_raw(&self) -> &RawVal {
         &self.0 .0

--- a/stellar-contract-env-common/src/symbol.rs
+++ b/stellar-contract-env-common/src/symbol.rs
@@ -1,4 +1,6 @@
-use crate::{require, ConversionError, RawVal, RawValConvertible, Tag, TagSymbol, TaggedVal};
+use crate::{
+    require, ConversionError, Env, EnvVal, RawVal, RawValConvertible, Tag, TagSymbol, TaggedVal,
+};
 use core::{
     cmp::Ordering,
     fmt::Debug,
@@ -111,6 +113,12 @@ impl AsRef<RawVal> for Symbol {
     }
 }
 
+impl AsMut<RawVal> for Symbol {
+    fn as_mut(&mut self) -> &mut RawVal {
+        self.0.as_mut()
+    }
+}
+
 impl From<TaggedVal<TagSymbol>> for Symbol {
     fn from(tv: TaggedVal<TagSymbol>) -> Self {
         Symbol(tv)
@@ -156,6 +164,13 @@ impl From<Symbol> for wasmi::RuntimeValue {
 }
 
 impl Symbol {
+    pub fn in_env<E: Env>(self, env: &E) -> EnvVal<E, Symbol> {
+        EnvVal {
+            env: env.clone(),
+            val: self,
+        }
+    }
+
     pub const fn as_raw(&self) -> &RawVal {
         &self.0 .0
     }

--- a/stellar-contract-env-common/src/val.rs
+++ b/stellar-contract-env-common/src/val.rs
@@ -3,9 +3,14 @@
 ///
 /// This is a sort of hack to work around not having inheritance
 /// in Rust.
-use crate::{RawVal, TagType, TaggedVal};
+use crate::{BitSet, Object, RawVal, Static, Status, Symbol, TagType, TaggedVal};
 
 pub trait Val: AsRef<RawVal> + AsMut<RawVal> + Into<RawVal> + Clone {}
 
 impl<T: TagType> Val for TaggedVal<T> {}
 impl Val for RawVal {}
+impl Val for Object {}
+impl Val for Status {}
+impl Val for Static {}
+impl Val for Symbol {}
+impl Val for BitSet {}

--- a/stellar-contract-env-host/src/test/invocation.rs
+++ b/stellar-contract-env-host/src/test/invocation.rs
@@ -179,7 +179,7 @@ fn invoke_cross_contract_lvl2_nested_with_err() -> Result<(), HostError> {
     let sv = host.try_call(obj.to_object(), sym.into(), args.clone().into())?;
     let code = ScHostObjErrorCode::VecIndexOutOfBound;
     let exp_st: Status = code.into();
-    assert_eq!(sv.get_payload(), exp_st.as_ref().get_payload());
+    assert_eq!(sv.get_payload(), exp_st.as_raw().get_payload());
     // call
     let res = host.call(obj.to_object(), sym.into(), args.into());
     assert!(HostError::result_matches_err_status(res, code));

--- a/stellar-contract-env-host/src/test/vec.rs
+++ b/stellar-contract-env-host/src/test/vec.rs
@@ -170,7 +170,7 @@ fn vec_slice_and_cmp() -> Result<(), HostError> {
     assert_eq!(host.obj_cmp(obj1.into(), obj_ref.into())?, 0);
 
     let obj2 = host.vec_slice(obj.to_object(), 0u32.into(), 3u32.into())?;
-    assert_ne!(obj2.as_ref().get_payload(), obj.as_raw().get_payload());
+    assert_ne!(obj2.as_raw().get_payload(), obj.as_raw().get_payload());
     assert_eq!(host.obj_cmp(obj2.into(), obj.into())?, 0);
     Ok(())
 }
@@ -275,7 +275,7 @@ fn vec_append() -> Result<(), HostError> {
     let host = Host::default();
     let obj0 = host.test_vec_obj::<u32>(&[1, 2, 3])?;
     let obj1 = host.test_vec_obj::<u32>(&[4, 5, 6])?;
-    let obj2 = host.vec_append(*obj0.as_ref(), *obj1.as_ref())?;
+    let obj2 = host.vec_append(obj0.val, obj1.val)?;
     let obj_ref = host.test_vec_obj::<u32>(&[1, 2, 3, 4, 5, 6])?;
     assert_eq!(host.obj_cmp(obj2.into(), obj_ref.into())?, 0);
     Ok(())
@@ -285,8 +285,8 @@ fn vec_append() -> Result<(), HostError> {
 fn vec_append_empty() -> Result<(), HostError> {
     let host = Host::default();
     let obj0 = host.test_vec_obj::<u32>(&[])?;
-    let obj1 = host.vec_append(*obj0.as_ref(), *obj0.as_ref())?;
-    assert_ne!(obj0.as_raw().get_payload(), obj1.as_ref().get_payload());
+    let obj1 = host.vec_append(obj0.val, obj0.val)?;
+    assert_ne!(obj0.as_raw().get_payload(), obj1.as_raw().get_payload());
     assert_eq!(host.obj_cmp(obj0.into(), obj1.into())?, 0);
     Ok(())
 }

--- a/stellar-contract-env-host/tests/integration.rs
+++ b/stellar-contract-env-host/tests/integration.rs
@@ -8,12 +8,12 @@ fn vec_as_seen_by_user() -> Result<(), ()> {
     let int1 = host.obj_from_i64(5).in_env(&host);
 
     let vec1a = host.vec_new(RawVal::from_void()).in_env(&host);
-    let vec1b = host.vec_push(*vec1a.as_ref(), *int1.as_ref()).in_env(&host);
+    let vec1b = host.vec_push(vec1a.val, *int1.as_ref()).in_env(&host);
 
     assert_ne!(vec1a.as_raw().get_payload(), vec1b.as_raw().get_payload());
 
     let vec2a = host.vec_new(RawVal::from_void()).in_env(&host);
-    let vec2b = host.vec_push(*vec2a.as_ref(), *int1.as_ref()).in_env(&host);
+    let vec2b = host.vec_push(vec2a.val, *int1.as_ref()).in_env(&host);
 
     assert_ne!(vec2a.as_raw().get_payload(), vec2b.as_raw().get_payload());
     assert_ne!(vec1b.as_raw().get_payload(), vec2b.as_raw().get_payload());


### PR DESCRIPTION
This is a followup to https://github.com/stellar/rs-stellar-contract-env/commit/85b352afa70530d4561b273abd0462fe3440dfc5 .. I'm not 100% sure we want to continue down this path, but I think we _might_.

I actually _think_ this is basically 1/3-1/2 of the work necessary to back out the use of `TaggedVal` as an optimistic-but-wrong adventure in attempting to generalize-and-simplify multiple separate wrapper types into one more-generic one. I think this has plausibly proven to be a mistake -- it is at least a lot of cognitive load and maintenance burden -- and I suggest that it might make sense to try to complete the adventure by backing it all the way out, and implementing concrete wrapper types via macros alone and/or manual replication of code, not generics.

The benefit to users are that there's much less type-system noise especially in error messages, and less trait-inference to fall prey to ambiguities and the need for "trait features that don't actually exist in stable rust or possibly ever" like specialization. Downside is we either write lots of code by hand or have more macros in the implementation. But I think I'm willing to give it a try, @leighmcculloch WDYT?