### PR TITLE
Simplify invoke_function for macro

### DIFF
--- a/stellar-contract-env-common/src/env_val.rs
+++ b/stellar-contract-env-common/src/env_val.rs
@@ -522,39 +522,3 @@ impl<E: Env, V: Val> Ord for EnvVal<E, V> {
         }
     }
 }
-
-#[cfg(feature = "std")]
-impl<E: Env> TryFrom<EnvVal<E, ScVal>> for () {
-    type Error = ();
-    fn try_from(ev: EnvVal<E, ScVal>) -> Result<Self, Self::Error> {
-        if let ScVal::Static(ScStatic::Void) = ev.val {
-            Ok(())
-        } else {
-            Err(())
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<E: Env> TryFrom<EnvVal<E, ScVal>> for bool {
-    type Error = ();
-    fn try_from(ev: EnvVal<E, ScVal>) -> Result<Self, Self::Error> {
-        match ev.val {
-            ScVal::Static(ScStatic::True) => Ok(true),
-            ScVal::Static(ScStatic::False) => Ok(false),
-            _ => Err(()),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<E: Env> TryFrom<EnvVal<E, ScVal>> for u32 {
-    type Error = ();
-    fn try_from(ev: EnvVal<E, ScVal>) -> Result<Self, Self::Error> {
-        if let ScVal::U32(x) = ev.val {
-            Ok(x)
-        } else {
-            Err(())
-        }
-    }
-}

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -713,7 +713,11 @@ impl Host {
         return Err(self.err_general("could not dispatch"));
     }
 
-    pub fn invoke_function_raw(&mut self, hf: HostFunction, args: ScVec) -> Result<RawVal, HostError> {
+    pub fn invoke_function_raw(
+        &mut self,
+        hf: HostFunction,
+        args: ScVec,
+    ) -> Result<RawVal, HostError> {
         match hf {
             HostFunction::Call => {
                 if let [ScVal::Object(Some(scobj)), ScVal::Symbol(scsym), rest @ ..] =
@@ -749,7 +753,9 @@ impl Host {
                     let signature: Object = self.to_host_obj(sig_obj)?.to_object();
 
                     //TODO: should create_contract_from_ed25519 return a RawVal instead of Object to avoid this conversion?
-                    let res: RawVal = self.create_contract_from_ed25519(contract, salt, key, signature)?.into();
+                    let res: RawVal = self
+                        .create_contract_from_ed25519(contract, salt, key, signature)?
+                        .into();
                     frame_guard.commit();
                     Ok(res)
                 } else {

--- a/stellar-contract-env-host/src/host.rs
+++ b/stellar-contract-env-host/src/host.rs
@@ -713,7 +713,7 @@ impl Host {
         return Err(self.err_general("could not dispatch"));
     }
 
-    pub fn invoke_function(&mut self, hf: HostFunction, args: ScVec) -> Result<ScVal, HostError> {
+    pub fn invoke_function_raw(&mut self, hf: HostFunction, args: ScVec) -> Result<RawVal, HostError> {
         match hf {
             HostFunction::Call => {
                 if let [ScVal::Object(Some(scobj)), ScVal::Symbol(scsym), rest @ ..] =
@@ -729,7 +729,7 @@ impl Host {
                     }
                     let res = self.call_n(object, symbol, &raw_args[..])?;
                     frame_guard.commit();
-                    Ok(self.from_host_val(res)?)
+                    Ok(res)
                 } else {
                     Err(self.err_status_msg(
                         ScHostFnErrorCode::InputArgsWrongLength,
@@ -749,10 +749,9 @@ impl Host {
                     let signature: Object = self.to_host_obj(sig_obj)?.to_object();
 
                     //TODO: should create_contract_from_ed25519 return a RawVal instead of Object to avoid this conversion?
-                    let res = self.create_contract_from_ed25519(contract, salt, key, signature)?;
-                    let sc_obj = self.from_host_obj(res)?;
+                    let res: RawVal = self.create_contract_from_ed25519(contract, salt, key, signature)?.into();
                     frame_guard.commit();
-                    Ok(ScVal::Object(Some(sc_obj)))
+                    Ok(res)
                 } else {
                     Err(self.err_status_msg(
                         ScHostFnErrorCode::InputArgsWrongLength,
@@ -761,6 +760,11 @@ impl Host {
                 }
             }
         }
+    }
+
+    pub fn invoke_function(&mut self, hf: HostFunction, args: ScVec) -> Result<ScVal, HostError> {
+        let rv = self.invoke_function_raw(hf, args)?;
+        self.from_host_val(rv)
     }
 
     fn load_account(&self, a: Object) -> Result<AccountEntry, HostError> {


### PR DESCRIPTION
### What

Reverts #267, introduces a simpler workaround where `invoke_function` returns a `RawVal` instead of `ScVal`.

Closes #268

### Why

Needed to make `call_external` macro work.

### Known limitations

This doesn't feel like the right approach in the long term.